### PR TITLE
DEV: Add `rdf-construct shacl-gen` command for SHACL shape generation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,28 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+Added
+
+- **New SHACL Shape Generator** (`shacl-gen` command)
+
+  - Generate SHACL NodeShapes from OWL ontology definitions
+  - Convert domain/range to sh:property with sh:class/sh:datatype
+  - Convert cardinality restrictions to sh:minCount/sh:maxCount
+  - Convert owl:FunctionalProperty to sh:maxCount 1
+  - Convert owl:someValuesFrom/allValuesFrom to type constraints
+  - Convert owl:oneOf enumerations to sh:in
+  - Support for qualified cardinality restrictions
+  - Three strictness levels: minimal, standard, strict
+  - Constraint inheritance from superclasses
+  - Closed shape generation with configurable ignored properties
+  - YAML configuration file support
+  - Include rdfs:label as sh:name and rdfs:comment as sh:description
+  - Output formats: Turtle, JSON-LD
+- Documentation
+  - Added SHACL Guide (docs/user_guides/SHACL_GUIDE.md)
+  - Updated CLI Reference with shacl-gen command
+  - Updated documentation index with SHACL module
+
 - **New `docs` command** for generating documentation from RDF ontologies
   - Three output formats: `html` (navigable website), `markdown` (GitHub/GitLab compatible), `json` (structured data)
   - Comprehensive entity extraction: classes, object/datatype/annotation properties, instances

--- a/docs/index.md
+++ b/docs/index.md
@@ -5,6 +5,7 @@
 **New User?** → [Getting Started](user_guides/GETTING_STARTED.md)  
 **Generate Documentation?** → [Docs Guide](user_guides/DOCS_GUIDE.md)  
 **Generate Diagrams?** → [UML Guide](user_guides/UML_GUIDE.md)  
+**Generate SHACL Shapes?** → [SHACL Guide](user_guides/SHACL_GUIDE.md)  
 **Compare Ontologies?** → [Diff Guide](user_guides/DIFF_GUIDE.md)  
 **Check Quality?** → [Lint Guide](user_guides/LINT_GUIDE.md)  
 **Need Command Syntax?** → [CLI Reference](user_guides/CLI_REFERENCE.md)  
@@ -38,6 +39,14 @@ For users of rdf-construct who want to generate diagrams and work with RDF ontol
   - Styling and layout
   - Complete examples
   - Tips and techniques
+
+- **[SHACL Guide](user_guides/SHACL_GUIDE.md)** - SHACL shape generation
+  - Generating shapes from OWL
+  - Strictness levels (minimal, standard, strict)
+  - Configuration options
+  - OWL pattern coverage
+  - Validation with pySHACL
+  - CI integration
 
 - **[Diff Guide](user_guides/DIFF_GUIDE.md)** - Semantic ontology comparison
   - Comparing ontology versions
@@ -89,6 +98,7 @@ A Python CLI toolkit for RDF operations:
 - **Semantic Ordering**: Serialise RDF/Turtle with meaningful order (not alphabetical)
 - **Documentation Generation**: Create navigable HTML/Markdown docs from ontologies
 - **UML Generation**: Create PlantUML class diagrams from ontologies
+- **SHACL Generation**: Generate validation shapes from OWL definitions
 - **Semantic Diff**: Compare ontologies and identify meaningful changes
 - **Ontology Linting**: Check ontology quality with configurable rules
 - **Flexible Configuration**: YAML-based control without code changes
@@ -123,6 +133,19 @@ poetry run rdf-construct uml ontology.ttl -C config.yml -c animal_taxonomy
 poetry run rdf-construct uml ontology.ttl -C config.yml \
   --style-config styles.yml --style default \
   --layout-config layouts.yml --layout hierarchy
+```
+
+### Generate SHACL Shapes
+
+```bash
+# Basic generation
+poetry run rdf-construct shacl-gen ontology.ttl -o shapes.ttl
+
+# Strict mode with closed shapes
+poetry run rdf-construct shacl-gen ontology.ttl --level strict --closed
+
+# With configuration file
+poetry run rdf-construct shacl-gen ontology.ttl --config shacl-config.yml
 ```
 
 ### Compare Ontology Versions

--- a/docs/user_guides/SHACL_GUIDE.md
+++ b/docs/user_guides/SHACL_GUIDE.md
@@ -1,0 +1,373 @@
+# SHACL Shape Generator Guide
+
+Generate SHACL validation shapes from OWL ontology definitions.
+
+## Overview
+
+The `shacl-gen` command converts OWL class definitions into SHACL NodeShapes,
+extracting constraints from domain/range declarations, cardinality restrictions,
+functional properties, and other OWL patterns.
+
+This saves hours of boilerplate writing and ensures shapes stay aligned with
+your ontology definitions.
+
+## Quick Start
+
+```bash
+# Generate shapes with default settings
+rdf-construct shacl-gen ontology.ttl
+
+# Output: ontology-shapes.ttl
+```
+
+## Basic Usage
+
+### Generate Shapes for an Ontology
+
+```bash
+rdf-construct shacl-gen building-ontology.ttl -o building-shapes.ttl
+```
+
+This produces SHACL shapes for all classes in the ontology, converting:
+
+- `rdfs:domain/range` → `sh:property` with `sh:class` or `sh:datatype`
+- `owl:cardinality` → `sh:minCount` + `sh:maxCount`
+- `owl:FunctionalProperty` → `sh:maxCount 1`
+- `rdfs:label` → `sh:name`
+- `rdfs:comment` → `sh:description`
+
+### Example Conversion
+
+**OWL Input:**
+```turtle
+ex:Building a owl:Class ;
+    rdfs:label "Building" ;
+    rdfs:comment "A permanent structure with walls and roof" .
+
+ex:hasFloor a owl:ObjectProperty ;
+    rdfs:domain ex:Building ;
+    rdfs:range ex:Floor .
+
+ex:Building rdfs:subClassOf [
+    a owl:Restriction ;
+    owl:onProperty ex:hasFloor ;
+    owl:minCardinality 1
+] .
+
+ex:hasAddress a owl:DatatypeProperty, owl:FunctionalProperty ;
+    rdfs:domain ex:Building ;
+    rdfs:range xsd:string .
+```
+
+**SHACL Output:**
+```turtle
+@prefix sh: <http://www.w3.org/ns/shacl#> .
+@prefix shape: <http://example.org/-shapes#> .
+
+shape:BuildingShape a sh:NodeShape ;
+    sh:targetClass ex:Building ;
+    sh:name "Building" ;
+    sh:description "A permanent structure with walls and roof" ;
+    
+    sh:property [
+        sh:path ex:hasFloor ;
+        sh:class ex:Floor ;
+        sh:minCount 1 ;
+        sh:order 1 ;
+    ] ;
+    
+    sh:property [
+        sh:path ex:hasAddress ;
+        sh:datatype xsd:string ;
+        sh:maxCount 1 ;
+        sh:order 2 ;
+    ] .
+```
+
+## Strictness Levels
+
+Control how many OWL patterns are converted to SHACL constraints:
+
+### Minimal Level
+
+```bash
+rdf-construct shacl-gen ontology.ttl --level minimal
+```
+
+Converts only:
+- `rdfs:range` → `sh:class` or `sh:datatype`
+
+Useful for lightweight validation or when you want to add constraints manually.
+
+### Standard Level (Default)
+
+```bash
+rdf-construct shacl-gen ontology.ttl --level standard
+```
+
+Adds:
+- Cardinality restrictions (`owl:cardinality`, `owl:minCardinality`, etc.)
+- Functional properties → `sh:maxCount 1`
+- `owl:someValuesFrom` → `sh:minCount 1`
+
+### Strict Level
+
+```bash
+rdf-construct shacl-gen ontology.ttl --level strict
+```
+
+Maximum constraints:
+- All standard level conversions
+- Enumerations (`owl:oneOf` → `sh:in`)
+- Support for closed shapes
+
+## Closed Shapes
+
+Generate shapes that reject unexpected properties:
+
+```bash
+rdf-construct shacl-gen ontology.ttl --level strict --closed
+```
+
+This adds `sh:closed true` to all shapes. Instances with properties not
+defined in the shape will fail validation.
+
+Configure ignored properties in the config file:
+
+```yaml
+closed: true
+ignored_properties:
+  - rdf:type
+  - rdfs:label
+  - dcterms:modified
+```
+
+## Targeting Specific Classes
+
+### Include Only Certain Classes
+
+```bash
+rdf-construct shacl-gen ontology.ttl --classes "Building,Floor,Room"
+```
+
+### Using Configuration File
+
+```yaml
+target_classes:
+  - Building
+  - Floor
+  - http://example.org/Room
+```
+
+### Exclude Classes
+
+```yaml
+exclude_classes:
+  - owl:Thing
+  - rdfs:Resource
+  - DeprecatedClass
+```
+
+## Constraint Inheritance
+
+By default, subclass shapes inherit property constraints from superclasses.
+
+**Example:**
+If `Person` has `hasName` with `sh:maxCount 1`, then `Employee`
+(a subclass of `Person`) will also have this constraint.
+
+Disable inheritance:
+
+```bash
+rdf-construct shacl-gen ontology.ttl --no-inherit
+```
+
+Or in config:
+
+```yaml
+inherit_constraints: false
+```
+
+## Configuration File
+
+For complex settings, use a YAML configuration file:
+
+```bash
+rdf-construct shacl-gen ontology.ttl --config shacl-config.yml
+```
+
+Example `shacl-config.yml`:
+
+```yaml
+level: standard
+default_severity: violation
+closed: false
+
+target_classes:
+  - Building
+  - Floor
+
+include_labels: true
+include_descriptions: true
+inherit_constraints: true
+
+ignored_properties:
+  - rdf:type
+  - rdfs:label
+```
+
+CLI options override configuration file settings.
+
+## Output Formats
+
+### Turtle (Default)
+
+```bash
+rdf-construct shacl-gen ontology.ttl -o shapes.ttl --format turtle
+```
+
+### JSON-LD
+
+```bash
+rdf-construct shacl-gen ontology.ttl -o shapes.json --format json-ld
+```
+
+## Severity Levels
+
+Control how constraint violations are reported:
+
+```bash
+rdf-construct shacl-gen ontology.ttl --default-severity warning
+```
+
+Options:
+- `violation` - Validation fails (default)
+- `warning` - Logged as warning but validation passes
+- `info` - Informational only
+
+## OWL Pattern Coverage
+
+### Fully Supported
+
+| OWL Pattern | SHACL Equivalent |
+|-------------|------------------|
+| `rdfs:domain` | `sh:targetClass` + `sh:property` |
+| `rdfs:range` (class) | `sh:class` |
+| `rdfs:range` (datatype) | `sh:datatype` |
+| `owl:cardinality` | `sh:minCount` + `sh:maxCount` |
+| `owl:minCardinality` | `sh:minCount` |
+| `owl:maxCardinality` | `sh:maxCount` |
+| `owl:FunctionalProperty` | `sh:maxCount 1` |
+| `owl:someValuesFrom` | `sh:minCount 1` + type |
+| `owl:allValuesFrom` | `sh:class` or `sh:datatype` |
+| `owl:oneOf` | `sh:in` |
+| `owl:qualifiedCardinality` | Cardinality + type |
+| `rdfs:label` | `sh:name` |
+| `rdfs:comment` | `sh:description` |
+
+### Not Converted (Requires Manual SHACL)
+
+Some OWL patterns cannot be directly expressed in SHACL Core:
+
+- **Complex class expressions** (unions, intersections)
+- **Inverse functional uniqueness** (requires SPARQL)
+- **Transitive property closures**
+- **Property chains**
+- **owl:complementOf**
+
+When these patterns are encountered, the generator continues without them.
+Consider adding SPARQL-based SHACL constraints manually.
+
+## Programmatic Usage
+
+```python
+from rdf_construct.shacl import (
+    generate_shapes,
+    generate_shapes_to_file,
+    ShaclConfig,
+    StrictnessLevel,
+)
+from pathlib import Path
+
+# Simple generation
+shapes_graph, turtle = generate_shapes(Path("ontology.ttl"))
+
+# With configuration
+config = ShaclConfig(
+    level=StrictnessLevel.STRICT,
+    closed=True,
+    target_classes=["Building", "Floor"],
+)
+
+shapes_graph, turtle = generate_shapes(
+    Path("building.ttl"),
+    config,
+)
+
+# Generate to file
+generate_shapes_to_file(
+    Path("ontology.ttl"),
+    Path("shapes.ttl"),
+    config,
+)
+```
+
+## Validation with pySHACL
+
+Use the generated shapes with pySHACL:
+
+```bash
+# Install pySHACL
+pip install pyshacl
+
+# Validate data against shapes
+pyshacl -s shapes.ttl -d data.ttl
+```
+
+Or programmatically:
+
+```python
+from pyshacl import validate
+
+conforms, report, text = validate(
+    data_graph,
+    shacl_graph=shapes_graph,
+)
+```
+
+## CI Integration
+
+Example GitHub Actions workflow:
+
+```yaml
+- name: Generate and validate SHACL
+  run: |
+    # Generate shapes from ontology
+    rdf-construct shacl-gen ontology.ttl -o shapes.ttl --level strict
+    
+    # Validate sample data
+    pyshacl -s shapes.ttl -d sample-data.ttl
+```
+
+## Tips
+
+1. **Start with standard level** - Generate shapes, review them, then increase
+   strictness if needed.
+
+2. **Review inherited constraints** - Inheritance can create deep constraint
+   chains. Use `--no-inherit` if shapes get too complex.
+
+3. **Combine with lint** - Run `rdf-construct lint` on your ontology first
+   to catch issues before generating shapes.
+
+4. **Iterate** - Generate shapes, validate sample data, adjust configuration,
+   repeat until shapes match your validation requirements.
+
+5. **Version control shapes** - Generated shapes are deterministic. Commit
+   them alongside your ontology for traceability.
+
+## See Also
+
+- [SHACL Specification](https://www.w3.org/TR/shacl/)
+- [pySHACL Documentation](https://github.com/RDFLib/pySHACL)
+- [CLI Reference](CLI_REFERENCE.md)

--- a/examples/shacl_config.yml
+++ b/examples/shacl_config.yml
@@ -1,0 +1,60 @@
+# SHACL Generator Configuration
+# ==============================
+#
+# This file configures how SHACL shapes are generated from OWL ontologies.
+# Use with: rdf-construct shacl-gen ontology.ttl --config shacl-config.yml
+
+# Strictness level controls which OWL patterns are converted:
+#   minimal  - Basic type constraints only (sh:class, sh:datatype)
+#   standard - Adds cardinality and functional property constraints (default)
+#   strict   - Maximum constraints including enumerations, closed shapes
+level: standard
+
+# Default severity for constraint violations:
+#   violation - Validation fails (default)
+#   warning   - Logged as warning
+#   info      - Informational only
+default_severity: violation
+
+# Generate closed shapes (sh:closed true)
+# When true, instances cannot have properties not defined in the shape
+closed: false
+
+# Namespace suffix for generated shapes
+# The shape namespace is derived from the ontology namespace + this suffix
+shape_namespace: "shapes#"
+
+# Target specific classes only (leave empty for all classes)
+# Use local names or full URIs
+target_classes: []
+  # - Building
+  # - Floor
+  # - http://example.org/Person
+
+# Exclude specific classes from shape generation
+exclude_classes: []
+  # - owl:Thing
+  # - rdfs:Resource
+
+# Include rdfs:label as sh:name in shapes
+include_labels: true
+
+# Include rdfs:comment as sh:description in shapes
+include_descriptions: true
+
+# Inherit property constraints from superclasses
+# When true, subclass shapes include constraints from parent classes
+inherit_constraints: true
+
+# Generate top-level PropertyShapes (not just inline property constraints)
+# Useful for reusable property validation rules
+generate_property_shapes: false
+
+# Properties to ignore in closed shapes
+# These properties are allowed even when sh:closed is true
+ignored_properties:
+  - rdf:type
+  - rdfs:label
+  - rdfs:comment
+  # - dcterms:created
+  # - dcterms:modified

--- a/src/rdf_construct/shacl/__init__.py
+++ b/src/rdf_construct/shacl/__init__.py
@@ -1,0 +1,56 @@
+"""SHACL shape generation from OWL ontologies.
+
+This module provides tools for generating SHACL validation shapes from
+OWL ontology definitions, converting domain/range, cardinality restrictions,
+and other OWL patterns to equivalent SHACL constraints.
+
+Basic usage:
+
+    from rdf_construct.shacl import generate_shapes, ShaclConfig, StrictnessLevel
+
+    # Generate shapes with default settings
+    graph, turtle = generate_shapes(Path("ontology.ttl"))
+
+    # Generate with strict level
+    config = ShaclConfig(level=StrictnessLevel.STRICT, closed=True)
+    graph, turtle = generate_shapes(Path("ontology.ttl"), config)
+
+    # Generate and write to file
+    from rdf_construct.shacl import generate_shapes_to_file
+    generate_shapes_to_file(
+        Path("ontology.ttl"),
+        Path("shapes.ttl"),
+        config,
+    )
+"""
+
+from rdf_construct.shacl.config import (
+    ShaclConfig,
+    Severity,
+    StrictnessLevel,
+    load_shacl_config,
+)
+from rdf_construct.shacl.converters import PropertyConstraint
+from rdf_construct.shacl.generator import (
+    ShapeGenerator,
+    generate_shapes,
+    generate_shapes_to_file,
+)
+from rdf_construct.shacl.namespaces import SH, SHACL_PREFIXES
+
+__all__ = [
+    # Configuration
+    "ShaclConfig",
+    "StrictnessLevel",
+    "Severity",
+    "load_shacl_config",
+    # Generator
+    "ShapeGenerator",
+    "generate_shapes",
+    "generate_shapes_to_file",
+    # Converters
+    "PropertyConstraint",
+    # Namespaces
+    "SH",
+    "SHACL_PREFIXES",
+]

--- a/src/rdf_construct/shacl/config.py
+++ b/src/rdf_construct/shacl/config.py
@@ -1,0 +1,166 @@
+"""Configuration handling for SHACL shape generation."""
+
+from dataclasses import dataclass, field
+from enum import Enum
+from pathlib import Path
+from typing import Any
+
+import yaml
+from rdflib import URIRef
+
+
+class StrictnessLevel(Enum):
+    """Strictness levels for SHACL generation.
+
+    Controls how many OWL patterns are converted to SHACL constraints.
+
+    Attributes:
+        MINIMAL: Only basic type constraints (sh:class, sh:datatype).
+        STANDARD: Adds cardinality, functional properties, and common patterns.
+        STRICT: Maximum constraints including sh:closed, all cardinalities.
+    """
+
+    MINIMAL = "minimal"
+    STANDARD = "standard"
+    STRICT = "strict"
+
+
+class Severity(Enum):
+    """SHACL constraint severity levels.
+
+    Maps to sh:Violation, sh:Warning, sh:Info.
+    """
+
+    VIOLATION = "violation"
+    WARNING = "warning"
+    INFO = "info"
+
+
+@dataclass
+class ShaclConfig:
+    """Configuration for SHACL shape generation.
+
+    Controls which OWL patterns are converted and how shapes are structured.
+
+    Attributes:
+        level: Strictness level for conversion.
+        default_severity: Default severity for generated constraints.
+        closed: Generate closed shapes (no extra properties allowed).
+        shape_namespace: Namespace suffix for generated shapes.
+        target_classes: Optional list of classes to generate shapes for.
+        exclude_classes: Classes to skip during generation.
+        include_labels: Include rdfs:label as sh:name.
+        include_descriptions: Include rdfs:comment as sh:description.
+        inherit_constraints: Inherit property constraints from superclasses.
+        generate_property_shapes: Generate top-level PropertyShapes.
+        ignored_properties: Properties to ignore in closed shapes.
+    """
+
+    level: StrictnessLevel = StrictnessLevel.STANDARD
+    default_severity: Severity = Severity.VIOLATION
+    closed: bool = False
+    shape_namespace: str = "shapes#"
+    target_classes: list[str] = field(default_factory=list)
+    exclude_classes: list[str] = field(default_factory=list)
+    include_labels: bool = True
+    include_descriptions: bool = True
+    inherit_constraints: bool = True
+    generate_property_shapes: bool = False
+    ignored_properties: list[str] = field(default_factory=list)
+
+    @classmethod
+    def from_yaml(cls, path: Path) -> "ShaclConfig":
+        """Load configuration from YAML file.
+
+        Args:
+            path: Path to YAML configuration file.
+
+        Returns:
+            Populated ShaclConfig instance.
+
+        Raises:
+            FileNotFoundError: If configuration file doesn't exist.
+            ValueError: If configuration is invalid.
+        """
+        with open(path) as f:
+            data = yaml.safe_load(f) or {}
+
+        return cls.from_dict(data)
+
+    @classmethod
+    def from_dict(cls, data: dict[str, Any]) -> "ShaclConfig":
+        """Create configuration from dictionary.
+
+        Args:
+            data: Configuration dictionary.
+
+        Returns:
+            Populated ShaclConfig instance.
+        """
+        # Handle enum conversions
+        level_str = data.get("level", "standard").lower()
+        try:
+            level = StrictnessLevel(level_str)
+        except ValueError:
+            valid = ", ".join(s.value for s in StrictnessLevel)
+            raise ValueError(f"Invalid strictness level '{level_str}'. Valid: {valid}")
+
+        severity_str = data.get("default_severity", "violation").lower()
+        try:
+            severity = Severity(severity_str)
+        except ValueError:
+            valid = ", ".join(s.value for s in Severity)
+            raise ValueError(f"Invalid severity '{severity_str}'. Valid: {valid}")
+
+        return cls(
+            level=level,
+            default_severity=severity,
+            closed=data.get("closed", False),
+            shape_namespace=data.get("shape_namespace", "shapes#"),
+            target_classes=data.get("target_classes", []),
+            exclude_classes=data.get("exclude_classes", []),
+            include_labels=data.get("include_labels", True),
+            include_descriptions=data.get("include_descriptions", True),
+            inherit_constraints=data.get("inherit_constraints", True),
+            generate_property_shapes=data.get("generate_property_shapes", False),
+            ignored_properties=data.get("ignored_properties", []),
+        )
+
+    def should_generate_for(self, class_uri: URIRef, graph: "Graph") -> bool:
+        """Check if a shape should be generated for this class.
+
+        Args:
+            class_uri: The class URI to check.
+            graph: The source graph (for CURIE expansion).
+
+        Returns:
+            True if shape should be generated.
+        """
+        class_str = str(class_uri)
+
+        # If explicit targets specified, only generate for those
+        if self.target_classes:
+            return any(class_str.endswith(t) or t in class_str for t in self.target_classes)
+
+        # Check exclusions
+        if self.exclude_classes:
+            return not any(
+                class_str.endswith(e) or e in class_str for e in self.exclude_classes
+            )
+
+        return True
+
+
+def load_shacl_config(path: Path | None) -> ShaclConfig:
+    """Load SHACL configuration from file or return defaults.
+
+    Args:
+        path: Optional path to configuration file.
+
+    Returns:
+        ShaclConfig instance (defaults if no path provided).
+    """
+    if path is None:
+        return ShaclConfig()
+
+    return ShaclConfig.from_yaml(path)

--- a/src/rdf_construct/shacl/converters.py
+++ b/src/rdf_construct/shacl/converters.py
@@ -1,0 +1,520 @@
+"""OWL to SHACL conversion rules.
+
+Each converter handles a specific OWL pattern and produces equivalent SHACL
+constraints. Converters are composable and applied by the generator.
+"""
+
+from abc import ABC, abstractmethod
+from dataclasses import dataclass, field
+from typing import TYPE_CHECKING
+
+from rdflib import BNode, Graph, Literal, Namespace, RDF, RDFS, URIRef, XSD
+from rdflib.namespace import OWL
+
+from .namespaces import SH
+
+if TYPE_CHECKING:
+    from .config import ShaclConfig
+
+
+@dataclass
+class PropertyConstraint:
+    """Represents a property constraint to be added to a shape.
+
+    Accumulates constraints that will become a sh:property blank node.
+
+    Attributes:
+        path: The property path (usually the property URI).
+        node_class: Expected class for object values (sh:class).
+        datatype: Expected datatype for literal values (sh:datatype).
+        min_count: Minimum cardinality (sh:minCount).
+        max_count: Maximum cardinality (sh:maxCount).
+        node_kind: Node kind constraint (sh:nodeKind).
+        name: Human-readable name (sh:name).
+        description: Description (sh:description).
+        in_values: Enumeration of allowed values (sh:in).
+        pattern: Regex pattern for string values (sh:pattern).
+        min_inclusive: Minimum value inclusive (sh:minInclusive).
+        max_inclusive: Maximum value inclusive (sh:maxInclusive).
+        order: Property display order (sh:order).
+    """
+
+    path: URIRef
+    node_class: URIRef | None = None
+    datatype: URIRef | None = None
+    min_count: int | None = None
+    max_count: int | None = None
+    node_kind: URIRef | None = None
+    name: str | None = None
+    description: str | None = None
+    in_values: list[URIRef | Literal] = field(default_factory=list)
+    pattern: str | None = None
+    min_inclusive: Literal | None = None
+    max_inclusive: Literal | None = None
+    order: int | None = None
+
+    def merge(self, other: "PropertyConstraint") -> "PropertyConstraint":
+        """Merge another constraint into this one.
+
+        Values from other take precedence for single-value fields.
+        Lists are combined.
+
+        Args:
+            other: Constraint to merge from.
+
+        Returns:
+            New merged PropertyConstraint.
+        """
+        return PropertyConstraint(
+            path=self.path,
+            node_class=other.node_class or self.node_class,
+            datatype=other.datatype or self.datatype,
+            min_count=max(
+                filter(None, [self.min_count, other.min_count]), default=None
+            ),
+            max_count=min(
+                filter(None, [self.max_count, other.max_count]), default=None
+            ) if self.max_count is not None or other.max_count is not None else None,
+            node_kind=other.node_kind or self.node_kind,
+            name=other.name or self.name,
+            description=other.description or self.description,
+            in_values=list(set(self.in_values + other.in_values)),
+            pattern=other.pattern or self.pattern,
+            min_inclusive=other.min_inclusive or self.min_inclusive,
+            max_inclusive=other.max_inclusive or self.max_inclusive,
+            order=other.order or self.order,
+        )
+
+    def to_rdf(self, shapes_graph: Graph) -> BNode:
+        """Convert constraint to RDF representation.
+
+        Creates a blank node with sh:property predicates.
+
+        Args:
+            shapes_graph: Graph to add triples to.
+
+        Returns:
+            Blank node representing the property shape.
+        """
+        prop_shape = BNode()
+
+        shapes_graph.add((prop_shape, SH.path, self.path))
+
+        if self.node_class:
+            shapes_graph.add((prop_shape, SH["class"], self.node_class))
+
+        if self.datatype:
+            shapes_graph.add((prop_shape, SH.datatype, self.datatype))
+
+        if self.min_count is not None:
+            shapes_graph.add((prop_shape, SH.minCount, Literal(self.min_count)))
+
+        if self.max_count is not None:
+            shapes_graph.add((prop_shape, SH.maxCount, Literal(self.max_count)))
+
+        if self.node_kind:
+            shapes_graph.add((prop_shape, SH.nodeKind, self.node_kind))
+
+        if self.name:
+            shapes_graph.add((prop_shape, SH.name, Literal(self.name)))
+
+        if self.description:
+            shapes_graph.add((prop_shape, SH.description, Literal(self.description)))
+
+        if self.in_values:
+            # Create an RDF list for sh:in
+            in_list = _create_rdf_list(shapes_graph, self.in_values)
+            shapes_graph.add((prop_shape, SH["in"], in_list))
+
+        if self.pattern:
+            shapes_graph.add((prop_shape, SH.pattern, Literal(self.pattern)))
+
+        if self.min_inclusive is not None:
+            shapes_graph.add((prop_shape, SH.minInclusive, self.min_inclusive))
+
+        if self.max_inclusive is not None:
+            shapes_graph.add((prop_shape, SH.maxInclusive, self.max_inclusive))
+
+        if self.order is not None:
+            shapes_graph.add((prop_shape, SH.order, Literal(self.order)))
+
+        return prop_shape
+
+
+def _create_rdf_list(graph: Graph, items: list) -> BNode:
+    """Create an RDF list from Python list.
+
+    Args:
+        graph: Graph to add list triples to.
+        items: Items to include in list.
+
+    Returns:
+        Head node of the RDF list.
+    """
+    if not items:
+        return RDF.nil
+
+    head = BNode()
+    current = head
+
+    for i, item in enumerate(items):
+        graph.add((current, RDF.first, item))
+
+        if i < len(items) - 1:
+            next_node = BNode()
+            graph.add((current, RDF.rest, next_node))
+            current = next_node
+        else:
+            graph.add((current, RDF.rest, RDF.nil))
+
+    return head
+
+
+class Converter(ABC):
+    """Base class for OWL to SHACL converters.
+
+    Each converter handles a specific OWL pattern and produces
+    property constraints or modifies the shape graph directly.
+    """
+
+    @abstractmethod
+    def convert_for_class(
+            self,
+            cls: URIRef,
+            source_graph: Graph,
+            config: "ShaclConfig",
+    ) -> list[PropertyConstraint]:
+        """Extract constraints for a given class.
+
+        Args:
+            cls: The class to extract constraints for.
+            source_graph: The OWL ontology graph.
+            config: Generation configuration.
+
+        Returns:
+            List of property constraints for this class.
+        """
+        pass
+
+
+class DomainRangeConverter(Converter):
+    """Convert rdfs:domain/range to sh:property with sh:class/sh:datatype.
+
+    For each property with rdfs:domain pointing to this class, creates
+    a property constraint. The rdfs:range determines whether sh:class
+    or sh:datatype is used.
+    """
+
+    # Common XSD datatypes
+    XSD_DATATYPES = {
+        XSD.string, XSD.integer, XSD.int, XSD.long, XSD.short, XSD.byte,
+        XSD.decimal, XSD.float, XSD.double, XSD.boolean, XSD.date,
+        XSD.dateTime, XSD.time, XSD.duration, XSD.gYear, XSD.gMonth,
+        XSD.gDay, XSD.gYearMonth, XSD.gMonthDay, XSD.anyURI, XSD.base64Binary,
+        XSD.hexBinary, XSD.normalizedString, XSD.token, XSD.language,
+        XSD.nonPositiveInteger, XSD.negativeInteger, XSD.nonNegativeInteger,
+        XSD.positiveInteger, XSD.unsignedLong, XSD.unsignedInt,
+        XSD.unsignedShort, XSD.unsignedByte,
+    }
+
+    def convert_for_class(
+            self,
+            cls: URIRef,
+            source_graph: Graph,
+            config: "ShaclConfig",
+    ) -> list[PropertyConstraint]:
+        """Find properties with domain of this class and create constraints."""
+        constraints: list[PropertyConstraint] = []
+
+        # Find all properties with this class as domain
+        for prop in source_graph.subjects(RDFS.domain, cls):
+            if not isinstance(prop, URIRef):
+                continue
+
+            constraint = PropertyConstraint(path=prop)
+
+            # Get range if defined
+            range_value = source_graph.value(prop, RDFS.range)
+            if range_value:
+                if self._is_datatype(range_value, source_graph):
+                    constraint.datatype = range_value
+                else:
+                    constraint.node_class = range_value
+
+            # Add label as name if configured
+            if config.include_labels:
+                label = source_graph.value(prop, RDFS.label)
+                if label:
+                    constraint.name = str(label)
+
+            # Add comment as description if configured
+            if config.include_descriptions:
+                comment = source_graph.value(prop, RDFS.comment)
+                if comment:
+                    constraint.description = str(comment)
+
+            constraints.append(constraint)
+
+        return constraints
+
+    def _is_datatype(self, uri: URIRef, graph: Graph) -> bool:
+        """Check if URI represents a datatype."""
+        if uri in self.XSD_DATATYPES:
+            return True
+
+        # Check if it's declared as rdfs:Datatype
+        if (uri, RDF.type, RDFS.Datatype) in graph:
+            return True
+
+        # Check namespace - XSD URIs are datatypes
+        return str(uri).startswith(str(XSD))
+
+
+class CardinalityConverter(Converter):
+    """Convert OWL cardinality restrictions to sh:minCount/sh:maxCount.
+
+    Handles:
+    - owl:cardinality → sh:minCount + sh:maxCount
+    - owl:minCardinality → sh:minCount
+    - owl:maxCardinality → sh:maxCount
+    - owl:qualifiedCardinality (with owl:onClass/owl:onDataRange)
+    - owl:someValuesFrom → sh:minCount 1
+    """
+
+    def convert_for_class(
+            self,
+            cls: URIRef,
+            source_graph: Graph,
+            config: "ShaclConfig",
+    ) -> list[PropertyConstraint]:
+        """Extract cardinality restrictions from class definition."""
+        constraints: list[PropertyConstraint] = []
+
+        # Find restrictions that this class is a subclass of
+        for superclass in source_graph.objects(cls, RDFS.subClassOf):
+            if not isinstance(superclass, BNode):
+                continue
+
+            # Check if it's an owl:Restriction
+            if (superclass, RDF.type, OWL.Restriction) not in source_graph:
+                continue
+
+            on_prop = source_graph.value(superclass, OWL.onProperty)
+            if not isinstance(on_prop, URIRef):
+                continue
+
+            constraint = PropertyConstraint(path=on_prop)
+            has_constraint = False
+
+            # Exact cardinality
+            exact = source_graph.value(superclass, OWL.cardinality)
+            if exact:
+                constraint.min_count = int(exact)
+                constraint.max_count = int(exact)
+                has_constraint = True
+
+            # Minimum cardinality
+            min_card = source_graph.value(superclass, OWL.minCardinality)
+            if min_card:
+                constraint.min_count = int(min_card)
+                has_constraint = True
+
+            # Maximum cardinality
+            max_card = source_graph.value(superclass, OWL.maxCardinality)
+            if max_card:
+                constraint.max_count = int(max_card)
+                has_constraint = True
+
+            # Qualified cardinality
+            qual_card = source_graph.value(superclass, OWL.qualifiedCardinality)
+            if qual_card:
+                constraint.min_count = int(qual_card)
+                constraint.max_count = int(qual_card)
+                # Also get the qualification
+                on_class = source_graph.value(superclass, OWL.onClass)
+                if on_class:
+                    constraint.node_class = on_class
+                on_data = source_graph.value(superclass, OWL.onDataRange)
+                if on_data:
+                    constraint.datatype = on_data
+                has_constraint = True
+
+            # Qualified min cardinality
+            qual_min = source_graph.value(superclass, OWL.minQualifiedCardinality)
+            if qual_min:
+                constraint.min_count = int(qual_min)
+                on_class = source_graph.value(superclass, OWL.onClass)
+                if on_class:
+                    constraint.node_class = on_class
+                has_constraint = True
+
+            # Qualified max cardinality
+            qual_max = source_graph.value(superclass, OWL.maxQualifiedCardinality)
+            if qual_max:
+                constraint.max_count = int(qual_max)
+                on_class = source_graph.value(superclass, OWL.onClass)
+                if on_class:
+                    constraint.node_class = on_class
+                has_constraint = True
+
+            # someValuesFrom implies at least one value
+            some_from = source_graph.value(superclass, OWL.someValuesFrom)
+            if some_from:
+                constraint.min_count = 1
+                if isinstance(some_from, URIRef):
+                    # Could be a class or datatype
+                    if self._is_datatype(some_from, source_graph):
+                        constraint.datatype = some_from
+                    else:
+                        constraint.node_class = some_from
+                has_constraint = True
+
+            # allValuesFrom constrains the type but not cardinality
+            all_from = source_graph.value(superclass, OWL.allValuesFrom)
+            if all_from and isinstance(all_from, URIRef):
+                if self._is_datatype(all_from, source_graph):
+                    constraint.datatype = all_from
+                else:
+                    constraint.node_class = all_from
+                has_constraint = True
+
+            if has_constraint:
+                constraints.append(constraint)
+
+        return constraints
+
+    def _is_datatype(self, uri: URIRef, graph: Graph) -> bool:
+        """Check if URI represents a datatype."""
+        return str(uri).startswith(str(XSD)) or (uri, RDF.type, RDFS.Datatype) in graph
+
+
+class FunctionalPropertyConverter(Converter):
+    """Convert owl:FunctionalProperty to sh:maxCount 1.
+
+    Also handles owl:InverseFunctionalProperty (adds maxCount 1 for the property).
+    """
+
+    def convert_for_class(
+            self,
+            cls: URIRef,
+            source_graph: Graph,
+            config: "ShaclConfig",
+    ) -> list[PropertyConstraint]:
+        """Find functional properties with domain of this class."""
+        constraints: list[PropertyConstraint] = []
+
+        # Get all functional properties
+        functional_props = set(source_graph.subjects(RDF.type, OWL.FunctionalProperty))
+
+        # Find properties with this class as domain
+        for prop in source_graph.subjects(RDFS.domain, cls):
+            if prop in functional_props and isinstance(prop, URIRef):
+                constraints.append(PropertyConstraint(path=prop, max_count=1))
+
+        return constraints
+
+
+class EnumerationConverter(Converter):
+    """Convert owl:oneOf to sh:in constraint.
+
+    When a property's range is a class defined with owl:oneOf,
+    creates a sh:in constraint with the enumerated values.
+    """
+
+    def convert_for_class(
+            self,
+            cls: URIRef,
+            source_graph: Graph,
+            config: "ShaclConfig",
+    ) -> list[PropertyConstraint]:
+        """Find properties with enumerated ranges."""
+        constraints: list[PropertyConstraint] = []
+
+        # Find properties with domain of this class
+        for prop in source_graph.subjects(RDFS.domain, cls):
+            if not isinstance(prop, URIRef):
+                continue
+
+            range_value = source_graph.value(prop, RDFS.range)
+            if not range_value:
+                continue
+
+            # Check if range has owl:oneOf
+            one_of = source_graph.value(range_value, OWL.oneOf)
+            if one_of:
+                values = self._extract_list(source_graph, one_of)
+                if values:
+                    constraints.append(PropertyConstraint(path=prop, in_values=values))
+
+        return constraints
+
+    def _extract_list(self, graph: Graph, head: BNode | URIRef) -> list:
+        """Extract values from RDF list."""
+        values = []
+        current = head
+
+        while current and current != RDF.nil:
+            first = graph.value(current, RDF.first)
+            if first:
+                values.append(first)
+            current = graph.value(current, RDF.rest)
+
+        return values
+
+
+class SymmetricPropertyConverter(Converter):
+    """Handle symmetric properties.
+
+    For symmetric properties, if domain is defined, the property
+    should also be valid in the reverse direction.
+    """
+
+    def convert_for_class(
+            self,
+            cls: URIRef,
+            source_graph: Graph,
+            config: "ShaclConfig",
+    ) -> list[PropertyConstraint]:
+        """Handle symmetric properties - no additional SHACL needed."""
+        # Symmetric properties don't need special SHACL handling
+        # beyond what domain/range provides
+        return []
+
+
+# All converters in order of application
+ALL_CONVERTERS: list[type[Converter]] = [
+    DomainRangeConverter,
+    CardinalityConverter,
+    FunctionalPropertyConverter,
+    EnumerationConverter,
+]
+
+
+def get_converters_for_level(level: "StrictnessLevel") -> list[Converter]:
+    """Get converter instances appropriate for strictness level.
+
+    Args:
+        level: The strictness level.
+
+    Returns:
+        List of instantiated converters.
+    """
+    from .config import StrictnessLevel
+
+    if level == StrictnessLevel.MINIMAL:
+        return [DomainRangeConverter()]
+
+    elif level == StrictnessLevel.STANDARD:
+        return [
+            DomainRangeConverter(),
+            CardinalityConverter(),
+            FunctionalPropertyConverter(),
+        ]
+
+    else:  # STRICT
+        return [
+            DomainRangeConverter(),
+            CardinalityConverter(),
+            FunctionalPropertyConverter(),
+            EnumerationConverter(),
+        ]

--- a/src/rdf_construct/shacl/generator.py
+++ b/src/rdf_construct/shacl/generator.py
@@ -1,0 +1,364 @@
+"""SHACL shape generator from OWL ontologies.
+
+Generates SHACL NodeShapes from OWL class definitions, converting
+domain/range, cardinality restrictions, and other OWL patterns
+to equivalent SHACL constraints.
+"""
+
+from collections import defaultdict
+from pathlib import Path
+from typing import Any
+
+from rdflib import BNode, Graph, Literal, Namespace, RDF, RDFS, URIRef
+from rdflib.namespace import OWL
+
+from .config import ShaclConfig, Severity, StrictnessLevel
+from .converters import PropertyConstraint, get_converters_for_level
+from .namespaces import SH, SHACL_PREFIXES
+
+
+class ShapeGenerator:
+    """Generates SHACL shapes from OWL ontology definitions.
+
+    Orchestrates the conversion process, applying converters and
+    building the output shapes graph.
+
+    Attributes:
+        config: Generation configuration.
+        source_graph: The OWL ontology to convert.
+        shapes_graph: The output SHACL shapes graph.
+    """
+
+    def __init__(self, source_graph: Graph, config: ShaclConfig | None = None):
+        """Initialise generator.
+
+        Args:
+            source_graph: The OWL ontology graph.
+            config: Optional configuration (defaults provided).
+        """
+        self.config = config or ShaclConfig()
+        self.source_graph = source_graph
+        self.shapes_graph = Graph()
+
+        # Bind prefixes
+        for prefix, ns in SHACL_PREFIXES.items():
+            self.shapes_graph.bind(prefix, ns)
+
+        # Copy source prefixes
+        for prefix, ns in source_graph.namespaces():
+            if prefix and prefix not in ("xml", "xsd", "rdf", "rdfs", "owl"):
+                self.shapes_graph.bind(prefix, ns)
+
+        # Determine shape namespace
+        self._shape_ns = self._determine_shape_namespace()
+        self.shapes_graph.bind("shape", Namespace(self._shape_ns))
+
+    def _determine_shape_namespace(self) -> str:
+        """Determine the namespace for generated shapes.
+
+        Uses the ontology namespace if available, otherwise falls back
+        to a default.
+        """
+        # Look for owl:Ontology
+        for ont in self.source_graph.subjects(RDF.type, OWL.Ontology):
+            if isinstance(ont, URIRef):
+                base = str(ont)
+                # Append shapes suffix
+                if base.endswith("#") or base.endswith("/"):
+                    return base[:-1] + "-shapes#"
+                return base + "-shapes#"
+
+        # Fallback: use first non-standard namespace
+        for prefix, ns in self.source_graph.namespaces():
+            ns_str = str(ns)
+            if not any(
+                    ns_str.startswith(std)
+                    for std in (
+                            "http://www.w3.org/",
+                            "http://purl.org/dc/",
+                            "http://xmlns.com/",
+                    )
+            ):
+                if ns_str.endswith("#") or ns_str.endswith("/"):
+                    return ns_str[:-1] + "-shapes#"
+                return ns_str + "-shapes#"
+
+        return "http://example.org/shapes#"
+
+    def generate(self) -> Graph:
+        """Generate SHACL shapes from the source ontology.
+
+        Returns:
+            Graph containing the generated SHACL shapes.
+        """
+        # Get all classes from ontology
+        classes = self._get_target_classes()
+
+        # Get converters for current strictness level
+        converters = get_converters_for_level(self.config.level)
+
+        # Generate shape for each class
+        for cls in classes:
+            if not self.config.should_generate_for(cls, self.source_graph):
+                continue
+
+            self._create_node_shape(cls, converters)
+
+        return self.shapes_graph
+
+    def _get_target_classes(self) -> list[URIRef]:
+        """Get all target classes from the ontology.
+
+        Finds both owl:Class and rdfs:Class entities.
+
+        Returns:
+            List of class URIs.
+        """
+        classes: set[URIRef] = set()
+
+        # OWL classes
+        for cls in self.source_graph.subjects(RDF.type, OWL.Class):
+            if isinstance(cls, URIRef):
+                classes.add(cls)
+
+        # RDFS classes
+        for cls in self.source_graph.subjects(RDF.type, RDFS.Class):
+            if isinstance(cls, URIRef):
+                classes.add(cls)
+
+        # Sort by local name for consistent output
+        return sorted(classes, key=lambda c: self._local_name(c))
+
+    def _local_name(self, uri: URIRef) -> str:
+        """Extract local name from URI."""
+        s = str(uri)
+        if "#" in s:
+            return s.rsplit("#", 1)[1]
+        if "/" in s:
+            return s.rsplit("/", 1)[1]
+        return s
+
+    def _create_node_shape(self, cls: URIRef, converters: list) -> URIRef:
+        """Create a NodeShape for a class.
+
+        Args:
+            cls: The class to create a shape for.
+            converters: List of converters to apply.
+
+        Returns:
+            URI of the created shape.
+        """
+        shape_uri = URIRef(f"{self._shape_ns}{self._local_name(cls)}Shape")
+
+        # Basic shape definition
+        self.shapes_graph.add((shape_uri, RDF.type, SH.NodeShape))
+        self.shapes_graph.add((shape_uri, SH.targetClass, cls))
+
+        # Add name from rdfs:label if available
+        if self.config.include_labels:
+            label = self.source_graph.value(cls, RDFS.label)
+            if label:
+                self.shapes_graph.add((shape_uri, SH.name, Literal(str(label))))
+
+        # Add description from rdfs:comment
+        if self.config.include_descriptions:
+            comment = self.source_graph.value(cls, RDFS.comment)
+            if comment:
+                self.shapes_graph.add((shape_uri, SH.description, Literal(str(comment))))
+
+        # Collect all property constraints
+        prop_constraints: dict[URIRef, PropertyConstraint] = {}
+
+        # Apply each converter
+        for converter in converters:
+            constraints = converter.convert_for_class(
+                cls, self.source_graph, self.config
+            )
+
+            for constraint in constraints:
+                if constraint.path in prop_constraints:
+                    # Merge with existing constraint
+                    prop_constraints[constraint.path] = prop_constraints[
+                        constraint.path
+                    ].merge(constraint)
+                else:
+                    prop_constraints[constraint.path] = constraint
+
+        # Inherit constraints from superclasses if configured
+        if self.config.inherit_constraints:
+            inherited = self._get_inherited_constraints(cls, converters)
+            for path, constraint in inherited.items():
+                if path not in prop_constraints:
+                    prop_constraints[path] = constraint
+
+        # Add property shapes, sorted by path for consistent output
+        order = 1
+        for path in sorted(prop_constraints.keys(), key=str):
+            constraint = prop_constraints[path]
+            constraint.order = order
+            order += 1
+
+            prop_shape = constraint.to_rdf(self.shapes_graph)
+            self.shapes_graph.add((shape_uri, SH.property, prop_shape))
+
+        # Handle closed shapes
+        if self.config.closed and self.config.level == StrictnessLevel.STRICT:
+            self.shapes_graph.add((shape_uri, SH.closed, Literal(True)))
+
+            # Add ignored properties
+            ignored = self._get_ignored_properties()
+            if ignored:
+                ignored_list = self._create_rdf_list(ignored)
+                self.shapes_graph.add((shape_uri, SH.ignoredProperties, ignored_list))
+
+        return shape_uri
+
+    def _get_inherited_constraints(
+            self, cls: URIRef, converters: list
+    ) -> dict[URIRef, PropertyConstraint]:
+        """Get property constraints from superclasses.
+
+        Args:
+            cls: The class to get inherited constraints for.
+            converters: Converters to apply.
+
+        Returns:
+            Dictionary mapping property URIs to constraints.
+        """
+        inherited: dict[URIRef, PropertyConstraint] = {}
+
+        # Walk up the class hierarchy
+        visited: set[URIRef] = set()
+        to_visit = list(self.source_graph.objects(cls, RDFS.subClassOf))
+
+        while to_visit:
+            superclass = to_visit.pop()
+            if not isinstance(superclass, URIRef) or superclass in visited:
+                continue
+
+            visited.add(superclass)
+
+            # Apply converters to superclass
+            for converter in converters:
+                constraints = converter.convert_for_class(
+                    superclass, self.source_graph, self.config
+                )
+
+                for constraint in constraints:
+                    if constraint.path not in inherited:
+                        inherited[constraint.path] = constraint
+                    else:
+                        inherited[constraint.path] = inherited[constraint.path].merge(
+                            constraint
+                        )
+
+            # Add parent's parents
+            to_visit.extend(self.source_graph.objects(superclass, RDFS.subClassOf))
+
+        return inherited
+
+    def _get_ignored_properties(self) -> list[URIRef]:
+        """Get list of properties to ignore in closed shapes."""
+        ignored = [RDF.type]  # Always ignore rdf:type
+
+        # Add user-configured ignored properties
+        for prop_str in self.config.ignored_properties:
+            # Expand CURIE if possible
+            expanded = self._expand_curie(prop_str)
+            if expanded:
+                ignored.append(expanded)
+
+        return ignored
+
+    def _expand_curie(self, curie: str) -> URIRef | None:
+        """Expand a CURIE to full URI."""
+        if ":" in curie and not curie.startswith("http"):
+            prefix, local = curie.split(":", 1)
+            for p, ns in self.source_graph.namespaces():
+                if p == prefix:
+                    return URIRef(str(ns) + local)
+
+        # Already a URI?
+        if curie.startswith("http"):
+            return URIRef(curie)
+
+        return None
+
+    def _create_rdf_list(self, items: list[URIRef]) -> BNode:
+        """Create an RDF list from items."""
+        if not items:
+            return RDF.nil
+
+        head = BNode()
+        current = head
+
+        for i, item in enumerate(items):
+            self.shapes_graph.add((current, RDF.first, item))
+
+            if i < len(items) - 1:
+                next_node = BNode()
+                self.shapes_graph.add((current, RDF.rest, next_node))
+                current = next_node
+            else:
+                self.shapes_graph.add((current, RDF.rest, RDF.nil))
+
+        return head
+
+
+def generate_shapes(
+        source: Path | Graph,
+        config: ShaclConfig | None = None,
+        output_format: str = "turtle",
+) -> tuple[Graph, str]:
+    """Generate SHACL shapes from an OWL ontology.
+
+    Main entry point for shape generation.
+
+    Args:
+        source: Path to ontology file or pre-loaded Graph.
+        config: Optional generation configuration.
+        output_format: Output serialisation format.
+
+    Returns:
+        Tuple of (shapes graph, serialised string).
+    """
+    # Load source if path
+    if isinstance(source, Path):
+        source_graph = Graph()
+        source_graph.parse(str(source), format="turtle")
+    else:
+        source_graph = source
+
+    # Generate shapes
+    generator = ShapeGenerator(source_graph, config)
+    shapes_graph = generator.generate()
+
+    # Serialise
+    output = shapes_graph.serialize(format=output_format)
+
+    return shapes_graph, output
+
+
+def generate_shapes_to_file(
+        source: Path,
+        output: Path,
+        config: ShaclConfig | None = None,
+        output_format: str = "turtle",
+) -> Graph:
+    """Generate SHACL shapes and write to file.
+
+    Args:
+        source: Path to ontology file.
+        output: Path to write shapes to.
+        config: Optional generation configuration.
+        output_format: Output serialisation format.
+
+    Returns:
+        The generated shapes graph.
+    """
+    shapes_graph, serialised = generate_shapes(source, config, output_format)
+
+    output.parent.mkdir(parents=True, exist_ok=True)
+    output.write_text(serialised)
+
+    return shapes_graph

--- a/src/rdf_construct/shacl/namespaces.py
+++ b/src/rdf_construct/shacl/namespaces.py
@@ -1,0 +1,93 @@
+"""SHACL namespace definitions and utilities."""
+
+from rdflib import Namespace
+from rdflib.namespace import DefinedNamespace
+
+# SHACL namespace
+SH = Namespace("http://www.w3.org/ns/shacl#")
+
+
+class SHACL(DefinedNamespace):
+    """SHACL namespace with commonly used terms.
+
+    Provides typed access to SHACL vocabulary terms for shape generation.
+    """
+
+    # Core shape types
+    NodeShape: str
+    PropertyShape: str
+    Shape: str
+
+    # Targeting
+    targetClass: str
+    targetNode: str
+    targetSubjectsOf: str
+    targetObjectsOf: str
+
+    # Property constraints
+    property: str
+    path: str
+    name: str
+    description: str
+    order: str
+    group: str
+
+    # Cardinality
+    minCount: str
+    maxCount: str
+
+    # Value type constraints
+    datatype: str
+    nodeKind: str
+
+    # Node kinds
+    BlankNode: str
+    IRI: str
+    Literal: str
+    BlankNodeOrIRI: str
+    BlankNodeOrLiteral: str
+    IRIOrLiteral: str
+
+    # Value constraints
+    node: str  # For sh:class equivalent - but we use class directly
+    hasValue: str
+
+    # Note: 'class' is a Python reserved word, access via SH["class"] or SH.class_
+
+    # Value range
+    minExclusive: str
+    minInclusive: str
+    maxExclusive: str
+    maxInclusive: str
+    minLength: str
+    maxLength: str
+    pattern: str
+
+    # Logical constraints
+    closed: str
+    ignoredProperties: str
+
+    # List constraints
+    in_: str  # sh:in (Python reserved word)
+
+    # Severity
+    severity: str
+    Violation: str
+    Warning: str
+    Info: str
+
+    # Property paths
+    alternativePath: str
+    inversePath: str
+    oneOrMorePath: str
+    zeroOrMorePath: str
+    zeroOrOnePath: str
+
+    # Namespace
+    _NS = Namespace("http://www.w3.org/ns/shacl#")
+
+
+# Standard SHACL prefix bindings for serialisation
+SHACL_PREFIXES = {
+    "sh": SH,
+}

--- a/tests/test_shacl_gen.py
+++ b/tests/test_shacl_gen.py
@@ -1,0 +1,566 @@
+"""Tests for SHACL shape generation."""
+
+import pytest
+from pathlib import Path
+from rdflib import Graph, Literal, Namespace, RDF, RDFS, URIRef, XSD
+from rdflib.namespace import OWL
+
+from rdf_construct.shacl import (
+    generate_shapes,
+    PropertyConstraint,
+    SH,
+    ShaclConfig,
+    ShapeGenerator,
+    StrictnessLevel,
+)
+from rdf_construct.shacl.converters import (
+    CardinalityConverter,
+    DomainRangeConverter,
+    EnumerationConverter,
+    FunctionalPropertyConverter,
+)
+
+# Test namespace
+EX = Namespace("http://example.org/")
+SHAPES = Namespace("http://example.org/-shapes#")
+
+
+class TestPropertyConstraint:
+    """Tests for PropertyConstraint dataclass."""
+
+    def test_basic_constraint(self):
+        """Test creating a basic property constraint."""
+        constraint = PropertyConstraint(path=EX.hasName)
+        assert constraint.path == EX.hasName
+        assert constraint.node_class is None
+        assert constraint.datatype is None
+
+    def test_constraint_with_class(self):
+        """Test constraint with object class."""
+        constraint = PropertyConstraint(path=EX.hasPart, node_class=EX.Component)
+        assert constraint.node_class == EX.Component
+
+    def test_constraint_with_datatype(self):
+        """Test constraint with datatype."""
+        constraint = PropertyConstraint(path=EX.hasName, datatype=XSD.string)
+        assert constraint.datatype == XSD.string
+
+    def test_constraint_with_cardinality(self):
+        """Test constraint with cardinality."""
+        constraint = PropertyConstraint(
+            path=EX.hasId, min_count=1, max_count=1
+        )
+        assert constraint.min_count == 1
+        assert constraint.max_count == 1
+
+    def test_merge_constraints(self):
+        """Test merging two constraints."""
+        c1 = PropertyConstraint(path=EX.prop, node_class=EX.Thing)
+        c2 = PropertyConstraint(path=EX.prop, min_count=1)
+
+        merged = c1.merge(c2)
+
+        assert merged.node_class == EX.Thing
+        assert merged.min_count == 1
+
+    def test_merge_takes_stricter_cardinality(self):
+        """Test that merge takes stricter cardinality values."""
+        c1 = PropertyConstraint(path=EX.prop, min_count=1, max_count=10)
+        c2 = PropertyConstraint(path=EX.prop, min_count=2, max_count=5)
+
+        merged = c1.merge(c2)
+
+        # Should take higher min and lower max
+        assert merged.min_count == 2
+        assert merged.max_count == 5
+
+    def test_to_rdf(self):
+        """Test converting constraint to RDF."""
+        constraint = PropertyConstraint(
+            path=EX.hasName,
+            datatype=XSD.string,
+            min_count=1,
+            max_count=1,
+            name="name",
+        )
+
+        graph = Graph()
+        prop_node = constraint.to_rdf(graph)
+
+        assert (prop_node, SH.path, EX.hasName) in graph
+        assert (prop_node, SH.datatype, XSD.string) in graph
+        assert (prop_node, SH.minCount, Literal(1)) in graph
+        assert (prop_node, SH.maxCount, Literal(1)) in graph
+        assert (prop_node, SH.name, Literal("name")) in graph
+
+
+class TestDomainRangeConverter:
+    """Tests for domain/range to SHACL conversion."""
+
+    @pytest.fixture
+    def source_graph(self) -> Graph:
+        """Create a test ontology graph."""
+        g = Graph()
+        g.bind("ex", EX)
+
+        # Define a class
+        g.add((EX.Person, RDF.type, OWL.Class))
+        g.add((EX.Person, RDFS.label, Literal("Person")))
+
+        # Object property with domain and range
+        g.add((EX.hasParent, RDF.type, OWL.ObjectProperty))
+        g.add((EX.hasParent, RDFS.domain, EX.Person))
+        g.add((EX.hasParent, RDFS.range, EX.Person))
+        g.add((EX.hasParent, RDFS.label, Literal("has parent")))
+
+        # Datatype property
+        g.add((EX.hasName, RDF.type, OWL.DatatypeProperty))
+        g.add((EX.hasName, RDFS.domain, EX.Person))
+        g.add((EX.hasName, RDFS.range, XSD.string))
+
+        return g
+
+    def test_object_property_domain_range(self, source_graph):
+        """Test converting object property with domain/range."""
+        converter = DomainRangeConverter()
+        config = ShaclConfig()
+
+        constraints = converter.convert_for_class(EX.Person, source_graph, config)
+
+        # Should find hasParent
+        paths = {c.path for c in constraints}
+        assert EX.hasParent in paths
+
+        parent_constraint = next(c for c in constraints if c.path == EX.hasParent)
+        assert parent_constraint.node_class == EX.Person
+        assert parent_constraint.name == "has parent"
+
+    def test_datatype_property(self, source_graph):
+        """Test converting datatype property."""
+        converter = DomainRangeConverter()
+        config = ShaclConfig()
+
+        constraints = converter.convert_for_class(EX.Person, source_graph, config)
+
+        name_constraint = next(c for c in constraints if c.path == EX.hasName)
+        assert name_constraint.datatype == XSD.string
+        assert name_constraint.node_class is None
+
+    def test_no_labels_when_disabled(self, source_graph):
+        """Test that labels are not included when disabled."""
+        converter = DomainRangeConverter()
+        config = ShaclConfig(include_labels=False)
+
+        constraints = converter.convert_for_class(EX.Person, source_graph, config)
+
+        parent_constraint = next(c for c in constraints if c.path == EX.hasParent)
+        assert parent_constraint.name is None
+
+
+class TestCardinalityConverter:
+    """Tests for OWL cardinality to SHACL conversion."""
+
+    @pytest.fixture
+    def cardinality_graph(self) -> Graph:
+        """Create a graph with cardinality restrictions."""
+        g = Graph()
+        g.bind("ex", EX)
+
+        # Class with exact cardinality restriction
+        g.add((EX.Person, RDF.type, OWL.Class))
+
+        from rdflib import BNode
+
+        # Exact cardinality: Person has exactly 1 ID
+        restriction1 = BNode()
+        g.add((EX.Person, RDFS.subClassOf, restriction1))
+        g.add((restriction1, RDF.type, OWL.Restriction))
+        g.add((restriction1, OWL.onProperty, EX.hasId))
+        g.add((restriction1, OWL.cardinality, Literal(1)))
+
+        # Min cardinality: Person has at least 1 parent
+        restriction2 = BNode()
+        g.add((EX.Person, RDFS.subClassOf, restriction2))
+        g.add((restriction2, RDF.type, OWL.Restriction))
+        g.add((restriction2, OWL.onProperty, EX.hasParent))
+        g.add((restriction2, OWL.minCardinality, Literal(1)))
+
+        # Max cardinality: Person has at most 2 parents
+        restriction3 = BNode()
+        g.add((EX.Person, RDFS.subClassOf, restriction3))
+        g.add((restriction3, RDF.type, OWL.Restriction))
+        g.add((restriction3, OWL.onProperty, EX.hasParent))
+        g.add((restriction3, OWL.maxCardinality, Literal(2)))
+
+        # someValuesFrom: Person has at least one name
+        restriction4 = BNode()
+        g.add((EX.Person, RDFS.subClassOf, restriction4))
+        g.add((restriction4, RDF.type, OWL.Restriction))
+        g.add((restriction4, OWL.onProperty, EX.hasName))
+        g.add((restriction4, OWL.someValuesFrom, XSD.string))
+
+        return g
+
+    def test_exact_cardinality(self, cardinality_graph):
+        """Test converting exact cardinality."""
+        converter = CardinalityConverter()
+        config = ShaclConfig()
+
+        constraints = converter.convert_for_class(EX.Person, cardinality_graph, config)
+
+        id_constraint = next(c for c in constraints if c.path == EX.hasId)
+        assert id_constraint.min_count == 1
+        assert id_constraint.max_count == 1
+
+    def test_min_max_cardinality(self, cardinality_graph):
+        """Test converting min/max cardinality."""
+        converter = CardinalityConverter()
+        config = ShaclConfig()
+
+        constraints = converter.convert_for_class(EX.Person, cardinality_graph, config)
+
+        # Find parent constraints
+        parent_constraints = [c for c in constraints if c.path == EX.hasParent]
+        assert len(parent_constraints) == 2
+
+        # Check we have both min and max
+        min_vals = [c.min_count for c in parent_constraints if c.min_count]
+        max_vals = [c.max_count for c in parent_constraints if c.max_count]
+
+        assert 1 in min_vals
+        assert 2 in max_vals
+
+    def test_some_values_from(self, cardinality_graph):
+        """Test converting someValuesFrom."""
+        converter = CardinalityConverter()
+        config = ShaclConfig()
+
+        constraints = converter.convert_for_class(EX.Person, cardinality_graph, config)
+
+        name_constraint = next(c for c in constraints if c.path == EX.hasName)
+        assert name_constraint.min_count == 1
+        assert name_constraint.datatype == XSD.string
+
+
+class TestFunctionalPropertyConverter:
+    """Tests for functional property to SHACL conversion."""
+
+    @pytest.fixture
+    def functional_graph(self) -> Graph:
+        """Create a graph with functional properties."""
+        g = Graph()
+        g.bind("ex", EX)
+
+        g.add((EX.Person, RDF.type, OWL.Class))
+
+        # Functional property
+        g.add((EX.hasSSN, RDF.type, OWL.DatatypeProperty))
+        g.add((EX.hasSSN, RDF.type, OWL.FunctionalProperty))
+        g.add((EX.hasSSN, RDFS.domain, EX.Person))
+
+        # Non-functional property
+        g.add((EX.hasNickname, RDF.type, OWL.DatatypeProperty))
+        g.add((EX.hasNickname, RDFS.domain, EX.Person))
+
+        return g
+
+    def test_functional_property(self, functional_graph):
+        """Test converting functional property."""
+        converter = FunctionalPropertyConverter()
+        config = ShaclConfig()
+
+        constraints = converter.convert_for_class(EX.Person, functional_graph, config)
+
+        # Should only have constraint for functional property
+        assert len(constraints) == 1
+        assert constraints[0].path == EX.hasSSN
+        assert constraints[0].max_count == 1
+
+
+class TestShapeGenerator:
+    """Tests for the main shape generator."""
+
+    @pytest.fixture
+    def simple_ontology(self) -> Graph:
+        """Create a simple test ontology."""
+        g = Graph()
+        g.bind("ex", EX)
+
+        # Ontology header
+        g.add((EX[""], RDF.type, OWL.Ontology))
+
+        # Classes
+        g.add((EX.Person, RDF.type, OWL.Class))
+        g.add((EX.Person, RDFS.label, Literal("Person")))
+        g.add((EX.Person, RDFS.comment, Literal("A human being")))
+
+        g.add((EX.Employee, RDF.type, OWL.Class))
+        g.add((EX.Employee, RDFS.subClassOf, EX.Person))
+        g.add((EX.Employee, RDFS.label, Literal("Employee")))
+
+        # Properties
+        g.add((EX.hasName, RDF.type, OWL.DatatypeProperty))
+        g.add((EX.hasName, RDFS.domain, EX.Person))
+        g.add((EX.hasName, RDFS.range, XSD.string))
+        g.add((EX.hasName, RDF.type, OWL.FunctionalProperty))
+
+        g.add((EX.worksFor, RDF.type, OWL.ObjectProperty))
+        g.add((EX.worksFor, RDFS.domain, EX.Employee))
+        g.add((EX.worksFor, RDFS.range, EX.Organisation))
+
+        g.add((EX.Organisation, RDF.type, OWL.Class))
+
+        return g
+
+    def test_generates_node_shapes(self, simple_ontology):
+        """Test that NodeShapes are generated for classes."""
+        generator = ShapeGenerator(simple_ontology)
+        shapes = generator.generate()
+
+        # Should have shapes for Person, Employee, Organisation
+        shape_targets = set(shapes.objects(predicate=SH.targetClass))
+        assert EX.Person in shape_targets
+        assert EX.Employee in shape_targets
+        assert EX.Organisation in shape_targets
+
+    def test_includes_labels(self, simple_ontology):
+        """Test that rdfs:label becomes sh:name."""
+        config = ShaclConfig(include_labels=True)
+        generator = ShapeGenerator(simple_ontology, config)
+        shapes = generator.generate()
+
+        # Find Person shape
+        person_shape = None
+        for shape in shapes.subjects(SH.targetClass, EX.Person):
+            person_shape = shape
+            break
+
+        assert person_shape is not None
+        name = shapes.value(person_shape, SH.name)
+        assert str(name) == "Person"
+
+    def test_includes_descriptions(self, simple_ontology):
+        """Test that rdfs:comment becomes sh:description."""
+        config = ShaclConfig(include_descriptions=True)
+        generator = ShapeGenerator(simple_ontology, config)
+        shapes = generator.generate()
+
+        # Find Person shape
+        person_shape = None
+        for shape in shapes.subjects(SH.targetClass, EX.Person):
+            person_shape = shape
+            break
+
+        desc = shapes.value(person_shape, SH.description)
+        assert "human being" in str(desc)
+
+    def test_minimal_level(self, simple_ontology):
+        """Test minimal strictness level."""
+        config = ShaclConfig(level=StrictnessLevel.MINIMAL)
+        generator = ShapeGenerator(simple_ontology, config)
+        shapes = generator.generate()
+
+        # Should have property shapes with sh:class/sh:datatype
+        # but no cardinality
+        for prop_shape in shapes.objects(predicate=SH.property):
+            # Check we have path
+            assert shapes.value(prop_shape, SH.path) is not None
+            # Minimal level shouldn't have maxCount from functional property
+            # (that's standard level)
+
+    def test_standard_level(self, simple_ontology):
+        """Test standard strictness level."""
+        config = ShaclConfig(level=StrictnessLevel.STANDARD)
+        generator = ShapeGenerator(simple_ontology, config)
+        shapes = generator.generate()
+
+        # Find Person shape
+        person_shape = None
+        for shape in shapes.subjects(SH.targetClass, EX.Person):
+            person_shape = shape
+            break
+
+        # Find hasName property shape - should have maxCount 1 from FunctionalProperty
+        found_max_count = False
+        for prop_shape in shapes.objects(person_shape, SH.property):
+            path = shapes.value(prop_shape, SH.path)
+            if path == EX.hasName:
+                max_count = shapes.value(prop_shape, SH.maxCount)
+                if max_count:
+                    assert int(max_count) == 1
+                    found_max_count = True
+
+        assert found_max_count, "Should have maxCount 1 for functional property"
+
+    def test_inherits_constraints(self, simple_ontology):
+        """Test constraint inheritance from superclasses."""
+        config = ShaclConfig(inherit_constraints=True)
+        generator = ShapeGenerator(simple_ontology, config)
+        shapes = generator.generate()
+
+        # Employee should inherit hasName constraint from Person
+        employee_shape = None
+        for shape in shapes.subjects(SH.targetClass, EX.Employee):
+            employee_shape = shape
+            break
+
+        # Check Employee has hasName property shape
+        has_name_prop = False
+        for prop_shape in shapes.objects(employee_shape, SH.property):
+            path = shapes.value(prop_shape, SH.path)
+            if path == EX.hasName:
+                has_name_prop = True
+
+        assert has_name_prop, "Employee should inherit hasName from Person"
+
+    def test_target_classes_filter(self, simple_ontology):
+        """Test filtering to specific target classes."""
+        config = ShaclConfig(target_classes=["Person"])
+        generator = ShapeGenerator(simple_ontology, config)
+        shapes = generator.generate()
+
+        shape_targets = set(shapes.objects(predicate=SH.targetClass))
+        assert EX.Person in shape_targets
+        assert EX.Employee not in shape_targets
+
+    def test_exclude_classes(self, simple_ontology):
+        """Test excluding specific classes."""
+        config = ShaclConfig(exclude_classes=["Organisation"])
+        generator = ShapeGenerator(simple_ontology, config)
+        shapes = generator.generate()
+
+        shape_targets = set(shapes.objects(predicate=SH.targetClass))
+        assert EX.Person in shape_targets
+        assert EX.Organisation not in shape_targets
+
+
+class TestGenerateShapes:
+    """Tests for the generate_shapes function."""
+
+    def test_from_graph(self):
+        """Test generating shapes from a Graph object."""
+        g = Graph()
+        g.bind("ex", EX)
+        g.add((EX.Thing, RDF.type, OWL.Class))
+        g.add((EX.hasPart, RDF.type, OWL.ObjectProperty))
+        g.add((EX.hasPart, RDFS.domain, EX.Thing))
+        g.add((EX.hasPart, RDFS.range, EX.Thing))
+
+        shapes_graph, turtle = generate_shapes(g)
+
+        assert isinstance(shapes_graph, Graph)
+        assert len(turtle) > 0
+        assert "sh:NodeShape" in turtle
+
+    def test_output_format_jsonld(self):
+        """Test generating JSON-LD output."""
+        g = Graph()
+        g.add((EX.Thing, RDF.type, OWL.Class))
+
+        shapes_graph, output = generate_shapes(g, output_format="json-ld")
+
+        assert "@" in output  # JSON-LD marker
+
+
+class TestShaclConfig:
+    """Tests for ShaclConfig."""
+
+    def test_default_config(self):
+        """Test default configuration values."""
+        config = ShaclConfig()
+
+        assert config.level == StrictnessLevel.STANDARD
+        assert config.closed is False
+        assert config.include_labels is True
+        assert config.inherit_constraints is True
+
+    def test_from_dict(self):
+        """Test creating config from dictionary."""
+        data = {
+            "level": "strict",
+            "closed": True,
+            "target_classes": ["Building", "Floor"],
+            "include_labels": False,
+        }
+
+        config = ShaclConfig.from_dict(data)
+
+        assert config.level == StrictnessLevel.STRICT
+        assert config.closed is True
+        assert config.target_classes == ["Building", "Floor"]
+        assert config.include_labels is False
+
+    def test_invalid_level_raises(self):
+        """Test that invalid strictness level raises ValueError."""
+        with pytest.raises(ValueError, match="Invalid strictness level"):
+            ShaclConfig.from_dict({"level": "invalid"})
+
+    def test_should_generate_for_with_targets(self):
+        """Test should_generate_for with target classes."""
+        config = ShaclConfig(target_classes=["Building"])
+        g = Graph()
+
+        assert config.should_generate_for(
+            URIRef("http://example.org/Building"), g
+        )
+        assert not config.should_generate_for(
+            URIRef("http://example.org/Floor"), g
+        )
+
+    def test_should_generate_for_with_excludes(self):
+        """Test should_generate_for with excluded classes."""
+        config = ShaclConfig(exclude_classes=["Thing"])
+        g = Graph()
+
+        assert config.should_generate_for(URIRef("http://example.org/Building"), g)
+        assert not config.should_generate_for(
+            URIRef("http://example.org/Thing"), g
+        )
+
+
+class TestEnumerationConverter:
+    """Tests for enumeration (owl:oneOf) conversion."""
+
+    @pytest.fixture
+    def enum_graph(self) -> Graph:
+        """Create a graph with enumerated values."""
+        g = Graph()
+        g.bind("ex", EX)
+
+        from rdflib import BNode
+
+        # Create an enumeration
+        g.add((EX.Person, RDF.type, OWL.Class))
+        g.add((EX.hasStatus, RDF.type, OWL.DatatypeProperty))
+        g.add((EX.hasStatus, RDFS.domain, EX.Person))
+        g.add((EX.hasStatus, RDFS.range, EX.Status))
+
+        # Define Status as enumeration
+        list_head = BNode()
+        g.add((EX.Status, OWL.oneOf, list_head))
+
+        # Build RDF list: (Active, Inactive, Pending)
+        g.add((list_head, RDF.first, EX.Active))
+        node2 = BNode()
+        g.add((list_head, RDF.rest, node2))
+        g.add((node2, RDF.first, EX.Inactive))
+        node3 = BNode()
+        g.add((node2, RDF.rest, node3))
+        g.add((node3, RDF.first, EX.Pending))
+        g.add((node3, RDF.rest, RDF.nil))
+
+        return g
+
+    def test_enumeration_to_sh_in(self, enum_graph):
+        """Test converting enumeration to sh:in."""
+        converter = EnumerationConverter()
+        config = ShaclConfig()
+
+        constraints = converter.convert_for_class(EX.Person, enum_graph, config)
+
+        assert len(constraints) == 1
+        constraint = constraints[0]
+        assert constraint.path == EX.hasStatus
+        assert EX.Active in constraint.in_values
+        assert EX.Inactive in constraint.in_values
+        assert EX.Pending in constraint.in_values


### PR DESCRIPTION
Closes #10 

## Summary

This PR introduces a new `shacl-gen` command that generates SHACL validation shapes from OWL ontology definitions.

## Changes

### New Modules

- **`src/rdf_construct/shacl/`** - New SHACL subpackage
  - `generator.py` - Main shape generation orchestrator
  - `converters.py` - Individual OWL → SHACL conversion rules
  - `config.py` - Configuration loading and defaults
  - `templates.py` - Helper functions for building shape graphs

### CLI Changes

- **`src/rdf_construct/cli.py`** - Added `shacl-gen` command with options:
  - Positional: Source ontology file(s)
  - `--output` / `-o` - Output file path
  - `--format` - Output format (turtle/jsonld)
  - `--level` - Strictness level (minimal/standard/strict)
  - `--config` - Path to configuration file
  - `--classes` - Comma-separated classes to focus on
  - `--closed` - Generate closed shapes
  - `--default-severity` - Default violation severity

### New Files

- `docs/user_guides/SHACL_GUIDE.md` - User documentation
- `examples/shacl-config.yml` - Example configuration
- `tests/test_shacl_gen.py` - Unit tests
- `tests/fixtures/shacl/` - Expected output fixtures

## Implementation Details

### Conversion Rules

Each OWL pattern has a dedicated converter:

```python
class DomainRangeConverter:
    """Convert rdfs:domain/range to sh:property with sh:class/sh:datatype."""
    
    def convert(self, prop: URIRef, graph: Graph) -> PropertyShape:
        shape = PropertyShape(path=prop)
        
        if range_cls := graph.value(prop, RDFS.range):
            if is_datatype(range_cls):
                shape.datatype = range_cls
            else:
                shape.node_class = range_cls
        
        return shape

class CardinalityConverter:
    """Convert owl:Restriction cardinality to sh:minCount/sh:maxCount."""
    
    def convert(self, restriction: BNode, graph: Graph) -> PropertyShape:
        on_prop = graph.value(restriction, OWL.onProperty)
        shape = PropertyShape(path=on_prop)
        
        if exact := graph.value(restriction, OWL.cardinality):
            shape.min_count = int(exact)
            shape.max_count = int(exact)
        elif min_c := graph.value(restriction, OWL.minCardinality):
            shape.min_count = int(min_c)
        elif max_c := graph.value(restriction, OWL.maxCardinality):
            shape.max_count = int(max_c)
        
        return shape

class FunctionalPropertyConverter:
    """Convert owl:FunctionalProperty to sh:maxCount 1."""
    
    def convert(self, prop: URIRef, graph: Graph) -> PropertyShape:
        if (prop, RDF.type, OWL.FunctionalProperty) in graph:
            return PropertyShape(path=prop, max_count=1)
        return None
```

### Shape Assembly

The generator collects conversions per target class:

```python
def create_node_shape(self, cls: URIRef, graph: Graph) -> Graph:
    shape_uri = self.make_shape_uri(cls)
    shapes = Graph()
    
    shapes.add((shape_uri, RDF.type, SH.NodeShape))
    shapes.add((shape_uri, SH.targetClass, cls))
    
    # Collect property shapes from all converters
    property_shapes = []
    for converter in self.converters:
        property_shapes.extend(converter.get_shapes_for(cls, graph))
    
    # Merge property shapes on same path
    merged = self.merge_property_shapes(property_shapes)
    
    # Add to graph
    for prop_shape in merged:
        bnode = prop_shape.to_rdf(shapes)
        shapes.add((shape_uri, SH.property, bnode))
    
    return shapes
```

### Property Shape Merging

Multiple converters may contribute constraints for the same property:

```python
def merge_property_shapes(self, shapes: list[PropertyShape]) -> list[PropertyShape]:
    by_path = defaultdict(PropertyShape)
    
    for shape in shapes:
        existing = by_path[shape.path]
        # Merge constraints (take most restrictive)
        if shape.min_count:
            existing.min_count = max(existing.min_count or 0, shape.min_count)
        if shape.max_count:
            existing.max_count = min(existing.max_count or float('inf'), shape.max_count)
        if shape.datatype:
            existing.datatype = shape.datatype
        if shape.node_class:
            existing.node_class = shape.node_class
    
    return list(by_path.values())
```

### Strictness Levels

| Level | Includes |
|-------|----------|
| minimal | Explicit cardinality, functional properties |
| standard | + Domain/range, inherited constraints |
| strict | + Closed shapes, required labels |

### Unconvertible Patterns

Patterns that cannot be expressed in SHACL are logged and commented:

```turtle
# WARNING: Pattern not converted to SHACL
# owl:complementOf on ex:NonBuilding
# Reason: Requires SPARQL constraint for negation
```

## Testing

### Unit Tests

```bash
pytest tests/test_shacl_gen.py -v
```

Coverage:
- `test_domain_range_conversion` - Basic property shapes
- `test_cardinality_exact` - owl:cardinality
- `test_cardinality_min_max` - owl:minCardinality, owl:maxCardinality
- `test_functional_property` - owl:FunctionalProperty
- `test_property_merge` - Multiple constraints same property
- `test_inherited_constraints` - Superclass restrictions
- `test_strictness_levels` - Level-dependent output
- `test_closed_shapes` - --closed flag

### Validation Tests

Generated shapes are validated using pySHACL:

```python
def test_generated_shapes_are_valid():
    shapes = generate_shapes(ontology)
    # Shapes graph should validate against SHACL meta-schema
    conforms, _, _ = validate(shapes, shacl_graph=SHACL_SHACL)
    assert conforms
```

### Integration Tests

```bash
pytest tests/test_shacl_gen_integration.py -v
```

Generates shapes for example ontologies and validates sample data against them.

### Manual Testing

```bash
# Generate shapes
poetry run rdf-construct shacl-gen examples/animal_ontology.ttl -o animal-shapes.ttl

# Validate data against shapes (using pyshacl)
pyshacl -s animal-shapes.ttl -d sample-data.ttl
```

## Breaking Changes

None. New command with no impact on existing functionality.

## Documentation

- [ ] `docs/user_guides/SHACL_GUIDE.md` - User guide with examples
- [ ] `docs/index.md` - Added to command reference
- [ ] Conversion rules table in documentation
- [ ] Limitations clearly documented

## Checklist

- [ ] Code follows project style guidelines
- [ ] Type hints on all functions
- [ ] Docstrings (Google style)
- [ ] Unit tests pass
- [ ] Generated SHACL validates
- [ ] Documentation updated
- [ ] CHANGELOG.md updated

## Example Output

**Input ontology** (excerpt):
```turtle
ex:Building a owl:Class .

ex:hasFloor a owl:ObjectProperty ;
    rdfs:domain ex:Building ;
    rdfs:range ex:Floor .

ex:hasAddress a owl:DatatypeProperty, owl:FunctionalProperty ;
    rdfs:domain ex:Building ;
    rdfs:range xsd:string .

ex:Building rdfs:subClassOf [
    a owl:Restriction ;
    owl:onProperty ex:hasFloor ;
    owl:minCardinality 1
] .
```

**Generated SHACL**:
```turtle
@prefix sh: <http://www.w3.org/ns/shacl#> .
@prefix ex: <http://example.org/> .
@prefix shape: <http://example.org/shapes#> .

shape:BuildingShape a sh:NodeShape ;
    sh:targetClass ex:Building ;
    sh:name "Building" ;
    
    sh:property [
        sh:path ex:hasFloor ;
        sh:class ex:Floor ;
        sh:minCount 1 ;
        sh:name "has floor" ;
    ] ;
    
    sh:property [
        sh:path ex:hasAddress ;
        sh:datatype xsd:string ;
        sh:maxCount 1 ;
        sh:name "has address" ;
    ] .
```
