### PR TITLE
DEV: Add `rdf-construct from-uml` command for PlantUML to RDF conversion

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,32 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 Added
 
+- **New `puml2rdf` command** for PlantUML to RDF conversion
+  - Convert PlantUML class diagrams to RDF/OWL ontologies
+  - Diagram-first ontology design workflow
+  - Parse classes, attributes, inheritance, and associations
+  - Support for dotted namespace prefixes (e.g., `building.Building` → `building:Building`)
+  - Handle `"Display Name" as alias` syntax for human-readable labels
+  - Direction hints in relationships (`-u-|>`, `-d-|>`, etc.)
+  - PlantUML styling attributes ignored gracefully (`#back:XXX;line:XXX`)
+  - Multi-line notes attached to classes become `rdfs:comment`
+  - Automatic namespace generation from package prefixes
+  - Custom datatype mappings (PlantUML types to XSD)
+  - Merge with existing ontologies (preserves manual annotations)
+  - Validation mode for CI integration (`--validate --strict`)
+  - YAML configuration file support for complex setups
+  - Output formats: Turtle, RDF/XML, JSON-LD, N-Triples
+- New module: `src/rdf_construct/puml2rdf/`
+  - `model.py` - Intermediate representation dataclasses
+  - `parser.py` - Regex-based PlantUML parser
+  - `converter.py` - Model to RDF/OWL conversion
+  - `config.py` - YAML configuration handling
+  - `merger.py` - Ontology merge logic
+  - `validators.py` - Model and RDF validation
+- New documentation: `docs/user_guides/PUML_IMPORT_GUIDE.md`
+- New example: `examples/puml_import_config.yml`
+- New tests: `tests/test_puml2rdf.py`
+
 - **New SHACL Shape Generator** (`shacl-gen` command)
 
   - Generate SHACL NodeShapes from OWL ontology definitions

--- a/CODE_INDEX.md
+++ b/CODE_INDEX.md
@@ -202,6 +202,53 @@ PlantUML diagram generation from RDF ontologies.
 - `LayoutConfig` class - diagram arrangement
 - Direction, spacing, grouping hints
 
+### UML `puml2rdf` Module
+
+Convert PlantUML class diagrams to RDF/OWL ontologies.
+
+**`puml2rdf/__init__.py`**
+- Public API exports
+- `PlantUMLParser`, `PumlToRdfConverter`, `validate_puml`, `validate_rdf`
+
+**`puml2rdf/model.py`**
+- `PumlClass` dataclass - parsed class with name, package, attributes, notes
+- `PumlAttribute` dataclass - class attributes with datatypes
+- `PumlRelationship` dataclass - inheritance and associations
+- `PumlPackage` dataclass - namespace mappings
+- `PumlModel` dataclass - complete parsed diagram
+- `RelationshipType` enum - INHERITANCE, ASSOCIATION, AGGREGATION, COMPOSITION
+
+**`puml2rdf/parser.py`**
+- `PlantUMLParser` class - regex-based multi-pass parser
+- `parse_dotted_name()` - split `building.Building` into package and local name
+- Handles `"Display Name" as alias` syntax
+- Supports direction hints (`-u-|>`, `-d-|>`, etc.)
+- Ignores PlantUML styling attributes (`#back:XXX;line:XXX`)
+
+**`puml2rdf/converter.py`**
+- `PumlToRdfConverter` class - transform parsed model to RDF graph
+- `ConversionConfig` dataclass - conversion options
+- Auto-generate namespaces from package prefixes
+- XSD datatype mapping for attributes
+- Label generation with camelCase conversion
+
+**`puml2rdf/config.py`**
+- `PumlImportConfig` dataclass - YAML configuration
+- `NamespaceMapping` - package to namespace URI mappings
+- `DatatypeMapping` - custom type conversions
+- `load_import_config()` - load from YAML file
+
+**`puml2rdf/merger.py`**
+- `OntologyMerger` class - merge generated RDF with existing ontologies
+- Preserves manual annotations while updating structure
+- Conflict detection and reporting
+
+**`puml2rdf/validators.py`**
+- `PumlModelValidator` - validate parsed PlantUML model
+- `RdfValidator` - validate generated RDF graph
+- Check for duplicate classes, unknown references, inheritance cycles
+- Severity levels: ERROR, WARNING, INFO
+
 ## Key Algorithms
 
 ### Topological Sorting

--- a/docs/index.md
+++ b/docs/index.md
@@ -5,6 +5,7 @@
 **New User?** → [Getting Started](user_guides/GETTING_STARTED.md)  
 **Generate Documentation?** → [Docs Guide](user_guides/DOCS_GUIDE.md)  
 **Generate Diagrams?** → [UML Guide](user_guides/UML_GUIDE.md)  
+**Import from PlantUML?** → [PlantUML Import Guide](user_guides/PUML_IMPORT_GUIDE.md)  
 **Generate SHACL Shapes?** → [SHACL Guide](user_guides/SHACL_GUIDE.md)  
 **Compare Ontologies?** → [Diff Guide](user_guides/DIFF_GUIDE.md)  
 **Check Quality?** → [Lint Guide](user_guides/LINT_GUIDE.md)  
@@ -39,6 +40,13 @@ For users of rdf-construct who want to generate diagrams and work with RDF ontol
   - Styling and layout
   - Complete examples
   - Tips and techniques
+
+- **[PlantUML Import Guide](user_guides/PUML_IMPORT_GUIDE.md)** - Convert PlantUML to RDF
+  - Diagram-first ontology design
+  - Supported PlantUML syntax
+  - Namespace handling
+  - Merge with existing ontologies
+  - Validation and configuration
 
 - **[SHACL Guide](user_guides/SHACL_GUIDE.md)** - SHACL shape generation
   - Generating shapes from OWL
@@ -98,6 +106,7 @@ A Python CLI toolkit for RDF operations:
 - **Semantic Ordering**: Serialise RDF/Turtle with meaningful order (not alphabetical)
 - **Documentation Generation**: Create navigable HTML/Markdown docs from ontologies
 - **UML Generation**: Create PlantUML class diagrams from ontologies
+- **PlantUML Import**: Convert PlantUML diagrams to RDF ontologies
 - **SHACL Generation**: Generate validation shapes from OWL definitions
 - **Semantic Diff**: Compare ontologies and identify meaningful changes
 - **Ontology Linting**: Check ontology quality with configurable rules
@@ -135,6 +144,22 @@ poetry run rdf-construct uml ontology.ttl -C config.yml \
   --layout-config layouts.yml --layout hierarchy
 ```
 
+### Import from PlantUML
+
+```bash
+# Basic conversion
+poetry run rdf-construct puml2rdf design.puml
+
+# Custom namespace
+poetry run rdf-construct puml2rdf design.puml -n http://example.org/ont#
+
+# Merge with existing ontology
+poetry run rdf-construct puml2rdf design.puml --merge existing.ttl
+
+# Validate only
+poetry run rdf-construct puml2rdf design.puml --validate
+```
+
 ### Generate SHACL Shapes
 
 ```bash
@@ -154,7 +179,7 @@ poetry run rdf-construct shacl-gen ontology.ttl --config shacl-config.yml
 # Basic comparison
 poetry run rdf-construct diff v1.0.ttl v1.1.ttl
 
-# Generate changelog
+# Generate markdown changelog
 poetry run rdf-construct diff v1.0.ttl v1.1.ttl --format markdown -o CHANGELOG.md
 ```
 

--- a/docs/user_guides/PLANTUML_IMPORT_GUIDE.md
+++ b/docs/user_guides/PLANTUML_IMPORT_GUIDE.md
@@ -1,0 +1,403 @@
+# PlantUML Import Guide
+
+Convert PlantUML class diagrams to RDF/OWL ontologies with the `from-uml` command.
+
+## Quick Start
+
+```bash
+# Basic conversion
+rdf-construct from-uml design.puml
+
+# Specify output and namespace
+rdf-construct from-uml design.puml -o ontology.ttl -n http://example.org/building#
+
+# Validate without generating
+rdf-construct from-uml design.puml --validate
+```
+
+## Supported PlantUML Syntax
+
+### Classes
+
+```plantuml
+' Simple class
+class Building
+
+' Class with attributes
+class Building {
+    floorArea : decimal
+    constructionYear : gYear
+    name : string
+}
+
+' Abstract class
+abstract class Entity
+
+' Class with stereotype
+class Building <<persistent>>
+```
+
+### Relationships
+
+```plantuml
+' Inheritance (generates rdfs:subClassOf)
+Building --|> Entity
+Entity <|-- Building  ' Same meaning, reversed arrow
+
+' Association (generates owl:ObjectProperty)
+Building --> Floor : hasFloor
+
+' With cardinalities (preserved as comments)
+Building "1" --> "*" Floor : hasFloor
+
+' Aggregation and composition
+Building o-- Room : contains
+Building *-- Foundation : hasFoundation
+```
+
+### Packages and Namespaces
+
+```plantuml
+' Package with explicit namespace URI
+package "http://example.org/building#" as bld {
+    class Building
+    class Floor
+}
+
+' Simple package (generates namespace from name)
+package core {
+    class Entity
+}
+```
+
+### Notes and Comments
+
+```plantuml
+' Single-line note
+note right of Building : A physical structure
+
+' Multi-line note
+note right of Building
+    A physical structure
+    that can be occupied.
+end note
+```
+
+Notes attached to classes become `rdfs:comment` in the generated ontology.
+
+## RDF Mapping
+
+### Classes
+
+| PlantUML | RDF |
+|----------|-----|
+| `class Building` | `bld:Building rdf:type owl:Class` |
+| `abstract class Entity` | `bld:Entity rdf:type owl:Class` |
+| Note attached to class | `rdfs:comment` |
+
+### Attributes
+
+Attributes become `owl:DatatypeProperty` with domain set to the containing class:
+
+| PlantUML | RDF |
+|----------|-----|
+| `floorArea : decimal` | `bld:floorArea rdf:type owl:DatatypeProperty ; rdfs:domain bld:Building ; rdfs:range xsd:decimal` |
+
+### Supported Datatypes
+
+| PlantUML Type | XSD Type |
+|---------------|----------|
+| `string`, `str`, `text` | `xsd:string` |
+| `integer`, `int` | `xsd:integer` |
+| `decimal`, `float`, `double` | `xsd:decimal`, `xsd:float`, `xsd:double` |
+| `boolean`, `bool` | `xsd:boolean` |
+| `date`, `datetime`, `time` | `xsd:date`, `xsd:dateTime`, `xsd:time` |
+| `gYear`, `gYearMonth` | `xsd:gYear`, `xsd:gYearMonth` |
+| `uri`, `anyURI`, `url` | `xsd:anyURI` |
+
+### Relationships
+
+| PlantUML | RDF |
+|----------|-----|
+| `A --\|> B` | `A rdfs:subClassOf B` |
+| `A --> B : label` | `label rdf:type owl:ObjectProperty ; rdfs:domain A ; rdfs:range B` |
+
+## CLI Reference
+
+```bash
+rdf-construct from-uml [OPTIONS] SOURCE
+```
+
+### Arguments
+
+| Argument | Description |
+|----------|-------------|
+| `SOURCE` | PlantUML file (.puml or .plantuml) |
+
+### Options
+
+| Option | Description |
+|--------|-------------|
+| `-o, --output PATH` | Output file path (default: source with .ttl extension) |
+| `-f, --format FORMAT` | Output format: turtle, xml, jsonld, nt (default: turtle) |
+| `-n, --namespace URI` | Default namespace URI for the ontology |
+| `-C, --config PATH` | Path to YAML configuration file |
+| `-m, --merge PATH` | Existing ontology file to merge with |
+| `-v, --validate` | Validate only, don't generate output |
+| `--strict` | Treat warnings as errors |
+| `-l, --language TAG` | Language tag for labels/comments (default: en) |
+| `--no-labels` | Don't auto-generate rdfs:label triples |
+
+### Exit Codes
+
+| Code | Meaning |
+|------|---------|
+| 0 | Success |
+| 1 | Validation warnings (with --strict) |
+| 2 | Parse or validation errors |
+
+## Configuration File
+
+Create a YAML configuration file for advanced control:
+
+```yaml
+# puml-import.yml
+
+# Default namespace for entities without explicit package
+default_namespace: "http://example.org/building#"
+
+# Language tag for labels and comments
+language: "en"
+
+# Automatically generate rdfs:label from entity names
+generate_labels: true
+
+# Convert camelCase names to readable labels
+# e.g., 'floorArea' -> 'floor area'
+camel_to_label: true
+
+# Map PlantUML packages to RDF namespaces
+namespace_mappings:
+  - package: "building"
+    namespace_uri: "http://example.org/building#"
+    prefix: "bld"
+  - package: "core"
+    namespace_uri: "http://example.org/core#"
+    prefix: "core"
+
+# Custom datatype mappings
+datatype_mappings:
+  Money: "xsd:decimal"
+  Percentage: "xsd:decimal"
+
+# Preferred prefix ordering in output
+prefix_order:
+  - ""
+  - "owl"
+  - "rdfs"
+  - "xsd"
+
+# URIs to include as owl:imports
+ontology_imports:
+  - "http://example.org/core"
+```
+
+Use with:
+
+```bash
+rdf-construct from-uml design.puml -C puml-import.yml
+```
+
+## Merging with Existing Ontologies
+
+The `--merge` option allows combining generated RDF with an existing ontology:
+
+```bash
+rdf-construct from-uml design.puml --merge existing.ttl -o merged.ttl
+```
+
+### Merge Behaviour
+
+- **New entities** are added
+- **Existing annotations** (comments, labels) are preserved
+- **Authoritative predicates** (subClassOf, domain, range) from PlantUML take precedence
+- **Conflicts** are reported but existing content wins by default
+
+This enables iterative workflows:
+1. Design structure in PlantUML
+2. Generate initial ontology
+3. Add manual annotations
+4. Update PlantUML and re-merge
+
+## Validation
+
+Run validation without generating output:
+
+```bash
+rdf-construct from-uml design.puml --validate
+```
+
+### Checks Performed
+
+**Model Validation:**
+- Duplicate class names
+- Relationships reference existing classes
+- Inheritance cycles
+- Unknown datatypes
+
+**RDF Validation:**
+- Classes properly typed
+- Properties have domain/range
+- No dangling references
+
+### Strict Mode
+
+Treat warnings as errors for CI pipelines:
+
+```bash
+rdf-construct from-uml design.puml --validate --strict
+```
+
+## Examples
+
+### Basic Building Ontology
+
+**Input** (`building.puml`):
+
+```plantuml
+@startuml
+title Building Ontology
+
+package "http://example.org/building#" as bld {
+  class Building {
+    floorArea : decimal
+    constructionYear : gYear
+  }
+  
+  class Floor {
+    level : integer
+  }
+  
+  class Room {
+    area : decimal
+    name : string
+  }
+}
+
+Building "1" --> "*" Floor : hasFloor
+Floor "1" --> "*" Room : hasRoom
+
+note right of Building
+  A physical structure that
+  can contain floors and rooms.
+end note
+
+@enduml
+```
+
+**Command:**
+
+```bash
+rdf-construct from-uml building.puml -o building.ttl
+```
+
+**Output** (`building.ttl`):
+
+```turtle
+@prefix bld: <http://example.org/building#> .
+@prefix owl: <http://www.w3.org/2002/07/owl#> .
+@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
+@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
+
+<http://example.org/building> a owl:Ontology ;
+    rdfs:label "Building Ontology"@en .
+
+bld:Building a owl:Class ;
+    rdfs:label "building"@en ;
+    rdfs:comment "A physical structure that can contain floors and rooms."@en .
+
+bld:Floor a owl:Class ;
+    rdfs:label "floor"@en .
+
+bld:Room a owl:Class ;
+    rdfs:label "room"@en .
+
+bld:floorArea a owl:DatatypeProperty ;
+    rdfs:domain bld:Building ;
+    rdfs:range xsd:decimal ;
+    rdfs:label "floor area"@en .
+
+bld:constructionYear a owl:DatatypeProperty ;
+    rdfs:domain bld:Building ;
+    rdfs:range xsd:gYear ;
+    rdfs:label "construction year"@en .
+
+bld:level a owl:DatatypeProperty ;
+    rdfs:domain bld:Floor ;
+    rdfs:range xsd:integer ;
+    rdfs:label "level"@en .
+
+bld:area a owl:DatatypeProperty ;
+    rdfs:domain bld:Room ;
+    rdfs:range xsd:decimal ;
+    rdfs:label "area"@en .
+
+bld:name a owl:DatatypeProperty ;
+    rdfs:domain bld:Room ;
+    rdfs:range xsd:string ;
+    rdfs:label "name"@en .
+
+bld:hasFloor a owl:ObjectProperty ;
+    rdfs:domain bld:Building ;
+    rdfs:range bld:Floor ;
+    rdfs:label "has floor"@en .
+
+bld:hasRoom a owl:ObjectProperty ;
+    rdfs:domain bld:Floor ;
+    rdfs:range bld:Room ;
+    rdfs:label "has room"@en .
+```
+
+## Unsupported Syntax
+
+The following PlantUML features are not currently supported:
+
+- Interface declarations (`interface`)
+- Enum declarations (`enum`)
+- Method declarations in classes
+- Composition/aggregation semantic distinction (treated as associations)
+- Generic types (`List<String>`)
+- Constraint expressions in attributes
+- Sequence diagrams, activity diagrams, etc.
+
+## Tips
+
+### Label Generation
+
+By default, camelCase names are converted to readable labels:
+- `floorArea` → "floor area"
+- `hasBuilding` → "has building"
+
+Disable with `--no-labels` or configure in YAML.
+
+### Round-Trip Workflow
+
+For ongoing development:
+
+1. Start with PlantUML diagram
+2. Generate initial RDF: `rdf-construct from-uml design.puml`
+3. Add detailed annotations manually
+4. Update PlantUML and merge: `rdf-construct from-uml design.puml --merge ontology.ttl`
+
+### CI Integration
+
+Add to your CI pipeline:
+
+```yaml
+# .github/workflows/ontology.yml
+- name: Validate PlantUML
+  run: rdf-construct from-uml design.puml --validate --strict
+
+- name: Generate ontology
+  run: rdf-construct from-uml design.puml -o ontology.ttl
+```

--- a/examples/puml_import.yml
+++ b/examples/puml_import.yml
@@ -1,0 +1,96 @@
+# Example PlantUML Import Configuration
+# ======================================
+#
+# This file configures how PlantUML class diagrams are converted to RDF ontologies.
+# Use with: rdf-construct puml2rdf diagram.puml -C puml_import_config.yml
+#
+
+# Default namespace URI for entities without an explicit package
+# This becomes the base URI for classes and properties
+default_namespace: "http://example.org/ontology#"
+
+# Language tag for rdfs:label and rdfs:comment
+# Standard BCP 47 language tags: en, en-GB, de, fr, etc.
+language: "en"
+
+# Automatically generate rdfs:label from entity names
+# When true, every class and property gets a human-readable label
+generate_labels: true
+
+# Convert camelCase/PascalCase names to readable labels
+# When true: 'floorArea' becomes 'floor area', 'Building' becomes 'building'
+# When false: names are used as-is
+camel_to_label: true
+
+# Generate inverse properties for object properties
+# When true: 'hasFloor' also creates 'isFloorOf' as inverse
+generate_inverse_properties: false
+
+# Map PlantUML packages to RDF namespaces
+# Each mapping specifies:
+#   package: The package name as it appears in PlantUML
+#   namespace_uri: The full namespace URI (should end with # or /)
+#   prefix: Optional short prefix for the namespace
+namespace_mappings:
+  - package: "building"
+    namespace_uri: "http://example.org/building#"
+    prefix: "bld"
+  - package: "core"
+    namespace_uri: "http://example.org/core#"
+    prefix: "core"
+  - package: "geo"
+    namespace_uri: "http://example.org/geo#"
+    prefix: "geo"
+
+# Custom datatype mappings
+# Map PlantUML/UML type names to XSD datatypes
+# The built-in mappings handle common types (string, integer, decimal, etc.)
+# Add custom mappings for domain-specific types
+datatype_mappings:
+  # Business types
+  Money: "xsd:decimal"
+  Currency: "xsd:string"
+  Percentage: "xsd:decimal"
+
+  # Identifiers
+  Identifier: "xsd:string"
+  UUID: "xsd:string"
+  Code: "xsd:token"
+
+  # Measurements
+  Area: "xsd:decimal"
+  Length: "xsd:decimal"
+  Temperature: "xsd:decimal"
+
+  # Time-related
+  Year: "xsd:gYear"
+  Month: "xsd:gYearMonth"
+  Timestamp: "xsd:dateTime"
+
+# Preferred prefix ordering in serialised output
+# Prefixes are bound in this order for consistent, readable output
+prefix_order:
+  - ""        # Default namespace (no prefix)
+  - "owl"     # OWL vocabulary
+  - "rdfs"    # RDFS vocabulary
+  - "rdf"     # RDF vocabulary
+  - "xsd"     # XML Schema datatypes
+  - "bld"     # Building namespace
+  - "core"    # Core namespace
+  - "geo"     # Geo namespace
+  - "dcterms" # Dublin Core terms
+
+# URIs to include as owl:imports in the generated ontology
+# These are added to the ontology header
+ontology_imports: []
+  # Uncomment to add imports:
+  # - "http://example.org/core"
+  # - "http://www.w3.org/2004/02/skos/core"
+
+# Annotation properties to recognise from notes
+# When notes contain patterns like "@see http://...", these can be
+# extracted into specific annotation properties
+annotation_properties: []
+  # - "rdfs:seeAlso"
+  # - "dcterms:description"
+  # - "skos:definition"

--- a/src/rdf_construct/puml2rdf/__init__.py
+++ b/src/rdf_construct/puml2rdf/__init__.py
@@ -1,0 +1,103 @@
+"""PlantUML to RDF import module.
+
+This module provides tools for converting PlantUML class diagrams
+to RDF/OWL ontologies, enabling diagram-first ontology design.
+
+Example:
+    from rdf_construct.puml_import import PlantUMLParser, PumlToRdfConverter
+
+    # Parse a PlantUML file
+    parser = PlantUMLParser()
+    result = parser.parse_file(Path("design.puml"))
+
+    if result.success:
+        # Convert to RDF
+        converter = PumlToRdfConverter()
+        rdf_result = converter.convert(result.model)
+
+        # Save the ontology
+        rdf_result.graph.serialize("ontology.ttl", format="turtle")
+"""
+
+from rdf_construct.puml2rdf.model import (
+    PropertyKind,
+    PumlAttribute,
+    PumlClass,
+    PumlModel,
+    PumlNote,
+    PumlPackage,
+    PumlRelationship,
+    RelationshipType,
+)
+from rdf_construct.puml2rdf.parser import (
+    ParseError,
+    ParseResult,
+    PlantUMLParser,
+)
+from rdf_construct.puml2rdf.converter import (
+    ConversionConfig,
+    ConversionResult,
+    PumlToRdfConverter,
+    XSD_TYPE_MAP,
+)
+from rdf_construct.puml2rdf.config import (
+    DatatypeMapping,
+    NamespaceMapping,
+    PumlImportConfig,
+    create_default_config,
+    load_import_config,
+)
+from rdf_construct.puml2rdf.merger import (
+    MergeResult,
+    OntologyMerger,
+    merge_with_existing,
+)
+from rdf_construct.puml2rdf.validators import (
+    PumlModelValidator,
+    RdfValidator,
+    Severity,
+    ValidationIssue,
+    ValidationResult,
+    validate_puml,
+    validate_rdf,
+)
+
+
+__all__ = [
+    # Model classes
+    "PropertyKind",
+    "PumlAttribute",
+    "PumlClass",
+    "PumlModel",
+    "PumlNote",
+    "PumlPackage",
+    "PumlRelationship",
+    "RelationshipType",
+    # Parser
+    "ParseError",
+    "ParseResult",
+    "PlantUMLParser",
+    # Converter
+    "ConversionConfig",
+    "ConversionResult",
+    "PumlToRdfConverter",
+    "XSD_TYPE_MAP",
+    # Config
+    "DatatypeMapping",
+    "NamespaceMapping",
+    "PumlImportConfig",
+    "create_default_config",
+    "load_import_config",
+    # Merger
+    "MergeResult",
+    "OntologyMerger",
+    "merge_with_existing",
+    # Validators
+    "PumlModelValidator",
+    "RdfValidator",
+    "Severity",
+    "ValidationIssue",
+    "ValidationResult",
+    "validate_puml",
+    "validate_rdf",
+]

--- a/src/rdf_construct/puml2rdf/config.py
+++ b/src/rdf_construct/puml2rdf/config.py
@@ -1,0 +1,230 @@
+"""Configuration handling for PlantUML import.
+
+This module provides YAML-based configuration for controlling
+how PlantUML diagrams are converted to RDF ontologies.
+"""
+
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Any, Optional
+
+import yaml
+
+from rdf_construct.puml2rdf.converter import ConversionConfig
+
+
+@dataclass
+class NamespaceMapping:
+    """Maps a PlantUML package to an RDF namespace.
+
+    Attributes:
+        package: PlantUML package name or pattern
+        namespace_uri: Target namespace URI
+        prefix: Preferred prefix for this namespace
+    """
+
+    package: str
+    namespace_uri: str
+    prefix: Optional[str] = None
+
+
+@dataclass
+class DatatypeMapping:
+    """Custom datatype mapping.
+
+    Attributes:
+        puml_type: PlantUML/UML type name
+        rdf_type: Full RDF type URI or CURIE
+    """
+
+    puml_type: str
+    rdf_type: str
+
+
+@dataclass
+class PumlImportConfig:
+    """Complete configuration for PlantUML to RDF import.
+
+    Attributes:
+        default_namespace: Default namespace for entities without explicit package
+        language: Language tag for labels/comments
+        generate_labels: Whether to auto-generate rdfs:label
+        camel_to_label: Convert camelCase to readable labels
+        generate_inverse_properties: Create inverse for each object property
+        namespace_mappings: Package to namespace mappings
+        datatype_mappings: Custom datatype conversions
+        prefix_order: Preferred prefix ordering for output
+        ontology_imports: URIs to add as owl:imports
+        annotation_properties: Additional properties to preserve
+    """
+
+    default_namespace: str = "http://example.org/ontology#"
+    language: str = "en"
+    generate_labels: bool = True
+    camel_to_label: bool = True
+    generate_inverse_properties: bool = False
+    namespace_mappings: list[NamespaceMapping] = field(default_factory=list)
+    datatype_mappings: list[DatatypeMapping] = field(default_factory=list)
+    prefix_order: list[str] = field(default_factory=list)
+    ontology_imports: list[str] = field(default_factory=list)
+    annotation_properties: list[str] = field(default_factory=list)
+
+    def to_conversion_config(self) -> ConversionConfig:
+        """Convert to the simpler ConversionConfig used by converter."""
+        return ConversionConfig(
+            default_namespace=self.default_namespace,
+            language=self.language,
+            generate_labels=self.generate_labels,
+            camel_to_label=self.camel_to_label,
+            generate_inverse_properties=self.generate_inverse_properties,
+        )
+
+
+def load_import_config(path: Path) -> PumlImportConfig:
+    """Load PlantUML import configuration from a YAML file.
+
+    Args:
+        path: Path to the YAML configuration file
+
+    Returns:
+        Parsed configuration object
+
+    Raises:
+        FileNotFoundError: If the config file doesn't exist
+        ValueError: If the config format is invalid
+    """
+    if not path.exists():
+        raise FileNotFoundError(f"Configuration file not found: {path}")
+
+    with open(path, "r", encoding="utf-8") as f:
+        data = yaml.safe_load(f)
+
+    if not isinstance(data, dict):
+        raise ValueError("Configuration must be a YAML dictionary")
+
+    return _parse_config(data)
+
+
+def _parse_config(data: dict[str, Any]) -> PumlImportConfig:
+    """Parse configuration dictionary into PumlImportConfig.
+
+    Args:
+        data: Raw YAML data dictionary
+
+    Returns:
+        Parsed configuration object
+    """
+    config = PumlImportConfig()
+
+    # Simple string/bool fields
+    if "default_namespace" in data:
+        config.default_namespace = str(data["default_namespace"])
+    if "language" in data:
+        config.language = str(data["language"])
+    if "generate_labels" in data:
+        config.generate_labels = bool(data["generate_labels"])
+    if "camel_to_label" in data:
+        config.camel_to_label = bool(data["camel_to_label"])
+    if "generate_inverse_properties" in data:
+        config.generate_inverse_properties = bool(data["generate_inverse_properties"])
+
+    # Parse namespace mappings
+    if "namespace_mappings" in data:
+        mappings = data["namespace_mappings"]
+        if isinstance(mappings, list):
+            for item in mappings:
+                if isinstance(item, dict):
+                    config.namespace_mappings.append(
+                        NamespaceMapping(
+                            package=item.get("package", ""),
+                            namespace_uri=item.get("namespace_uri", ""),
+                            prefix=item.get("prefix"),
+                        )
+                    )
+
+    # Parse datatype mappings
+    if "datatype_mappings" in data:
+        mappings = data["datatype_mappings"]
+        if isinstance(mappings, dict):
+            for puml_type, rdf_type in mappings.items():
+                config.datatype_mappings.append(
+                    DatatypeMapping(puml_type=puml_type, rdf_type=str(rdf_type))
+                )
+        elif isinstance(mappings, list):
+            for item in mappings:
+                if isinstance(item, dict):
+                    config.datatype_mappings.append(
+                        DatatypeMapping(
+                            puml_type=item.get("puml_type", ""),
+                            rdf_type=item.get("rdf_type", ""),
+                        )
+                    )
+
+    # Parse simple lists
+    if "prefix_order" in data:
+        config.prefix_order = list(data["prefix_order"])
+    if "ontology_imports" in data:
+        config.ontology_imports = list(data["ontology_imports"])
+    if "annotation_properties" in data:
+        config.annotation_properties = list(data["annotation_properties"])
+
+    return config
+
+
+def create_default_config() -> str:
+    """Generate a default configuration YAML string.
+
+    Returns:
+        YAML string with default configuration and comments
+    """
+    return '''# PlantUML Import Configuration
+# ================================
+
+# Default namespace for entities without explicit package
+default_namespace: "http://example.org/ontology#"
+
+# Language tag for labels and comments
+language: "en"
+
+# Automatically generate rdfs:label from entity names
+generate_labels: true
+
+# Convert camelCase names to readable labels
+# e.g., 'floorArea' -> 'floor area'
+camel_to_label: true
+
+# Generate inverse properties for object properties
+generate_inverse_properties: false
+
+# Map PlantUML packages to RDF namespaces
+namespace_mappings:
+  - package: "building"
+    namespace_uri: "http://example.org/building#"
+    prefix: "bld"
+  # - package: "core"
+  #   namespace_uri: "http://example.org/core#"
+  #   prefix: "core"
+
+# Custom datatype mappings (PlantUML type -> XSD type)
+datatype_mappings:
+  Money: "xsd:decimal"
+  Percentage: "xsd:decimal"
+  Identifier: "xsd:string"
+  # Add custom types as needed
+
+# Preferred prefix ordering in output
+prefix_order:
+  - ""      # Default namespace first
+  - "owl"
+  - "rdfs"
+  - "xsd"
+
+# URIs to include as owl:imports
+ontology_imports: []
+  # - "http://example.org/core"
+
+# Annotation properties to preserve from notes
+annotation_properties: []
+  # - "dcterms:description"
+  # - "skos:definition"
+'''

--- a/src/rdf_construct/puml2rdf/converter.py
+++ b/src/rdf_construct/puml2rdf/converter.py
@@ -1,0 +1,420 @@
+"""Convert parsed PlantUML models to RDF graphs.
+
+This module transforms the intermediate PumlModel representation
+into a proper RDF/OWL ontology using rdflib.
+"""
+
+import re
+from dataclasses import dataclass, field
+from typing import Optional
+
+from rdflib import Graph, Literal, Namespace, URIRef, RDF, RDFS
+from rdflib.namespace import OWL, XSD
+
+from rdf_construct.puml2rdf.model import (
+    PumlAttribute,
+    PumlClass,
+    PumlModel,
+    PumlPackage,
+    PumlRelationship,
+    RelationshipType,
+)
+
+
+# Standard XSD datatype mappings from common PlantUML/UML type names
+XSD_TYPE_MAP: dict[str, URIRef] = {
+    # String types
+    "string": XSD.string,
+    "str": XSD.string,
+    "text": XSD.string,
+    # Numeric types
+    "integer": XSD.integer,
+    "int": XSD.integer,
+    "decimal": XSD.decimal,
+    "float": XSD.float,
+    "double": XSD.double,
+    "number": XSD.decimal,
+    # Boolean
+    "boolean": XSD.boolean,
+    "bool": XSD.boolean,
+    # Date/time types
+    "date": XSD.date,
+    "datetime": XSD.dateTime,
+    "time": XSD.time,
+    "gYear": XSD.gYear,
+    "gyear": XSD.gYear,
+    "gYearMonth": XSD.gYearMonth,
+    "duration": XSD.duration,
+    # URI types
+    "uri": XSD.anyURI,
+    "anyURI": XSD.anyURI,
+    "anyuri": XSD.anyURI,
+    "url": XSD.anyURI,
+    # Other common types
+    "base64": XSD.base64Binary,
+    "hexBinary": XSD.hexBinary,
+    "language": XSD.language,
+    "token": XSD.token,
+}
+
+
+@dataclass
+class ConversionConfig:
+    """Configuration options for PlantUML to RDF conversion.
+
+    Attributes:
+        default_namespace: Default namespace URI for entities without explicit package
+        language: Language tag for labels and comments (default: 'en')
+        generate_labels: Whether to generate rdfs:label from names
+        generate_inverse_properties: Whether to create inverse properties
+        camel_to_label: Convert camelCase names to readable labels
+        use_owl_thing: Whether to make classes subclass of owl:Thing explicitly
+    """
+
+    default_namespace: str = "http://example.org/ontology#"
+    language: str = "en"
+    generate_labels: bool = True
+    generate_inverse_properties: bool = False
+    camel_to_label: bool = True
+    use_owl_thing: bool = False
+
+
+@dataclass
+class ConversionResult:
+    """Result of converting a PlantUML model to RDF.
+
+    Attributes:
+        graph: The generated RDF graph
+        class_uris: Mapping from class names to their URIs
+        property_uris: Mapping from property names to their URIs
+        warnings: Any warnings generated during conversion
+    """
+
+    graph: Graph
+    class_uris: dict[str, URIRef] = field(default_factory=dict)
+    property_uris: dict[str, URIRef] = field(default_factory=dict)
+    warnings: list[str] = field(default_factory=list)
+
+
+class PumlToRdfConverter:
+    """Converts parsed PlantUML models to RDF/OWL ontologies.
+
+    This converter produces OWL 2 ontologies following common patterns:
+    - Classes become owl:Class
+    - Attributes become owl:DatatypeProperty
+    - Associations become owl:ObjectProperty
+    - Inheritance becomes rdfs:subClassOf
+    - Notes become rdfs:comment
+
+    Example:
+        converter = PumlToRdfConverter()
+        result = converter.convert(model)
+        result.graph.serialize("ontology.ttl", format="turtle")
+    """
+
+    def __init__(self, config: Optional[ConversionConfig] = None) -> None:
+        """Initialise the converter.
+
+        Args:
+            config: Conversion configuration options
+        """
+        self.config = config or ConversionConfig()
+        self._graph: Graph = Graph()
+        self._namespaces: dict[str, Namespace] = {}
+        self._class_uris: dict[str, URIRef] = {}
+        self._property_uris: dict[str, URIRef] = {}
+        self._warnings: list[str] = []
+
+    def convert(self, model: PumlModel) -> ConversionResult:
+        """Convert a PlantUML model to an RDF graph."""
+        self._graph = Graph()
+        self._namespaces = {}
+        self._class_uris = {}
+        self._property_uris = {}
+        self._warnings = []
+
+        # Set up namespaces from packages AND class prefixes
+        self._setup_namespaces(model.packages, model.classes)
+
+        # Create ontology header
+        self._create_ontology_header(model)
+
+        # Convert classes
+        for cls in model.classes:
+            self._convert_class(cls)
+
+        # Convert relationships
+        for rel in model.relationships:
+            self._convert_relationship(rel)
+
+        return ConversionResult(
+            graph=self._graph,
+            class_uris=self._class_uris,
+            property_uris=self._property_uris,
+            warnings=self._warnings,
+        )
+
+    def _setup_namespaces(self, packages: list[PumlPackage], classes: list[PumlClass]) -> None:
+        """Set up RDF namespaces from PlantUML packages and class prefixes."""
+        # Standard namespaces
+        self._graph.bind("owl", OWL)
+        self._graph.bind("rdfs", RDFS)
+        self._graph.bind("xsd", XSD)
+
+        # Default namespace
+        default_ns = Namespace(self.config.default_namespace)
+        self._namespaces[None] = default_ns  # None key for unpackaged classes
+        self._graph.bind("", default_ns)
+
+        # Collect all unique package prefixes from classes
+        prefixes = {cls.package for cls in classes if cls.package}
+
+        # Also add packages from PlantUML package declarations
+        for pkg in packages:
+            if pkg.namespace_uri:
+                ns_uri = pkg.namespace_uri
+                if not ns_uri.endswith(("#", "/")):
+                    ns_uri += "#"
+                ns = Namespace(ns_uri)
+                self._namespaces[pkg.name] = ns
+                self._graph.bind(pkg.name, ns)
+                prefixes.discard(pkg.name)  # Don't auto-generate
+
+        # Auto-generate namespaces for remaining prefixes
+        base = self.config.default_namespace.rstrip("#/")
+        for prefix in prefixes:
+            ns_uri = f"{base}/{prefix}#"
+            ns = Namespace(ns_uri)
+            self._namespaces[prefix] = ns
+            self._graph.bind(prefix, ns)
+
+    def _generate_prefix(self, name: str) -> str:
+        """Generate a namespace prefix from a package name.
+
+        Args:
+            name: Package name (may be a URI or display name)
+
+        Returns:
+            Short lowercase prefix string
+        """
+        # If it looks like a URI, extract the last segment
+        if "://" in name or name.startswith("http"):
+            # Extract meaningful part from URI
+            name = name.rstrip("#/")
+            if "/" in name:
+                name = name.rsplit("/", 1)[-1]
+            if "#" in name:
+                name = name.rsplit("#", 1)[-1]
+
+        # Clean and shorten
+        prefix = re.sub(r"[^a-zA-Z0-9]", "", name).lower()
+        return prefix[:10] if len(prefix) > 10 else prefix or "ns"
+
+    def _create_ontology_header(self, model: PumlModel) -> None:
+        """Create the owl:Ontology declaration."""
+        ont_uri = URIRef(self.config.default_namespace.rstrip("#/"))
+
+        self._graph.add((ont_uri, RDF.type, OWL.Ontology))
+
+        if model.title:
+            self._graph.add(
+                (ont_uri, RDFS.label, Literal(model.title, lang=self.config.language))
+            )
+
+    def _convert_class(self, cls: PumlClass) -> None:
+        """Convert a PlantUML class to owl:Class and properties."""
+        ns = self._get_namespace_for_class(cls)
+        class_uri = ns[cls.name]  # Use local name only
+
+        # Store by qualified name for relationship lookups
+        self._class_uris[cls.name] = class_uri
+        self._class_uris[cls.qualified_name] = class_uri
+
+        self._graph.add((class_uri, RDF.type, OWL.Class))
+
+        # Use display_name for label if available, else convert local name
+        if self.config.generate_labels:
+            if cls.display_name:
+                label = cls.display_name
+            elif self.config.camel_to_label:
+                label = self._camel_to_label(cls.name)
+            else:
+                label = cls.name
+            self._graph.add(
+                (class_uri, RDFS.label, Literal(label, lang=self.config.language))
+            )
+
+        # Add comment from note
+        if cls.note:
+            self._graph.add(
+                (class_uri, RDFS.comment, Literal(cls.note, lang=self.config.language))
+            )
+
+        # Handle abstract classes - add deprecated or custom annotation
+        if cls.is_abstract:
+            # We could add a custom annotation here
+            pass
+
+        # Convert attributes to datatype properties
+        for attr in cls.attributes:
+            self._convert_attribute(attr, class_uri, ns)
+
+    def _convert_attribute(
+        self, attr: PumlAttribute, domain_class: URIRef, ns: Namespace
+    ) -> None:
+        """Convert a class attribute to owl:DatatypeProperty."""
+        prop_uri = ns[attr.name]
+        self._property_uris[attr.name] = prop_uri
+
+        # Add property declaration
+        self._graph.add((prop_uri, RDF.type, OWL.DatatypeProperty))
+
+        # Add domain
+        self._graph.add((prop_uri, RDFS.domain, domain_class))
+
+        # Add range if datatype specified
+        if attr.datatype:
+            xsd_type = self._map_datatype(attr.datatype)
+            self._graph.add((prop_uri, RDFS.range, xsd_type))
+
+        # Add label
+        if self.config.generate_labels:
+            label = self._camel_to_label(attr.name) if self.config.camel_to_label else attr.name
+            self._graph.add(
+                (prop_uri, RDFS.label, Literal(label, lang=self.config.language))
+            )
+
+    def _convert_relationship(self, rel: PumlRelationship) -> None:
+        """Convert a PlantUML relationship to RDF."""
+        # Get class URIs
+        source_uri = self._class_uris.get(rel.source)
+        target_uri = self._class_uris.get(rel.target)
+
+        if not source_uri:
+            self._warnings.append(f"Unknown source class in relationship: {rel.source}")
+            return
+        if not target_uri:
+            self._warnings.append(f"Unknown target class in relationship: {rel.target}")
+            return
+
+        if rel.rel_type == RelationshipType.INHERITANCE:
+            # Source is subclass of target
+            self._graph.add((source_uri, RDFS.subClassOf, target_uri))
+        else:
+            # Create object property for associations
+            self._convert_association(rel, source_uri, target_uri)
+
+    def _convert_association(
+        self, rel: PumlRelationship, source_uri: URIRef, target_uri: URIRef
+    ) -> None:
+        """Convert an association to owl:ObjectProperty."""
+        # Generate property name from label or classes
+        if rel.label:
+            prop_name = self._label_to_property_name(rel.label)
+        else:
+            # Generate name from class names
+            target_name = rel.target
+            prop_name = f"has{target_name}"
+
+        # Get namespace from source class
+        ns = self._get_namespace_for_class_uri(source_uri)
+
+        prop_uri = ns[prop_name]
+        self._property_uris[prop_name] = prop_uri
+
+        # Add property declaration
+        self._graph.add((prop_uri, RDF.type, OWL.ObjectProperty))
+
+        # Add domain and range
+        self._graph.add((prop_uri, RDFS.domain, source_uri))
+        self._graph.add((prop_uri, RDFS.range, target_uri))
+
+        # Add label
+        if self.config.generate_labels:
+            label = rel.label or self._camel_to_label(prop_name)
+            self._graph.add(
+                (prop_uri, RDFS.label, Literal(label, lang=self.config.language))
+            )
+
+        # Add cardinality constraints as comments for now
+        # Full OWL restrictions would be more complex
+        if rel.source_cardinality or rel.target_cardinality:
+            card_note = f"Cardinality: {rel.source_cardinality or '*'} -> {rel.target_cardinality or '*'}"
+            # Could add as annotation or restriction
+
+    def _get_namespace_for_class(self, cls: PumlClass) -> Namespace:
+        """Get the appropriate namespace for a class."""
+        if cls.package and cls.package in self._namespaces:
+            return self._namespaces[cls.package]
+        return self._namespaces[None]
+
+    def _get_namespace_for_class_uri(self, class_uri: URIRef) -> Namespace:
+        """Get the namespace containing a class URI."""
+        uri_str = str(class_uri)
+        for ns in self._namespaces.values():
+            if uri_str.startswith(str(ns)):
+                return ns
+        return self._namespaces["default"]
+
+    def _map_datatype(self, type_name: str) -> URIRef:
+        """Map a PlantUML type name to XSD datatype."""
+        normalised = type_name.lower().strip()
+
+        if normalised in XSD_TYPE_MAP:
+            return XSD_TYPE_MAP[normalised]
+
+        # Check for qualified XSD types
+        if type_name.startswith("xsd:"):
+            local = type_name[4:]
+            return XSD[local]
+
+        # Default to string
+        self._warnings.append(f"Unknown datatype '{type_name}', defaulting to xsd:string")
+        return XSD.string
+
+    def _camel_to_label(self, name: str) -> str:
+        """Convert camelCase or PascalCase to readable label.
+
+        Examples:
+            'FloorArea' -> 'floor area'
+            'hasBuilding' -> 'has building'
+            'constructionYear' -> 'construction year'
+        """
+        # Insert space before uppercase letters
+        result = re.sub(r"([a-z])([A-Z])", r"\1 \2", name)
+        # Insert space between consecutive uppercase and following lowercase
+        result = re.sub(r"([A-Z]+)([A-Z][a-z])", r"\1 \2", result)
+        return result.lower()
+
+    def _label_to_property_name(self, label: str) -> str:
+        """Convert a relationship label to a valid property name.
+
+        If the label is already a valid identifier (no spaces), preserve it.
+        Otherwise, convert multi-word labels to camelCase.
+
+        Examples:
+            'hasFloor' -> 'hasFloor' (preserved)
+            'has floor' -> 'hasFloor' (converted)
+            'is located in' -> 'isLocatedIn'
+        """
+        label = label.strip()
+
+        # If no spaces, assume it's already a valid property name - preserve case
+        if " " not in label:
+            # Just remove non-alphanumeric characters
+            return re.sub(r"[^a-zA-Z0-9]", "", label)
+
+        # Multi-word: convert to camelCase
+        words = label.split()
+        if not words:
+            return "property"
+
+        # First word lowercase, rest capitalised
+        result = words[0].lower()
+        for word in words[1:]:
+            result += word.capitalize()
+
+        # Remove non-alphanumeric characters
+        result = re.sub(r"[^a-zA-Z0-9]", "", result)
+
+        return result

--- a/src/rdf_construct/puml2rdf/merger.py
+++ b/src/rdf_construct/puml2rdf/merger.py
@@ -1,0 +1,200 @@
+"""Merge generated RDF with existing ontologies.
+
+This module provides functionality to merge newly generated RDF
+from PlantUML with existing ontology files, preserving manually
+added content while updating what's defined in the diagram.
+"""
+
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Optional
+
+from rdflib import Graph, Namespace, URIRef, RDF, RDFS
+from rdflib.namespace import OWL
+
+
+@dataclass
+class MergeResult:
+    """Result of merging two graphs.
+
+    Attributes:
+        graph: The merged graph
+        added_count: Number of triples added from new graph
+        updated_count: Number of triples updated (replaced)
+        preserved_count: Number of triples preserved from existing
+        conflicts: List of conflict descriptions
+    """
+
+    graph: Graph
+    added_count: int = 0
+    updated_count: int = 0
+    preserved_count: int = 0
+    conflicts: list[str] = None
+
+    def __post_init__(self):
+        if self.conflicts is None:
+            self.conflicts = []
+
+
+class OntologyMerger:
+    """Merges generated RDF with existing ontology content.
+
+    The merger follows these principles:
+    1. Entities defined in PlantUML are authoritative - their
+       rdfs:subClassOf, domain, range etc. are updated
+    2. Additional annotations (comments, labels) in the existing
+       file are preserved if not explicitly defined in PlantUML
+    3. Entities only in the existing file are preserved
+    4. Conflicts are reported but existing content wins by default
+
+    Example:
+        merger = OntologyMerger()
+        result = merger.merge(new_graph, existing_path)
+        result.graph.serialize("merged.ttl", format="turtle")
+    """
+
+    # Predicates that PlantUML defines authoritatively
+    AUTHORITATIVE_PREDICATES = {
+        RDF.type,
+        RDFS.subClassOf,
+        RDFS.domain,
+        RDFS.range,
+        RDFS.subPropertyOf,
+    }
+
+    # Predicates to merge (keep both if different)
+    MERGEABLE_PREDICATES = {
+        RDFS.label,
+        RDFS.comment,
+        RDFS.seeAlso,
+    }
+
+    def __init__(self, preserve_existing: bool = True) -> None:
+        """Initialise the merger.
+
+        Args:
+            preserve_existing: If True, existing content wins on conflict
+        """
+        self.preserve_existing = preserve_existing
+
+    def merge(
+        self,
+        new_graph: Graph,
+        existing_path: Path,
+        output_format: str = "turtle",
+    ) -> MergeResult:
+        """Merge new graph with existing ontology file.
+
+        Args:
+            new_graph: Newly generated RDF graph
+            existing_path: Path to existing ontology file
+            output_format: RDF format for parsing existing file
+
+        Returns:
+            MergeResult with merged graph and statistics
+        """
+        # Load existing graph
+        existing = Graph()
+        existing.parse(str(existing_path), format=output_format)
+
+        return self.merge_graphs(new_graph, existing)
+
+    def merge_graphs(
+        self,
+        new_graph: Graph,
+        existing: Graph,
+    ) -> MergeResult:
+        """Merge two graphs.
+
+        Args:
+            new_graph: Newly generated RDF graph
+            existing: Existing ontology graph
+
+        Returns:
+            MergeResult with merged graph and statistics
+        """
+        result = MergeResult(graph=Graph())
+        conflicts = []
+
+        # Copy all prefixes from both
+        for prefix, ns in existing.namespace_manager.namespaces():
+            result.graph.bind(prefix, ns, override=False)
+        for prefix, ns in new_graph.namespace_manager.namespaces():
+            result.graph.bind(prefix, ns, override=False)
+
+        # Get all subjects defined in new graph
+        new_subjects = set(new_graph.subjects())
+
+        # Process existing triples
+        for s, p, o in existing:
+            if s in new_subjects:
+                # Subject is also in new graph - check for conflicts
+                if p in self.AUTHORITATIVE_PREDICATES:
+                    # New graph is authoritative for these
+                    new_values = set(new_graph.objects(s, p))
+                    if new_values:
+                        # Will be added from new graph
+                        result.updated_count += 1
+                        continue
+                    else:
+                        # Keep existing if not in new
+                        result.graph.add((s, p, o))
+                        result.preserved_count += 1
+                elif p in self.MERGEABLE_PREDICATES:
+                    # Keep existing and add new if different
+                    result.graph.add((s, p, o))
+                    result.preserved_count += 1
+                else:
+                    # Other predicates - preserve existing
+                    result.graph.add((s, p, o))
+                    result.preserved_count += 1
+            else:
+                # Subject only in existing - preserve
+                result.graph.add((s, p, o))
+                result.preserved_count += 1
+
+        # Add triples from new graph
+        for s, p, o in new_graph:
+            if (s, p, o) not in result.graph:
+                # Check for conflicting values on authoritative predicates
+                if p in self.AUTHORITATIVE_PREDICATES:
+                    existing_values = list(result.graph.objects(s, p))
+                    for ev in existing_values:
+                        if ev != o:
+                            conflicts.append(
+                                f"Conflict on {s} {p}: existing={ev}, new={o}"
+                            )
+                            if not self.preserve_existing:
+                                result.graph.remove((s, p, ev))
+
+                result.graph.add((s, p, o))
+                result.added_count += 1
+
+        result.conflicts = conflicts
+        return result
+
+
+def merge_with_existing(
+    new_graph: Graph,
+    existing_path: Path,
+    output_path: Optional[Path] = None,
+    output_format: str = "turtle",
+) -> MergeResult:
+    """Convenience function to merge and optionally save.
+
+    Args:
+        new_graph: Newly generated RDF graph
+        existing_path: Path to existing ontology
+        output_path: Path to write merged result (optional)
+        output_format: RDF serialization format
+
+    Returns:
+        MergeResult with merged graph and statistics
+    """
+    merger = OntologyMerger()
+    result = merger.merge(new_graph, existing_path, output_format)
+
+    if output_path:
+        result.graph.serialize(str(output_path), format=output_format)
+
+    return result

--- a/src/rdf_construct/puml2rdf/model.py
+++ b/src/rdf_construct/puml2rdf/model.py
@@ -1,0 +1,202 @@
+"""Intermediate representation for parsed PlantUML diagrams.
+
+This module defines dataclasses that represent PlantUML elements in a
+structured form, acting as an intermediate representation between the
+raw PlantUML text and the generated RDF graph.
+"""
+
+from dataclasses import dataclass, field
+from enum import Enum
+from typing import Optional
+
+
+class RelationshipType(Enum):
+    """Types of relationships that can be represented in PlantUML."""
+
+    INHERITANCE = "inheritance"  # --|> or <|--
+    ASSOCIATION = "association"  # --> or --
+    AGGREGATION = "aggregation"  # o-- or --o
+    COMPOSITION = "composition"  # *-- or --*
+
+
+class PropertyKind(Enum):
+    """Kind of property to generate in RDF."""
+
+    DATATYPE = "datatype"  # owl:DatatypeProperty
+    OBJECT = "object"  # owl:ObjectProperty
+    ANNOTATION = "annotation"  # owl:AnnotationProperty
+
+
+@dataclass
+class PumlAttribute:
+    """An attribute within a PlantUML class.
+
+    Attributes represent datatype properties in the generated ontology.
+
+    Attributes:
+        name: Attribute name (e.g., 'floorArea')
+        datatype: XSD datatype string (e.g., 'decimal', 'string')
+        visibility: UML visibility marker (+, -, #, ~)
+        is_static: Whether marked as static (underlined)
+    """
+
+    name: str
+    datatype: Optional[str] = None
+    visibility: str = "+"
+    is_static: bool = False
+
+
+@dataclass
+class PumlClass:
+    """A class definition from PlantUML."""
+
+    name: str  # Local name only (e.g., "Building")
+    package: Optional[str] = None  # Namespace prefix (e.g., "building")
+    stereotype: Optional[str] = None
+    attributes: list[PumlAttribute] = field(default_factory=list)
+    note: Optional[str] = None
+    is_abstract: bool = False
+    display_name: Optional[str] = None  # NEW: From "Display Name" as alias syntax
+
+    @property
+    def qualified_name(self) -> str:
+        """Return the fully qualified name including package."""
+        if self.package:
+            return f"{self.package}.{self.name}"
+        return self.name
+
+
+@dataclass
+class PumlRelationship:
+    """A relationship between two classes in PlantUML.
+
+    Depending on the type, this generates different RDF constructs:
+    - INHERITANCE -> rdfs:subClassOf
+    - ASSOCIATION -> owl:ObjectProperty
+    - AGGREGATION/COMPOSITION -> owl:ObjectProperty with semantics note
+
+    Attributes:
+        source: Source class name
+        target: Target class name
+        rel_type: Type of relationship
+        label: Relationship label (becomes property name)
+        source_cardinality: Cardinality at source end (e.g., '1', '*', '0..1')
+        target_cardinality: Cardinality at target end
+        note: Attached note for the relationship
+    """
+
+    source: str
+    target: str
+    rel_type: RelationshipType
+    label: Optional[str] = None
+    source_cardinality: Optional[str] = None
+    target_cardinality: Optional[str] = None
+    note: Optional[str] = None
+
+
+@dataclass
+class PumlPackage:
+    """A package definition from PlantUML.
+
+    Packages map to RDF namespaces in the generated ontology.
+
+    Attributes:
+        name: Display name of the package
+        namespace_uri: The URI to use as the namespace (from 'as' clause)
+        stereotype: Package stereotype (if any)
+    """
+
+    name: str
+    namespace_uri: Optional[str] = None
+    stereotype: Optional[str] = None
+
+
+@dataclass
+class PumlNote:
+    """A standalone note in PlantUML.
+
+    Notes attached to classes become rdfs:comment.
+    Standalone notes may be used for ontology metadata.
+
+    Attributes:
+        content: The note text
+        attached_to: Name of class this note is attached to (if any)
+        position: Position relative to attached element
+    """
+
+    content: str
+    attached_to: Optional[str] = None
+    position: Optional[str] = None
+
+
+@dataclass
+class PumlModel:
+    """Complete parsed PlantUML model.
+
+    This is the top-level container for all parsed elements,
+    ready for conversion to RDF.
+
+    Attributes:
+        classes: All parsed classes
+        relationships: All parsed relationships
+        packages: All parsed packages
+        notes: All standalone notes
+        title: Diagram title (becomes ontology label)
+        skin_params: PlantUML skinparam settings (preserved for round-trip)
+    """
+
+    classes: list[PumlClass] = field(default_factory=list)
+    relationships: list[PumlRelationship] = field(default_factory=list)
+    packages: list[PumlPackage] = field(default_factory=list)
+    notes: list[PumlNote] = field(default_factory=list)
+    title: Optional[str] = None
+    skin_params: dict[str, str] = field(default_factory=dict)
+
+    def get_class(self, name: str) -> Optional[PumlClass]:
+        """Find a class by name (local or qualified).
+
+        Args:
+            name: Class name - can be "Building" or "building.Building"
+
+        Returns:
+            The PumlClass if found, None otherwise
+        """
+        for cls in self.classes:
+            # Match by local name
+            if cls.name == name:
+                return cls
+            # Match by qualified name
+            if cls.qualified_name == name:
+                return cls
+        return None
+
+    def get_package(self, name: str) -> Optional[PumlPackage]:
+        """Find a package by name or URI.
+
+        Args:
+            name: Package name or namespace URI
+
+        Returns:
+            The PumlPackage if found, None otherwise
+        """
+        for pkg in self.packages:
+            if pkg.name == name or pkg.namespace_uri == name:
+                return pkg
+        return None
+
+    def inheritance_relationships(self) -> list[PumlRelationship]:
+        """Return only inheritance relationships (rdfs:subClassOf)."""
+        return [r for r in self.relationships if r.rel_type == RelationshipType.INHERITANCE]
+
+    def property_relationships(self) -> list[PumlRelationship]:
+        """Return relationships that become object properties."""
+        return [
+            r
+            for r in self.relationships
+            if r.rel_type
+            in (
+                RelationshipType.ASSOCIATION,
+                RelationshipType.AGGREGATION,
+                RelationshipType.COMPOSITION,
+            )
+        ]

--- a/src/rdf_construct/puml2rdf/parser.py
+++ b/src/rdf_construct/puml2rdf/parser.py
@@ -1,0 +1,565 @@
+"""PlantUML parser for class diagram syntax.
+
+This module provides regex-based parsing of PlantUML class diagrams,
+extracting classes, relationships, packages, and notes into an
+intermediate model representation.
+
+The parser uses a multi-pass approach:
+1. Extract packages and set up namespaces
+2. Extract classes with attributes
+3. Extract relationships
+4. Attach notes to entities
+"""
+
+import re
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Optional
+
+from rdf_construct.puml2rdf.model import (
+    PumlAttribute,
+    PumlClass,
+    PumlModel,
+    PumlNote,
+    PumlPackage,
+    PumlRelationship,
+    RelationshipType,
+)
+
+
+def parse_dotted_name(dotted: str) -> tuple[Optional[str], str]:
+    """Split a dotted name into package and local name.
+
+    Examples:
+        "building.Building" -> ("building", "Building")
+        "ies.ArtificialFeature" -> ("ies", "ArtificialFeature")
+        "Building" -> (None, "Building")
+    """
+    if "." in dotted:
+        parts = dotted.rsplit(".", 1)  # Split on last dot
+        return (parts[0], parts[1])
+    return (None, dotted)
+
+
+@dataclass
+class ParseError:
+    """An error encountered during parsing.
+
+    Attributes:
+        line_number: Line where the error occurred
+        message: Description of the error
+        line_content: The actual line content
+    """
+
+    line_number: int
+    message: str
+    line_content: str
+
+
+@dataclass
+class ParseResult:
+    """Result of parsing a PlantUML file.
+
+    Attributes:
+        model: The parsed model (may be partial if errors occurred)
+        errors: List of parse errors encountered
+        warnings: List of non-fatal warnings
+    """
+
+    model: PumlModel
+    errors: list[ParseError]
+    warnings: list[str]
+
+    @property
+    def success(self) -> bool:
+        """Return True if parsing completed without errors."""
+        return len(self.errors) == 0
+
+
+class PlantUMLParser:
+    """Parser for PlantUML class diagram syntax.
+
+    Parses PlantUML text and produces a PumlModel containing all
+    extracted entities ready for RDF conversion.
+
+    Example:
+        parser = PlantUMLParser()
+        result = parser.parse('''
+            @startuml
+            class Building {
+                floorArea : decimal
+            }
+            @enduml
+        ''')
+        if result.success:
+            model = result.model
+    """
+
+    # ==========================================================================
+    # Regex patterns for PlantUML syntax elements
+    # ==========================================================================
+
+    # Package: package "Name" as ns { ... } or package Name { ... }
+    PACKAGE_PATTERN = re.compile(
+        r'package\s+(?:"([^"]+)"|(\S+))'  # Package name (quoted or unquoted)
+        r'(?:\s+as\s+(\S+))?'  # Optional 'as namespace'
+        r'(?:\s*<<(\w+)>>)?'  # Optional stereotype
+        r'\s*\{',  # Opening brace
+        re.MULTILINE,
+    )
+
+    # Class declaration: class Name <<stereotype>> { ... } or class "Name" { ... }
+    CLASS_PATTERN = re.compile(
+        r'(?:^|\n)\s*'
+        r'(abstract\s+)?'  # Group 1: Optional abstract keyword
+        r'class\s+'
+        r'(?:'
+        r'"([^"]+)"\s+as\s+([\w.]+)'  # Groups 2,3: "Display Name" as alias
+        r'|'
+        r'"([^"]+)"'  # Group 4: Just "Quoted Name"
+        r'|'
+        r'([\w.]+)'  # Group 5: Unquoted name (may include dots)
+        r')'
+        r'(?:\s*<<(\w+)>>)?'  # Group 6: Optional stereotype
+        r'(?:\s*#[^\s{]*)?'  # Optional styling - ignore
+        r'[ \t]*(?:\{([^}]*)\})?',  # Group 7: Optional body
+        re.MULTILINE | re.DOTALL,
+    )
+
+    # Attribute: visibility name : type
+    ATTRIBUTE_PATTERN = re.compile(
+        r'^\s*'
+        r'([+\-#~])?\s*'  # Optional visibility
+        r'(\{static\})?\s*'  # Optional static marker
+        r'(\w+)'  # Attribute name
+        r'(?:\s*:\s*(\w+))?'  # Optional : type
+        r'\s*$',
+        re.MULTILINE,
+    )
+
+    # Relationships - various arrow styles
+    # A --|> B (inheritance)
+    # A --> B : label (association)
+    # A "1" --> "*" B : label (with cardinalities)
+    # A o-- B (aggregation)
+    # A *-- B (composition)
+    RELATIONSHIP_PATTERN = re.compile(
+        r'(?:^|\n)\s*'
+        r'(?:"([^"]+)"|(\w+))'  # Source class (quoted or not)
+        r'\s*'
+        r'(?:"([^"]*)")?\s*'  # Optional source cardinality
+        r'([o*])?'  # Optional aggregation/composition marker at source
+        r'(--?|\.\.)'  # Line style (-- or ..)
+        r'([|>o*])?'  # Arrow head or aggregation marker at target
+        r'\s*'
+        r'(?:"([^"]*)")?\s*'  # Optional target cardinality
+        r'(?:"([^"]+)"|(\w+))'  # Target class (quoted or not)
+        r'(?:\s*:\s*([^\n]+))?',  # Optional label
+        re.MULTILINE,
+    )
+
+    # Note attached to element: note right of Class : text
+    NOTE_ATTACHED_PATTERN = re.compile(
+        r'note\s+(right|left|top|bottom)\s+of\s+(\w+)\s*'
+        r'(?::\s*([^\n]+))?'  # Single line note
+        r'|'
+        r'note\s+(right|left|top|bottom)\s+of\s+(\w+)\s*\n'
+        r'(.*?)'  # Multi-line content
+        r'\s*end\s*note',
+        re.MULTILINE | re.DOTALL,
+    )
+
+    # Standalone note block: note "text" as N1
+    NOTE_STANDALONE_PATTERN = re.compile(
+        r'note\s+"([^"]+)"\s+as\s+(\w+)', re.MULTILINE
+    )
+
+    # Diagram title
+    TITLE_PATTERN = re.compile(r'title\s+(.+?)(?:\n|$)', re.MULTILINE)
+
+    # Skinparam settings
+    SKINPARAM_PATTERN = re.compile(
+        r'skinparam\s+(\w+)\s+(\S+)', re.MULTILINE
+    )
+
+    def __init__(self) -> None:
+        """Initialise the parser."""
+        self._errors: list[ParseError] = []
+        self._warnings: list[str] = []
+        self._current_package: Optional[str] = None
+        self._package_stack: list[str] = []
+
+    def parse(self, content: str) -> ParseResult:
+        """Parse PlantUML content into a model.
+
+        Args:
+            content: PlantUML diagram text
+
+        Returns:
+            ParseResult containing the model and any errors/warnings
+        """
+        self._errors = []
+        self._warnings = []
+
+        model = PumlModel()
+
+        # Strip @startuml / @enduml
+        content = self._strip_diagram_markers(content)
+
+        # Pass 1: Extract packages and namespaces
+        model.packages = self._parse_packages(content)
+
+        # Pass 2: Extract classes with attributes
+        model.classes = self._parse_classes(content)
+
+        # Pass 3: Extract relationships
+        model.relationships = self._parse_relationships(content)
+
+        # Pass 4: Extract and attach notes
+        notes = self._parse_notes(content)
+        self._attach_notes(model, notes)
+        model.notes = [n for n in notes if n.attached_to is None]
+
+        # Extract title
+        model.title = self._parse_title(content)
+
+        # Extract skinparams
+        model.skin_params = self._parse_skinparams(content)
+
+        return ParseResult(model=model, errors=self._errors, warnings=self._warnings)
+
+    def parse_file(self, path: Path) -> ParseResult:
+        """Parse a PlantUML file.
+
+        Args:
+            path: Path to the .puml file
+
+        Returns:
+            ParseResult containing the model and any errors/warnings
+        """
+        content = path.read_text(encoding="utf-8")
+        return self.parse(content)
+
+    def _strip_diagram_markers(self, content: str) -> str:
+        """Remove @startuml and @enduml markers."""
+        # Remove @startuml (with optional name)
+        content = re.sub(r'@startuml\s*(?:\([^)]*\))?\s*\n?', '', content)
+        # Remove @enduml
+        content = re.sub(r'@enduml\s*', '', content)
+        return content
+
+    def _parse_packages(self, content: str) -> list[PumlPackage]:
+        """Extract package definitions from content."""
+        packages = []
+
+        for match in self.PACKAGE_PATTERN.finditer(content):
+            name = match.group(1) or match.group(2)  # Quoted or unquoted
+            namespace_uri = match.group(3)  # From 'as' clause
+            stereotype = match.group(4)
+
+            # If namespace looks like a URI, use it; otherwise treat as prefix
+            if namespace_uri and not namespace_uri.startswith("http"):
+                # It's a prefix alias like 'bld', not a full URI
+                namespace_uri = None
+
+            packages.append(
+                PumlPackage(
+                    name=name,
+                    namespace_uri=namespace_uri,
+                    stereotype=stereotype,
+                )
+            )
+
+        return packages
+
+    def _parse_classes(self, content: str) -> list[PumlClass]:
+        """Extract class definitions from content."""
+        classes = []
+        package_map = self._build_package_map(content)
+
+        for match in self.CLASS_PATTERN.finditer(content):
+            is_abstract = match.group(1) is not None
+            display_name = None
+
+            if match.group(3):  # "Display Name" as alias pattern
+                display_name = match.group(2)  # "Building"
+                alias = match.group(3)  # "building.Building"
+                package, name = parse_dotted_name(alias)
+            elif match.group(4):  # Just "Quoted Name"
+                package, name = None, match.group(4)
+            else:  # Unquoted name (group 5), may be dotted
+                package, name = parse_dotted_name(match.group(5))
+
+            stereotype = match.group(6)
+            body = match.group(7) or ""
+
+            # Parse attributes from body
+            attributes = self._parse_attributes(body)
+
+            # Package from dotted name takes precedence over positional package
+            if package is None:
+                pos = match.start()
+                package = self._find_package_at_position(pos, package_map)
+
+            classes.append(
+                PumlClass(
+                    name=name,
+                    package=package,
+                    stereotype=stereotype,
+                    attributes=attributes,
+                    is_abstract=is_abstract or stereotype == "abstract",
+                    display_name=display_name,
+                )
+            )
+
+        return classes
+
+    def _parse_attributes(self, body: str) -> list[PumlAttribute]:
+        """Extract attributes from a class body."""
+        attributes = []
+
+        for line in body.strip().split("\n"):
+            line = line.strip()
+            if not line or line.startswith("--"):
+                continue  # Skip separators
+
+            match = self.ATTRIBUTE_PATTERN.match(line)
+            if match:
+                visibility = match.group(1) or "+"
+                is_static = match.group(2) is not None
+                name = match.group(3)
+                datatype = match.group(4)
+
+                attributes.append(
+                    PumlAttribute(
+                        name=name,
+                        datatype=datatype,
+                        visibility=visibility,
+                        is_static=is_static,
+                    )
+                )
+            else:
+                # Try simpler pattern: just "name" or "name : type"
+                simple_match = re.match(r'(\w+)(?:\s*:\s*(\w+))?', line)
+                if simple_match:
+                    attributes.append(
+                        PumlAttribute(
+                            name=simple_match.group(1),
+                            datatype=simple_match.group(2),
+                        )
+                    )
+
+        return attributes
+
+    def _parse_relationships(self, content: str) -> list[PumlRelationship]:
+        """Extract relationship definitions from content."""
+        relationships = []
+
+        # Pattern for inheritance with direction hints
+        inheritance_pattern = re.compile(
+            r'(?:^|\n)\s*'
+            r'([\w.]+)'  # Source (dotted names)
+            r'\s*'
+            r'(<\|)?'  # Left arrow head
+            r'(-[udlr]?-)'  # Line with optional direction
+            r'(\|>)?'  # Right arrow head  
+            r'\s*'
+            r'([\w.]+)',  # Target (dotted names)
+            re.MULTILINE,
+        )
+
+        for match in inheritance_pattern.finditer(content):
+            source_full = match.group(1)
+            left_head = match.group(2)
+            right_head = match.group(4)
+            target_full = match.group(5)
+
+            # Split into package.name - store qualified name for lookup
+            if left_head and not right_head:
+                # <|-- pattern: target extends source
+                relationships.append(
+                    PumlRelationship(
+                        source=target_full,  # Keep full qualified name for lookup
+                        target=source_full,
+                        rel_type=RelationshipType.INHERITANCE,
+                    )
+                )
+            elif right_head and not left_head:
+                # --|> pattern: source extends target
+                relationships.append(
+                    PumlRelationship(
+                        source=source_full,
+                        target=target_full,
+                        rel_type=RelationshipType.INHERITANCE,
+                    )
+                )
+
+        # Association pattern (unchanged but now with --)
+        assoc_pattern = re.compile(
+            r'(?:^|\n)\s*'
+            r'([\w.]+)'
+            r'\s*'
+            r'(?:"([^"]*)")?\s*'
+            r'([o*])?'
+            r'--'  # Require two dashes
+            r'([o*>])?'
+            r'\s*'
+            r'(?:"([^"]*)")?\s*'
+            r'([\w.]+)'
+            r'(?:\s*:\s*([^\n]+))?',
+            re.MULTILINE,
+        )
+
+        for match in assoc_pattern.finditer(content):
+            source = match.group(1)
+            source_card = match.group(2)
+            source_marker = match.group(3)
+            target_marker = match.group(4)
+            target_card = match.group(5)
+            target = match.group(6)
+            label = match.group(7)
+
+            # Skip if this looks like inheritance (already handled)
+            if "|" in str(target_marker) or "|" in str(source_marker):
+                continue
+
+            # Determine relationship type
+            if source_marker == "*" or target_marker == "*":
+                rel_type = RelationshipType.COMPOSITION
+            elif source_marker == "o" or target_marker == "o":
+                rel_type = RelationshipType.AGGREGATION
+            else:
+                rel_type = RelationshipType.ASSOCIATION
+
+            if label:
+                label = label.strip()
+
+            relationships.append(
+                PumlRelationship(
+                    source=source,
+                    target=target,
+                    rel_type=rel_type,
+                    label=label,
+                    source_cardinality=source_card,
+                    target_cardinality=target_card,
+                )
+            )
+
+        return relationships
+
+    def _parse_notes(self, content: str) -> list[PumlNote]:
+        """Extract note definitions from content."""
+        notes = []
+
+        # Multi-line notes: note right of Class\n...\nend note
+        multiline_pattern = re.compile(
+            r'note\s+(right|left|top|bottom)\s+of\s+(\w+)\s*\n'
+            r'(.*?)'
+            r'\n\s*end\s*note',
+            re.MULTILINE | re.DOTALL,
+        )
+
+        for match in multiline_pattern.finditer(content):
+            position = match.group(1)
+            attached_to = match.group(2)
+            text = match.group(3).strip()
+
+            notes.append(
+                PumlNote(
+                    content=text,
+                    attached_to=attached_to,
+                    position=position,
+                )
+            )
+
+        # Single-line notes: note right of Class : text
+        inline_pattern = re.compile(
+            r'note\s+(right|left|top|bottom)\s+of\s+(\w+)\s*:\s*([^\n]+)',
+            re.MULTILINE,
+        )
+
+        for match in inline_pattern.finditer(content):
+            position = match.group(1)
+            attached_to = match.group(2)
+            text = match.group(3).strip()
+
+            notes.append(
+                PumlNote(
+                    content=text,
+                    attached_to=attached_to,
+                    position=position,
+                )
+            )
+
+        return notes
+
+    def _attach_notes(self, model: PumlModel, notes: list[PumlNote]) -> None:
+        """Attach notes to their referenced classes."""
+        for note in notes:
+            if note.attached_to:
+                cls = model.get_class(note.attached_to)
+                if cls:
+                    cls.note = note.content
+                else:
+                    self._warnings.append(
+                        f"Note attached to unknown class: {note.attached_to}"
+                    )
+
+    def _parse_title(self, content: str) -> Optional[str]:
+        """Extract diagram title."""
+        match = self.TITLE_PATTERN.search(content)
+        if match:
+            return match.group(1).strip()
+        return None
+
+    def _parse_skinparams(self, content: str) -> dict[str, str]:
+        """Extract skinparam settings."""
+        params = {}
+        for match in self.SKINPARAM_PATTERN.finditer(content):
+            key = match.group(1)
+            value = match.group(2)
+            params[key] = value
+        return params
+
+    def _build_package_map(self, content: str) -> list[tuple[int, int, str]]:
+        """Build a map of character positions to package names.
+
+        Returns a list of (start, end, package_name) tuples.
+        """
+        package_map = []
+
+        # Find all package blocks with their content
+        pattern = re.compile(
+            r'package\s+(?:"([^"]+)"|(\S+))'
+            r'(?:\s+as\s+\S+)?'
+            r'(?:\s*<<\w+>>)?'
+            r'\s*\{',
+            re.MULTILINE,
+        )
+
+        for match in pattern.finditer(content):
+            package_name = match.group(1) or match.group(2)
+            start = match.end()
+
+            # Find matching closing brace
+            brace_count = 1
+            pos = start
+            while pos < len(content) and brace_count > 0:
+                if content[pos] == "{":
+                    brace_count += 1
+                elif content[pos] == "}":
+                    brace_count -= 1
+                pos += 1
+
+            package_map.append((start, pos - 1, package_name))
+
+        return package_map
+
+    def _find_package_at_position(
+        self, pos: int, package_map: list[tuple[int, int, str]]
+    ) -> Optional[str]:
+        """Find which package contains a given character position."""
+        for start, end, name in package_map:
+            if start <= pos <= end:
+                return name
+        return None

--- a/src/rdf_construct/puml2rdf/validators.py
+++ b/src/rdf_construct/puml2rdf/validators.py
@@ -1,0 +1,451 @@
+"""Validation for PlantUML import.
+
+This module provides validation of parsed PlantUML models and
+generated RDF, ensuring consistency and flagging potential issues.
+"""
+
+from dataclasses import dataclass
+from enum import Enum
+from typing import Optional
+
+from rdflib import Graph, URIRef, RDF, RDFS
+from rdflib.namespace import OWL
+
+from rdf_construct.puml2rdf.model import PumlModel, PumlRelationship, RelationshipType
+
+
+class Severity(Enum):
+    """Severity level for validation issues."""
+
+    ERROR = "error"  # Must be fixed
+    WARNING = "warning"  # Should be reviewed
+    INFO = "info"  # Informational
+
+
+@dataclass
+class ValidationIssue:
+    """A validation issue found during checking.
+
+    Attributes:
+        severity: How serious the issue is
+        code: Machine-readable issue code
+        message: Human-readable description
+        entity: The entity this issue relates to
+        suggestion: Optional fix suggestion
+    """
+
+    severity: Severity
+    code: str
+    message: str
+    entity: Optional[str] = None
+    suggestion: Optional[str] = None
+
+    def __str__(self) -> str:
+        prefix = f"[{self.severity.value.upper()}]"
+        entity_str = f" ({self.entity})" if self.entity else ""
+        return f"{prefix} {self.code}: {self.message}{entity_str}"
+
+
+@dataclass
+class ValidationResult:
+    """Result of validation.
+
+    Attributes:
+        issues: List of validation issues found
+    """
+
+    issues: list[ValidationIssue]
+
+    @property
+    def has_errors(self) -> bool:
+        """Return True if any errors were found."""
+        return any(i.severity == Severity.ERROR for i in self.issues)
+
+    @property
+    def has_warnings(self) -> bool:
+        """Return True if any warnings were found."""
+        return any(i.severity == Severity.WARNING for i in self.issues)
+
+    @property
+    def error_count(self) -> int:
+        """Count of errors."""
+        return sum(1 for i in self.issues if i.severity == Severity.ERROR)
+
+    @property
+    def warning_count(self) -> int:
+        """Count of warnings."""
+        return sum(1 for i in self.issues if i.severity == Severity.WARNING)
+
+    def errors(self) -> list[ValidationIssue]:
+        """Return only error-level issues."""
+        return [i for i in self.issues if i.severity == Severity.ERROR]
+
+    def warnings(self) -> list[ValidationIssue]:
+        """Return only warning-level issues."""
+        return [i for i in self.issues if i.severity == Severity.WARNING]
+
+
+class PumlModelValidator:
+    """Validates parsed PlantUML models for consistency.
+
+    Checks include:
+    - Relationships reference existing classes
+    - No duplicate class names
+    - Attributes have valid types
+    - Inheritance doesn't create cycles
+    """
+
+    def validate(self, model: PumlModel) -> ValidationResult:
+        """Validate a parsed PlantUML model.
+
+        Args:
+            model: The parsed model to validate
+
+        Returns:
+            ValidationResult with any issues found
+        """
+        issues: list[ValidationIssue] = []
+
+        # Check for duplicate class names
+        issues.extend(self._check_duplicate_classes(model))
+
+        # Check relationship references
+        issues.extend(self._check_relationship_references(model))
+
+        # Check for inheritance cycles
+        issues.extend(self._check_inheritance_cycles(model))
+
+        # Check attribute types
+        issues.extend(self._check_attribute_types(model))
+
+        # Check for classes without any relationships
+        issues.extend(self._check_orphan_classes(model))
+
+        return ValidationResult(issues=issues)
+
+    def _check_duplicate_classes(self, model: PumlModel) -> list[ValidationIssue]:
+        """Check for duplicate class names."""
+        issues = []
+        seen = set()
+
+        for cls in model.classes:
+            if cls.name in seen:
+                issues.append(
+                    ValidationIssue(
+                        severity=Severity.ERROR,
+                        code="DUPLICATE_CLASS",
+                        message=f"Duplicate class name: {cls.name}",
+                        entity=cls.name,
+                        suggestion="Rename one of the classes or use packages to distinguish them",
+                    )
+                )
+            seen.add(cls.name)
+
+        return issues
+
+    def _check_relationship_references(self, model: PumlModel) -> list[ValidationIssue]:
+        """Check that relationships reference existing classes."""
+        issues = []
+
+        # Include both local and qualified names for lookup
+        class_names = set()
+        for cls in model.classes:
+            class_names.add(cls.name)  # Local name: "Building"
+            class_names.add(cls.qualified_name)  # Qualified: "building.Building"
+
+        for rel in model.relationships:
+            if rel.source not in class_names:
+                issues.append(
+                    ValidationIssue(
+                        severity=Severity.ERROR,
+                        code="UNKNOWN_CLASS",
+                        message=f"Relationship references unknown source class: {rel.source}",
+                        entity=rel.source,
+                        suggestion=f"Add class declaration for '{rel.source}'",
+                    )
+                )
+            if rel.target not in class_names:
+                issues.append(
+                    ValidationIssue(
+                        severity=Severity.ERROR,
+                        code="UNKNOWN_CLASS",
+                        message=f"Relationship references unknown target class: {rel.target}",
+                        entity=rel.target,
+                        suggestion=f"Add class declaration for '{rel.target}'",
+                    )
+                )
+
+        return issues
+
+    def _check_inheritance_cycles(self, model: PumlModel) -> list[ValidationIssue]:
+        """Check for cycles in inheritance hierarchy."""
+        issues = []
+
+        # Build inheritance graph
+        inheritance: dict[str, set[str]] = {}
+        for rel in model.inheritance_relationships():
+            if rel.source not in inheritance:
+                inheritance[rel.source] = set()
+            inheritance[rel.source].add(rel.target)
+
+        # Check for cycles using DFS
+        def has_cycle(start: str, visited: set[str], path: list[str]) -> Optional[list[str]]:
+            if start in path:
+                cycle_start = path.index(start)
+                return path[cycle_start:] + [start]
+
+            if start in visited:
+                return None
+
+            visited.add(start)
+            path.append(start)
+
+            for parent in inheritance.get(start, set()):
+                cycle = has_cycle(parent, visited, path)
+                if cycle:
+                    return cycle
+
+            path.pop()
+            return None
+
+        for cls in model.classes:
+            cycle = has_cycle(cls.name, set(), [])
+            if cycle:
+                issues.append(
+                    ValidationIssue(
+                        severity=Severity.ERROR,
+                        code="INHERITANCE_CYCLE",
+                        message=f"Inheritance cycle detected: {' -> '.join(cycle)}",
+                        entity=cls.name,
+                        suggestion="Break the cycle by removing one of the inheritance relationships",
+                    )
+                )
+                break  # Only report once
+
+        return issues
+
+    def _check_attribute_types(self, model: PumlModel) -> list[ValidationIssue]:
+        """Check that attribute types are recognized."""
+        issues = []
+
+        known_types = {
+            "string", "str", "text",
+            "integer", "int",
+            "decimal", "float", "double", "number",
+            "boolean", "bool",
+            "date", "datetime", "time",
+            "gYear", "gyear", "gYearMonth",
+            "duration",
+            "uri", "anyURI", "anyuri", "url",
+            "base64", "hexBinary",
+            "language", "token",
+        }
+
+        for cls in model.classes:
+            for attr in cls.attributes:
+                if attr.datatype and attr.datatype.lower() not in known_types:
+                    if not attr.datatype.startswith("xsd:"):
+                        issues.append(
+                            ValidationIssue(
+                                severity=Severity.WARNING,
+                                code="UNKNOWN_DATATYPE",
+                                message=f"Unknown datatype '{attr.datatype}' for attribute '{attr.name}'",
+                                entity=f"{cls.name}.{attr.name}",
+                                suggestion="Use standard XSD type or add custom mapping in config",
+                            )
+                        )
+
+        return issues
+
+    def _check_orphan_classes(self, model: PumlModel) -> list[ValidationIssue]:
+        """Check for classes with no relationships."""
+        issues = []
+
+        # Get all classes involved in relationships
+        related_classes = set()
+        for rel in model.relationships:
+            related_classes.add(rel.source)
+            related_classes.add(rel.target)
+
+        for cls in model.classes:
+            if cls.name not in related_classes and not cls.attributes:
+                issues.append(
+                    ValidationIssue(
+                        severity=Severity.INFO,
+                        code="ISOLATED_CLASS",
+                        message=f"Class '{cls.name}' has no relationships or attributes",
+                        entity=cls.name,
+                        suggestion="Consider adding relationships or attributes",
+                    )
+                )
+
+        return issues
+
+
+class RdfValidator:
+    """Validates generated RDF for OWL/RDFS consistency.
+
+    Checks include:
+    - Classes are typed as owl:Class
+    - Properties have domain and range
+    - No dangling references
+    """
+
+    def validate(self, graph: Graph) -> ValidationResult:
+        """Validate an RDF graph.
+
+        Args:
+            graph: The graph to validate
+
+        Returns:
+            ValidationResult with any issues found
+        """
+        issues: list[ValidationIssue] = []
+
+        # Check class typing
+        issues.extend(self._check_class_typing(graph))
+
+        # Check property completeness
+        issues.extend(self._check_property_completeness(graph))
+
+        # Check for dangling references
+        issues.extend(self._check_dangling_references(graph))
+
+        return ValidationResult(issues=issues)
+
+    def _check_class_typing(self, graph: Graph) -> list[ValidationIssue]:
+        """Check that classes are properly typed."""
+        issues = []
+
+        # Find subjects of rdfs:subClassOf that aren't typed as classes
+        for s in graph.subjects(RDFS.subClassOf, None):
+            if not isinstance(s, URIRef):
+                continue
+
+            is_class = (
+                (s, RDF.type, OWL.Class) in graph
+                or (s, RDF.type, RDFS.Class) in graph
+            )
+            if not is_class:
+                issues.append(
+                    ValidationIssue(
+                        severity=Severity.WARNING,
+                        code="UNTYPED_CLASS",
+                        message=f"Subject of rdfs:subClassOf not typed as class",
+                        entity=str(s),
+                        suggestion="Add rdf:type owl:Class triple",
+                    )
+                )
+
+        return issues
+
+    def _check_property_completeness(self, graph: Graph) -> list[ValidationIssue]:
+        """Check that properties have domain and range."""
+        issues = []
+
+        for prop in graph.subjects(RDF.type, OWL.ObjectProperty):
+            if not isinstance(prop, URIRef):
+                continue
+
+            has_domain = any(graph.objects(prop, RDFS.domain))
+            has_range = any(graph.objects(prop, RDFS.range))
+
+            if not has_domain:
+                issues.append(
+                    ValidationIssue(
+                        severity=Severity.INFO,
+                        code="MISSING_DOMAIN",
+                        message="Object property has no domain",
+                        entity=str(prop),
+                    )
+                )
+            if not has_range:
+                issues.append(
+                    ValidationIssue(
+                        severity=Severity.INFO,
+                        code="MISSING_RANGE",
+                        message="Object property has no range",
+                        entity=str(prop),
+                    )
+                )
+
+        for prop in graph.subjects(RDF.type, OWL.DatatypeProperty):
+            if not isinstance(prop, URIRef):
+                continue
+
+            has_range = any(graph.objects(prop, RDFS.range))
+            if not has_range:
+                issues.append(
+                    ValidationIssue(
+                        severity=Severity.INFO,
+                        code="MISSING_RANGE",
+                        message="Datatype property has no range (XSD type)",
+                        entity=str(prop),
+                    )
+                )
+
+        return issues
+
+    def _check_dangling_references(self, graph: Graph) -> list[ValidationIssue]:
+        """Check for references to undefined entities."""
+        issues = []
+
+        # Get all defined classes
+        defined_classes = set()
+        for cls in graph.subjects(RDF.type, OWL.Class):
+            defined_classes.add(cls)
+        for cls in graph.subjects(RDF.type, RDFS.Class):
+            defined_classes.add(cls)
+
+        # Check domain and range references
+        for prop in graph.subjects(RDF.type, OWL.ObjectProperty):
+            for domain in graph.objects(prop, RDFS.domain):
+                if isinstance(domain, URIRef) and domain not in defined_classes:
+                    issues.append(
+                        ValidationIssue(
+                            severity=Severity.WARNING,
+                            code="UNDEFINED_DOMAIN",
+                            message=f"Property domain references undefined class",
+                            entity=f"{prop} -> {domain}",
+                        )
+                    )
+
+            for rng in graph.objects(prop, RDFS.range):
+                if isinstance(rng, URIRef) and rng not in defined_classes:
+                    # Could be external class - just info
+                    issues.append(
+                        ValidationIssue(
+                            severity=Severity.INFO,
+                            code="EXTERNAL_RANGE",
+                            message=f"Property range references class not in this graph",
+                            entity=f"{prop} -> {rng}",
+                        )
+                    )
+
+        return issues
+
+
+def validate_puml(model: PumlModel) -> ValidationResult:
+    """Convenience function to validate a PlantUML model.
+
+    Args:
+        model: The parsed model to validate
+
+    Returns:
+        ValidationResult with any issues found
+    """
+    validator = PumlModelValidator()
+    return validator.validate(model)
+
+
+def validate_rdf(graph: Graph) -> ValidationResult:
+    """Convenience function to validate an RDF graph.
+
+    Args:
+        graph: The graph to validate
+
+    Returns:
+        ValidationResult with any issues found
+    """
+    validator = RdfValidator()
+    return validator.validate(graph)

--- a/tests/test_puml2rdf.py
+++ b/tests/test_puml2rdf.py
@@ -1,0 +1,629 @@
+"""Tests for PlantUML import module.
+
+Tests cover parsing, conversion, validation, and merging functionality.
+"""
+
+import pytest
+from pathlib import Path
+from rdflib import Graph, Namespace, RDF, RDFS, Literal
+from rdflib.namespace import OWL, XSD
+
+from rdf_construct.puml2rdf import (
+    PlantUMLParser,
+    PumlToRdfConverter,
+    ConversionConfig,
+    PumlModel,
+    PumlClass,
+    PumlAttribute,
+    PumlRelationship,
+    RelationshipType,
+    validate_puml,
+    validate_rdf,
+    OntologyMerger,
+)
+
+
+# ==============================================================================
+# Parser Tests
+# ==============================================================================
+
+
+class TestPlantUMLParser:
+    """Tests for PlantUML parsing."""
+
+    def test_parse_simple_class(self):
+        """Test parsing a simple class declaration."""
+        content = """
+        @startuml
+        class Building
+        @enduml
+        """
+        parser = PlantUMLParser()
+        result = parser.parse(content)
+
+        assert result.success
+        assert len(result.model.classes) == 1
+        assert result.model.classes[0].name == "Building"
+
+    def test_parse_class_with_attributes(self):
+        """Test parsing a class with attributes."""
+        content = """
+        @startuml
+        class Building {
+            floorArea : decimal
+            constructionYear : gYear
+            name : string
+        }
+        @enduml
+        """
+        parser = PlantUMLParser()
+        result = parser.parse(content)
+
+        assert result.success
+        assert len(result.model.classes) == 1
+        cls = result.model.classes[0]
+        assert cls.name == "Building"
+        assert len(cls.attributes) == 3
+
+        attr_names = {a.name for a in cls.attributes}
+        assert attr_names == {"floorArea", "constructionYear", "name"}
+
+        floor_area = next(a for a in cls.attributes if a.name == "floorArea")
+        assert floor_area.datatype == "decimal"
+
+    def test_parse_abstract_class(self):
+        """Test parsing abstract class declaration."""
+        content = """
+        @startuml
+        abstract class Entity
+        class Building
+        @enduml
+        """
+        parser = PlantUMLParser()
+        result = parser.parse(content)
+
+        assert result.success
+        entity = result.model.get_class("Entity")
+        assert entity is not None
+        assert entity.is_abstract is True
+
+        building = result.model.get_class("Building")
+        assert building is not None
+        assert building.is_abstract is False
+
+    def test_parse_inheritance(self):
+        """Test parsing inheritance relationships."""
+        content = """
+        @startuml
+        class Entity
+        class Building
+        Building --|> Entity
+        @enduml
+        """
+        parser = PlantUMLParser()
+        result = parser.parse(content)
+
+        assert result.success
+        assert len(result.model.relationships) == 1
+
+        rel = result.model.relationships[0]
+        assert rel.rel_type == RelationshipType.INHERITANCE
+        assert rel.source == "Building"  # Child
+        assert rel.target == "Entity"  # Parent
+
+    def test_parse_inheritance_reverse_arrow(self):
+        """Test parsing inheritance with reversed arrow."""
+        content = """
+        @startuml
+        class Entity
+        class Building
+        Entity <|-- Building
+        @enduml
+        """
+        parser = PlantUMLParser()
+        result = parser.parse(content)
+
+        assert result.success
+        rel = result.model.relationships[0]
+        assert rel.source == "Building"  # Child
+        assert rel.target == "Entity"  # Parent
+
+    def test_parse_association_with_label(self):
+        """Test parsing labeled association."""
+        content = """
+        @startuml
+        class Building
+        class Floor
+        Building --> Floor : hasFloor
+        @enduml
+        """
+        parser = PlantUMLParser()
+        result = parser.parse(content)
+
+        assert result.success
+        # Find non-inheritance relationships
+        assocs = result.model.property_relationships()
+        assert len(assocs) >= 1
+
+        rel = assocs[0]
+        assert rel.source == "Building"
+        assert rel.target == "Floor"
+        assert rel.label == "hasFloor"
+
+    def test_parse_package(self):
+        """Test parsing package declaration."""
+        content = """
+        @startuml
+        package "http://example.org/building#" as bld {
+            class Building
+        }
+        @enduml
+        """
+        parser = PlantUMLParser()
+        result = parser.parse(content)
+
+        assert result.success
+        assert len(result.model.packages) == 1
+
+        pkg = result.model.packages[0]
+        assert pkg.name == "http://example.org/building#"
+
+    def test_parse_class_in_package(self):
+        """Test that classes track their containing package."""
+        content = """
+        @startuml
+        package building {
+            class Building
+            class Floor
+        }
+        class ExternalClass
+        @enduml
+        """
+        parser = PlantUMLParser()
+        result = parser.parse(content)
+
+        assert result.success
+
+        building = result.model.get_class("Building")
+        assert building is not None
+        assert building.package == "building"
+
+        external = result.model.get_class("ExternalClass")
+        assert external is not None
+        assert external.package is None
+
+    def test_parse_note_attached_to_class(self):
+        """Test parsing notes attached to classes."""
+        content = """
+        @startuml
+        class Building
+        note right of Building : A physical structure
+        @enduml
+        """
+        parser = PlantUMLParser()
+        result = parser.parse(content)
+
+        assert result.success
+        building = result.model.get_class("Building")
+        assert building.note == "A physical structure"
+
+    def test_parse_multiline_note(self):
+        """Test parsing multi-line notes."""
+        content = """
+        @startuml
+        class Building
+        note right of Building
+            A physical structure
+            that can be occupied
+        end note
+        @enduml
+        """
+        parser = PlantUMLParser()
+        result = parser.parse(content)
+
+        assert result.success
+        building = result.model.get_class("Building")
+        assert building.note is not None
+        assert "physical structure" in building.note
+
+    def test_parse_title(self):
+        """Test parsing diagram title."""
+        content = """
+        @startuml
+        title Building Ontology
+        class Building
+        @enduml
+        """
+        parser = PlantUMLParser()
+        result = parser.parse(content)
+
+        assert result.success
+        assert result.model.title == "Building Ontology"
+
+
+# ==============================================================================
+# Converter Tests
+# ==============================================================================
+
+
+class TestPumlToRdfConverter:
+    """Tests for PlantUML to RDF conversion."""
+
+    def test_convert_simple_class(self):
+        """Test converting a simple class."""
+        model = PumlModel(
+            classes=[PumlClass(name="Building")]
+        )
+
+        config = ConversionConfig(
+            default_namespace="http://example.org/ont#"
+        )
+        converter = PumlToRdfConverter(config)
+        result = converter.convert(model)
+
+        graph = result.graph
+        ns = Namespace("http://example.org/ont#")
+
+        # Check class exists and is typed
+        assert (ns.Building, RDF.type, OWL.Class) in graph
+
+    def test_convert_class_with_label(self):
+        """Test that classes get labels."""
+        model = PumlModel(
+            classes=[PumlClass(name="FloorArea")]
+        )
+
+        config = ConversionConfig(
+            default_namespace="http://example.org/ont#",
+            generate_labels=True,
+            camel_to_label=True,
+        )
+        converter = PumlToRdfConverter(config)
+        result = converter.convert(model)
+
+        ns = Namespace("http://example.org/ont#")
+        labels = list(result.graph.objects(ns.FloorArea, RDFS.label))
+
+        assert len(labels) == 1
+        assert str(labels[0]) == "floor area"
+
+    def test_convert_class_with_comment(self):
+        """Test that notes become comments."""
+        model = PumlModel(
+            classes=[
+                PumlClass(
+                    name="Building",
+                    note="A physical structure"
+                )
+            ]
+        )
+
+        converter = PumlToRdfConverter()
+        result = converter.convert(model)
+
+        ns = Namespace("http://example.org/ontology#")
+        comments = list(result.graph.objects(ns.Building, RDFS.comment))
+
+        assert len(comments) == 1
+        assert "physical structure" in str(comments[0])
+
+    def test_convert_attribute_to_datatype_property(self):
+        """Test that attributes become datatype properties."""
+        model = PumlModel(
+            classes=[
+                PumlClass(
+                    name="Building",
+                    attributes=[
+                        PumlAttribute(name="floorArea", datatype="decimal")
+                    ]
+                )
+            ]
+        )
+
+        config = ConversionConfig(
+            default_namespace="http://example.org/ont#"
+        )
+        converter = PumlToRdfConverter(config)
+        result = converter.convert(model)
+
+        ns = Namespace("http://example.org/ont#")
+        graph = result.graph
+
+        # Check property type
+        assert (ns.floorArea, RDF.type, OWL.DatatypeProperty) in graph
+
+        # Check domain
+        domains = list(graph.objects(ns.floorArea, RDFS.domain))
+        assert ns.Building in domains
+
+        # Check range
+        ranges = list(graph.objects(ns.floorArea, RDFS.range))
+        assert XSD.decimal in ranges
+
+    def test_convert_inheritance(self):
+        """Test that inheritance becomes subClassOf."""
+        model = PumlModel(
+            classes=[
+                PumlClass(name="Entity"),
+                PumlClass(name="Building"),
+            ],
+            relationships=[
+                PumlRelationship(
+                    source="Building",
+                    target="Entity",
+                    rel_type=RelationshipType.INHERITANCE,
+                )
+            ]
+        )
+
+        config = ConversionConfig(
+            default_namespace="http://example.org/ont#"
+        )
+        converter = PumlToRdfConverter(config)
+        result = converter.convert(model)
+
+        ns = Namespace("http://example.org/ont#")
+        assert (ns.Building, RDFS.subClassOf, ns.Entity) in result.graph
+
+    def test_convert_association_to_object_property(self):
+        """Test that associations become object properties."""
+        model = PumlModel(
+            classes=[
+                PumlClass(name="Building"),
+                PumlClass(name="Floor"),
+            ],
+            relationships=[
+                PumlRelationship(
+                    source="Building",
+                    target="Floor",
+                    rel_type=RelationshipType.ASSOCIATION,
+                    label="has floor",
+                )
+            ]
+        )
+
+        config = ConversionConfig(
+            default_namespace="http://example.org/ont#"
+        )
+        converter = PumlToRdfConverter(config)
+        result = converter.convert(model)
+
+        ns = Namespace("http://example.org/ont#")
+        graph = result.graph
+
+        # Check property exists
+        assert (ns.hasFloor, RDF.type, OWL.ObjectProperty) in graph
+
+        # Check domain and range
+        assert (ns.hasFloor, RDFS.domain, ns.Building) in graph
+        assert (ns.hasFloor, RDFS.range, ns.Floor) in graph
+
+    def test_convert_generates_ontology_header(self):
+        """Test that conversion creates ontology declaration."""
+        model = PumlModel(
+            title="Building Ontology",
+            classes=[PumlClass(name="Building")]
+        )
+
+        config = ConversionConfig(
+            default_namespace="http://example.org/building#"
+        )
+        converter = PumlToRdfConverter(config)
+        result = converter.convert(model)
+
+        ont_uri = Namespace("http://example.org/building")[""]
+        # Check for ontology type (URI without trailing #)
+        ont_types = list(result.graph.subjects(RDF.type, OWL.Ontology))
+        assert len(ont_types) >= 1
+
+
+# ==============================================================================
+# Validator Tests
+# ==============================================================================
+
+
+class TestPumlValidation:
+    """Tests for PlantUML model validation."""
+
+    def test_validate_duplicate_classes(self):
+        """Test detection of duplicate class names."""
+        model = PumlModel(
+            classes=[
+                PumlClass(name="Building"),
+                PumlClass(name="Building"),
+            ]
+        )
+
+        result = validate_puml(model)
+        assert result.has_errors
+        assert any("DUPLICATE_CLASS" in str(i) for i in result.issues)
+
+    def test_validate_unknown_relationship_class(self):
+        """Test detection of relationships to unknown classes."""
+        model = PumlModel(
+            classes=[PumlClass(name="Building")],
+            relationships=[
+                PumlRelationship(
+                    source="Building",
+                    target="NonExistent",
+                    rel_type=RelationshipType.ASSOCIATION,
+                )
+            ]
+        )
+
+        result = validate_puml(model)
+        assert result.has_errors
+        assert any("UNKNOWN_CLASS" in str(i) for i in result.issues)
+
+    def test_validate_unknown_datatype(self):
+        """Test warning for unknown datatypes."""
+        model = PumlModel(
+            classes=[
+                PumlClass(
+                    name="Building",
+                    attributes=[
+                        PumlAttribute(name="custom", datatype="UnknownType")
+                    ]
+                )
+            ]
+        )
+
+        result = validate_puml(model)
+        assert result.has_warnings
+        assert any("UNKNOWN_DATATYPE" in str(i) for i in result.issues)
+
+    def test_validate_inheritance_cycle(self):
+        """Test detection of inheritance cycles."""
+        model = PumlModel(
+            classes=[
+                PumlClass(name="A"),
+                PumlClass(name="B"),
+                PumlClass(name="C"),
+            ],
+            relationships=[
+                PumlRelationship(source="A", target="B", rel_type=RelationshipType.INHERITANCE),
+                PumlRelationship(source="B", target="C", rel_type=RelationshipType.INHERITANCE),
+                PumlRelationship(source="C", target="A", rel_type=RelationshipType.INHERITANCE),
+            ]
+        )
+
+        result = validate_puml(model)
+        assert result.has_errors
+        assert any("INHERITANCE_CYCLE" in str(i) for i in result.issues)
+
+
+class TestRdfValidation:
+    """Tests for RDF graph validation."""
+
+    def test_validate_untyped_class(self):
+        """Test warning for classes used without type declaration."""
+        graph = Graph()
+        ns = Namespace("http://example.org/ont#")
+
+        # Add subClassOf without class type
+        graph.add((ns.Building, RDFS.subClassOf, ns.Entity))
+
+        result = validate_rdf(graph)
+        assert any("UNTYPED_CLASS" in str(i) for i in result.issues)
+
+    def test_validate_missing_domain(self):
+        """Test info for properties without domain."""
+        graph = Graph()
+        ns = Namespace("http://example.org/ont#")
+
+        graph.add((ns.hasFloor, RDF.type, OWL.ObjectProperty))
+        # No domain added
+
+        result = validate_rdf(graph)
+        assert any("MISSING_DOMAIN" in str(i) for i in result.issues)
+
+
+# ==============================================================================
+# Merger Tests
+# ==============================================================================
+
+
+class TestOntologyMerger:
+    """Tests for ontology merging."""
+
+    def test_merge_adds_new_triples(self):
+        """Test that new triples are added."""
+        existing = Graph()
+        ns = Namespace("http://example.org/ont#")
+        existing.add((ns.Building, RDF.type, OWL.Class))
+
+        new_graph = Graph()
+        new_graph.add((ns.Floor, RDF.type, OWL.Class))
+
+        merger = OntologyMerger()
+        result = merger.merge_graphs(new_graph, existing)
+
+        assert (ns.Building, RDF.type, OWL.Class) in result.graph
+        assert (ns.Floor, RDF.type, OWL.Class) in result.graph
+
+    def test_merge_preserves_existing_annotations(self):
+        """Test that existing annotations are preserved."""
+        existing = Graph()
+        ns = Namespace("http://example.org/ont#")
+        existing.add((ns.Building, RDF.type, OWL.Class))
+        existing.add((ns.Building, RDFS.comment, Literal("Manually added comment")))
+
+        new_graph = Graph()
+        new_graph.add((ns.Building, RDF.type, OWL.Class))
+        # No comment in new
+
+        merger = OntologyMerger()
+        result = merger.merge_graphs(new_graph, existing)
+
+        comments = list(result.graph.objects(ns.Building, RDFS.comment))
+        assert any("Manually added" in str(c) for c in comments)
+
+
+# ==============================================================================
+# Integration Tests
+# ==============================================================================
+
+
+class TestRoundTrip:
+    """Integration tests for full parse-convert workflow."""
+
+    def test_full_conversion(self):
+        """Test complete parse and convert workflow."""
+        puml = """
+        @startuml
+        title Building Ontology
+
+        class Building {
+            floorArea : decimal
+            constructionYear : gYear
+        }
+
+        class Floor {
+            level : integer
+        }
+
+        Building --|> Entity
+        Building --> Floor : hasFloor
+
+        note right of Building
+            A physical structure
+            that can be occupied.
+        end note
+
+        @enduml
+        """
+
+        # Parse
+        parser = PlantUMLParser()
+        parse_result = parser.parse(puml)
+        assert parse_result.success
+
+        # Add Entity class (referenced but not defined)
+        parse_result.model.classes.append(PumlClass(name="Entity"))
+
+        # Convert
+        config = ConversionConfig(
+            default_namespace="http://example.org/building#",
+            generate_labels=True,
+        )
+        converter = PumlToRdfConverter(config)
+        result = converter.convert(parse_result.model)
+
+        # Verify
+        graph = result.graph
+        ns = Namespace("http://example.org/building#")
+
+        # Classes exist
+        assert (ns.Building, RDF.type, OWL.Class) in graph
+        assert (ns.Floor, RDF.type, OWL.Class) in graph
+
+        # Inheritance
+        assert (ns.Building, RDFS.subClassOf, ns.Entity) in graph
+
+        # Properties
+        assert (ns.floorArea, RDF.type, OWL.DatatypeProperty) in graph
+        assert (ns.hasFloor, RDF.type, OWL.ObjectProperty) in graph
+
+        # Comment from note
+        comments = list(graph.objects(ns.Building, RDFS.comment))
+        assert len(comments) >= 1


### PR DESCRIPTION
Closes #11 

## Summary

This PR introduces a new `from-uml` command that parses PlantUML class diagrams and generates RDF ontology files, enabling diagram-first ontology design.

## Changes

### New Modules

- **`src/rdf_construct/puml_import/`** - New PlantUML import subpackage
  - `parser.py` - Regex-based PlantUML parsing
  - `model.py` - Intermediate representation dataclasses
  - `converter.py` - Model to RDF Graph conversion
  - `config.py` - Configuration handling
  - `validators.py` - Syntax validation and error reporting
  - `merger.py` - Ontology merge logic

### CLI Changes

- **`src/rdf_construct/cli.py`** - Added `from-uml` command with options:
  - Positional: PlantUML source file
  - `--output` / `-o` - Output file path
  - `--format` - Output format (turtle/jsonld/rdfxml)
  - `--namespace` - Default namespace URI
  - `--config` - Path to configuration file
  - `--merge` - Existing ontology to merge with
  - `--validate` - Validate only, don't generate

### New Files

- `docs/user_guides/PUML_IMPORT_GUIDE.md` - User documentation
- `examples/uml-import.yml` - Example configuration
- `tests/test_puml_import.py` - Unit tests
- `tests/fixtures/puml_import/` - Sample PlantUML files

## Implementation Details

### Parser Architecture

The parser uses a multi-pass approach:

```python
class PlantUMLParser:
    def parse(self, content: str) -> PumlModel:
        # Pass 1: Extract packages and set up namespaces
        packages = self._parse_packages(content)
        
        # Pass 2: Extract classes with attributes
        classes = self._parse_classes(content)
        
        # Pass 3: Extract relationships
        relationships = self._parse_relationships(content)
        
        # Pass 4: Extract notes and attach to entities
        self._attach_notes(classes, content)
        
        return PumlModel(classes, relationships, packages)
```

### Regex Patterns

Core patterns for PlantUML syntax:

```python
PATTERNS = {
    # class Building <<stereotype>> { ... }
    "class": r'class\s+"?(\w+)"?\s*(?:<<(\w+)>>)?\s*(?:\{([^}]*)\})?',
    
    # Building <|-- ResidentialBuilding
    "inheritance": r'(\w+)\s+<\|--\s+(\w+)',
    
    # Building "1" --> "*" Floor : hasFloor
    "association": r'(\w+)\s*"?([^"]*)"?\s*-->\s*"?([^"]*)"?\s*(\w+)\s*(?::\s*(\w+))?',
    
    # package "http://..." as alias { ... }
    "package": r'package\s+"([^"]+)"\s+as\s+(\w+)\s*\{',
    
    # note right of Building : text
    "note": r'note\s+(?:right|left|top|bottom)\s+of\s+(\w+)\s*:\s*(.+)',
}
```

### Model to RDF Conversion

```python
class ModelConverter:
    def convert(self, model: PumlModel, config: ImportConfig) -> Graph:
        graph = Graph()
        self._bind_namespaces(graph, model.packages, config)
        
        # Convert classes
        for cls in model.classes:
            self._add_class(graph, cls, config)
        
        # Convert relationships
        for rel in model.relationships:
            if rel.type == "inheritance":
                self._add_subclass(graph, rel)
            else:
                self._add_property(graph, rel, config)
        
        return graph
    
    def _add_class(self, graph: Graph, cls: PumlClass, config: ImportConfig):
        uri = self._make_uri(cls.name, cls.package, config)
        
        graph.add((uri, RDF.type, OWL.Class))
        graph.add((uri, RDFS.label, Literal(self._to_label(cls.name), lang="en")))
        
        if cls.note:
            graph.add((uri, RDFS.comment, Literal(cls.note, lang="en")))
        
        # Convert attributes to datatype properties
        for attr in cls.attributes:
            self._add_datatype_property(graph, uri, attr, config)
```

### Merge Logic

When `--merge existing.ttl` is specified:

```python
def merge_ontologies(existing: Graph, generated: Graph) -> Graph:
    result = Graph()
    
    # Copy all existing triples
    for triple in existing:
        result.add(triple)
    
    # Add new entities from generated
    for subject in generated.subjects():
        if subject not in existing.subjects():
            # New entity - add all triples
            for p, o in generated.predicate_objects(subject):
                result.add((subject, p, o))
        else:
            # Existing entity - add only new predicates
            existing_preds = set(existing.predicates(subject))
            for p, o in generated.predicate_objects(subject):
                if p not in existing_preds:
                    result.add((subject, p, o))
    
    return result
```

### Error Handling

Parser provides detailed error messages:

```python
class ParseError:
    line: int
    column: int
    message: str
    hint: str | None

class ValidationResult:
    valid: bool
    errors: list[ParseError]
    warnings: list[ParseWarning]
    
    def format(self) -> str:
        lines = []
        for err in self.errors:
            lines.append(f"  Line {err.line}: {err.message}")
            if err.hint:
                lines.append(f"    Hint: {err.hint}")
        return "\n".join(lines)
```

### Supported Syntax Summary

| PlantUML | RDF Output |
|----------|------------|
| `class Foo` | `ex:Foo a owl:Class` |
| `class Foo { bar : string }` | Datatype property with domain |
| `A <\|-- B` | `ex:B rdfs:subClassOf ex:A` |
| `A --> B : rel` | Object property with domain/range |
| `<<stereotype>>` | Controls `rdf:type` |
| `package "uri"` | Namespace for contained classes |
| `note of Foo` | `rdfs:comment` |

### Unsupported Syntax

Clearly documented limitations:

- Sequence diagrams, activity diagrams, etc.
- Interface declarations
- Composition (`*--`) vs aggregation (`o--`) - treated as association
- Method declarations in classes
- Generic types (`List<Foo>`)

## Testing

### Unit Tests

```bash
pytest tests/test_puml_import.py -v
```

Coverage:
- `test_parse_simple_class` - Basic class parsing
- `test_parse_class_with_attributes` - Attribute extraction
- `test_parse_inheritance` - Inheritance arrow
- `test_parse_association` - Association with label
- `test_parse_association_cardinality` - Cardinality parsing
- `test_parse_package` - Package/namespace handling
- `test_parse_stereotype` - Stereotype interpretation
- `test_parse_note` - Note attachment
- `test_convert_to_rdf` - Full conversion
- `test_merge_mode` - Merge with existing

### Round-Trip Tests

```python
def test_round_trip():
    # Generate UML from ontology
    puml = generate_uml(ontology, context)
    
    # Parse UML back to RDF
    regenerated = parse_uml(puml, config)
    
    # Core structure should match
    assert same_classes(ontology, regenerated)
    assert same_hierarchy(ontology, regenerated)
```

### Manual Testing

```bash
# Basic conversion
poetry run rdf-construct from-uml examples/design.puml -o generated.ttl

# Validate syntax
poetry run rdf-construct from-uml examples/design.puml --validate

# Merge with existing
poetry run rdf-construct from-uml updated.puml --merge existing.ttl -o merged.ttl

# Full round-trip
poetry run rdf-construct uml existing.ttl config.yml -c full -o round-trip.puml
poetry run rdf-construct from-uml round-trip.puml -o regenerated.ttl
diff existing.ttl regenerated.ttl
```

## Breaking Changes

None. New command with no impact on existing functionality.

## Documentation

- [ ] `docs/user_guides/PUML_IMPORT_GUIDE.md` - Comprehensive guide
- [ ] Supported syntax table
- [ ] Unsupported syntax documented
- [ ] Merge workflow explained
- [ ] Example configuration file

## Checklist

- [ ] Code follows project style guidelines
- [ ] Type hints on all functions
- [ ] Docstrings (Google style)
- [ ] Unit tests pass
- [ ] Round-trip tests pass
- [ ] Documentation updated
- [ ] CHANGELOG.md updated

## Example

**Input** (`design.puml`):
```plantuml
@startuml

package "http://example.org/building#" as bld {
  class Building {
    floorArea : decimal
    constructionYear : gYear
  }
  
  class Floor
}

Building "1" --> "*" Floor : hasFloor

note right of Building
  A constructed physical structure.
end note

@enduml
```

**Output** (`ontology.ttl`):
```turtle
@prefix bld: <http://example.org/building#> .
@prefix owl: <http://www.w3.org/2002/07/owl#> .
@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .

<http://example.org/building#> a owl:Ontology ;
    rdfs:label "Building Ontology" .

bld:Building a owl:Class ;
    rdfs:label "Building"@en ;
    rdfs:comment "A constructed physical structure."@en .

bld:Floor a owl:Class ;
    rdfs:label "Floor"@en .

bld:floorArea a owl:DatatypeProperty ;
    rdfs:domain bld:Building ;
    rdfs:range xsd:decimal ;
    rdfs:label "floor area"@en .

bld:constructionYear a owl:DatatypeProperty ;
    rdfs:domain bld:Building ;
    rdfs:range xsd:gYear ;
    rdfs:label "construction year"@en .

bld:hasFloor a owl:ObjectProperty ;
    rdfs:domain bld:Building ;
    rdfs:range bld:Floor ;
    rdfs:label "has floor"@en .
```
