### PR TITLE
DEV: Add `localise` command for multi-language label management

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,28 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- **New `localise` command** for multi-language translation management
+  - `localise extract` - Extract translatable strings (rdfs:label, rdfs:comment, skos:prefLabel, etc.) to YAML files
+  - `localise merge` - Merge completed translations back into ontologies as language-tagged literals
+  - `localise report` - Generate translation coverage reports across languages
+  - `localise init` - Create empty translation file for a new language
+  - `localise config --init` - Generate default configuration file
+  - Four-level status tracking: pending → needs_review → translated → approved
+  - Property-aware extraction (configurable properties to extract)
+  - Missing-only mode for incremental translation updates
+  - Preserve/overwrite strategies for existing translations
+  - Text and Markdown output formatters
+  - Exit codes: 0 (success), 1 (warnings), 2 (error)
+- New module: `src/rdf_construct/localise/`
+  - `config.py` - Configuration dataclasses (TranslationEntry, TranslationFile, etc.)
+  - `extractor.py` - String extraction from ontologies
+  - `merger.py` - Merge translations back into graphs
+  - `reporter.py` - Coverage analysis
+  - `formatters/` - Text and Markdown output formatters
+- New documentation: `docs/user_guides/LOCALISE_GUIDE.md`
+- New example: `examples/localise_config.yml`
+- New tests: `tests/test_localise.py` (27 test cases)
+
 - **New `refactor` command group** for URI renaming and deprecation
   - `refactor rename` subcommand for URI renaming:
     - Single entity renames (fixing typos): `--from ex:Buiding --to ex:Building`

--- a/CODE_INDEX.md
+++ b/CODE_INDEX.md
@@ -9,35 +9,28 @@ docs/
 ├── index.md
 ├── dev/
 │   ├── ARCHITECTURE.md
-│   ├── UML_IMPLEMENTATION.md
-│   └── UML_ODM_RDF_INTEGRATION.md
+│   └── UML_IMPLEMENTATION.md
 └── user_guides/
     ├── CLI_REFERENCE.md
     ├── CQ_TEST_GUIDE.md
     ├── DIFF_GUIDE.md
     ├── DOCS_GUIDE.md
-    ├── EXPLICIT_MODE.md
     ├── GETTING_STARTED.md
-    ├── IES_COLOUR_PALETTE_GUIDE.md
-    ├── IES_COLOUR_REFERENCE.md
-    ├── IES_COLOUR_SCHEME_COMPARISON.md
     ├── LINT_GUIDE.md
+    ├── LOCALISE_GUIDE.md
     ├── MERGE_GUIDE.md
+    ├── PLANTUML_IMPORT_GUIDE.md
     ├── PROJECT_SETUP.md
-    ├── PUML2RDF_GUIDE.md
     ├── QUICK_REFERENCE.md
     ├── REFACTOR_GUIDE.md
     ├── SHACL_GUIDE.md
     ├── STATS_GUIDE.md
-    ├── UML_GUIDE.md
-    ├── UML_MODE_DECISION_TREE.md
-    └── UML_ODM_RDF_GUIDE.md
+    └── UML_GUIDE.md
 
 src/rdf_construct/
 ├── __init__.py
 ├── __main__.py
 ├── cli.py
-├── main.py
 ├── core/
 │   ├── __init__.py
 │   ├── config.py
@@ -114,6 +107,7 @@ src/rdf_construct/
 │   ├── comparator.py
 │   ├── metrics/
 │   │   ├── __init__.py
+│   │   ├── base.py
 │   │   ├── basic.py
 │   │   ├── complexity.py
 │   │   ├── connectivity.py
@@ -142,6 +136,16 @@ src/rdf_construct/
 │   └── formatters/
 │       ├── __init__.py
 │       └── text.py
+├── localise/
+│   ├── __init__.py
+│   ├── config.py
+│   ├── extractor.py
+│   ├── merger.py
+│   ├── reporter.py
+│   └── formatters/
+│       ├── __init__.py
+│       ├── text.py
+│       └── markdown.py
 └── uml/
     ├── __init__.py
     ├── context.py
@@ -153,54 +157,33 @@ src/rdf_construct/
 
 examples/
 ├── animal_ontology.ttl
-├── organisation_ontology.ttl
-├── simple_ontology.ttl
-├── cq-test/
-│   └── cq_tests_animal.yml
-├── docs/
-│   └── docs_config.yml
-├── lint/
-│   ├── example_lint_problematic.ttl
-│   └── rdf_lint.yml
-├── merge/
-│   ├── merge_config.yml
-│   ├── merge_conflicting.ttl
-│   ├── merge_core.ttl
-│   ├── merge_extension.ttl
-│   └── merge_instances.ttl
-├── order/
-│   ├── basic_ordering.py
-│   ├── ies_profile.yml
-│   ├── sample_profile.yml
-│   └── test_profile.yml
-├── puml2rdf/
-│   └── puml2rdf_config.yml
-├── refactor/
-│   ├── deprecations.yml
-│   ├── instances.ttl
-│   ├── legacy.ttl
-│   ├── old_namespace.ttl
-│   ├── renames.yml
-│   └── typos.ttl
-├── shacl/
-│   └── shacl_config.yml
-├── split/
-│   ├── split_config.yml
-│   ├── split_instances.ttl
-│   └── split_monolith.ttl
-└── uml/
-    ├── example_styled_uml.py
-    ├── ies_colour_examples.yml
-    ├── ies_colour_palette.yml
-    ├── ies_colour_palette_with_instances.yml
-    ├── uml_contexts.yml
-    ├── uml_contexts_explicit.yml
-    ├── uml_layouts.yml
-    └── uml_styles.yml
-
-templates/
+├── basic_ordering.py
+├── building_structure_context.yml
+├── cq_tests_animal.yml
+├── docs_config.yml
+├── ies_building_contexts.yml
+├── ies_colour_examples.yml
+├── ies_colour_palette.yml
+├── ies_colour_palette_with_instances.yml
+├── localise_config.yml
+├── merge_config.yml
 ├── ordering_starter.yml
+├── organisation_ontology.ttl
+├── puml_import.yml
+├── rdf_lint.yml
+├── refactor_deprecations.yml
+├── refactor_renames.yml
+├── sample_profile.yml
+├── shacl_config.yml
+├── split_config.yml
+├── split_instances.ttl
+├── split_monolith.ttl
+├── test_profile.yml
+├── uml_contexts.yml
+├── uml_contexts_explicit.yml
 ├── uml_contexts_starter.yml
+├── uml_layouts.yml
+├── uml_styles.yml
 └── uml_styles_starter.yml
 
 tests/
@@ -212,6 +195,7 @@ tests/
 ├── test_explicit_mode.py
 ├── test_instance_styling.py
 ├── test_lint.py
+├── test_localise.py
 ├── test_merge.py
 ├── test_odm_renderer.py
 ├── test_ordering.py
@@ -224,8 +208,8 @@ tests/
 ├── test_stats.py
 └── fixtures/
     ├── diff/
-    │   ├── v1.0.ttl
-    │   └── v1.1.ttl
+    │   ├── v1_0.ttl
+    │   └── v1_1.ttl
     ├── merge/
     │   ├── conflicting.ttl
     │   ├── core.ttl
@@ -235,12 +219,11 @@ tests/
     │   ├── deprecations.yml
     │   ├── instances.ttl
     │   ├── legacy.ttl
-    │   ├── old_namespace.ttl
     │   ├── renames.yml
     │   └── typos.ttl
-    └── split/
-        ├── instances.ttl
-        └── monolith.ttl
+    ├── split/
+    │   ├── instances.ttl
+    │   └── monolith.ttl
 
 ├── pyproject.toml              # Modern Python packaging config
 ├── poetry.lock                 # Locked dependencies
@@ -280,6 +263,10 @@ tests/
 - `diff` command for semantic comparison
 - `cq-test` command for competency question testing
 - `stats` command for ontology metrics
+- `merge` command for combining ontologies
+- `split` command for modularising ontologies
+- `refactor` command group for renaming and deprecation
+- `localise` command group for translation management
 
 ### Core Modules (`core/`)
 
@@ -548,60 +535,6 @@ Combine multiple RDF ontologies with conflict detection, namespace management, a
 
 ---
 
-### Refactor Module (`refactor/`)
-
-Rename URIs and deprecate entities in RDF ontologies.
-
-**`refactor/__init__.py`**
-- Public API exports
-- `OntologyRenamer`, `OntologyDeprecator`
-- `RenameConfig`, `DeprecationSpec`, `RefactorConfig`
-- `RenameResult`, `DeprecationResult`
-- `rename_file()`, `deprecate_file()`
-
-**`refactor/config.py`**
-- `RenameConfig` dataclass - namespace and entity rename mappings
-- `RenameMapping` dataclass - single from/to URI mapping
-- `DeprecationSpec` dataclass - entity deprecation specification
-- `DeprecationConfig` dataclass - bulk deprecation configuration
-- `RefactorConfig` dataclass - complete refactor configuration
-- `DataMigrationSpec` dataclass - data migration settings
-- `load_refactor_config()` - load from YAML
-- `create_default_rename_config()` - generate rename starter config
-- `create_default_deprecation_config()` - generate deprecation starter config
-
-**`refactor/renamer.py`**
-- `OntologyRenamer` class - core URI renaming
-- `RenameResult` dataclass - rename outcome with stats
-- `RenameStats` dataclass - rename statistics
-- `rename_file()` - convenience function for single file
-- `rename_files()` - batch processing
-- Namespace bulk rename (all URIs in namespace)
-- Explicit entity rename (individual URIs)
-- Predicate position handling
-- Literals intentionally NOT modified
-
-**`refactor/deprecator.py`**
-- `OntologyDeprecator` class - deprecation workflow
-- `DeprecationResult` dataclass - deprecation outcome
-- `DeprecationStats` dataclass - deprecation statistics
-- `EntityDeprecationInfo` dataclass - per-entity details
-- `deprecate_file()` - convenience function
-- Adds `owl:deprecated true`
-- Adds `dcterms:isReplacedBy` when replacement specified
-- Prepends "DEPRECATED:" to `rdfs:comment`
-- Preserves all existing entity properties
-
-**`refactor/formatters/text.py`**
-- `TextFormatter` - dry-run preview formatting
-- `format_rename_preview()` - rename preview output
-- `format_rename_result()` - rename result summary
-- `format_deprecation_preview()` - deprecation preview output
-- `format_deprecation_result()` - deprecation result summary
-- Coloured terminal output support
-
----
-
 ### `puml2rdf` Module
 
 Convert PlantUML class diagrams to RDF/OWL ontologies.
@@ -707,6 +640,72 @@ Comprehensive ontology metrics and comparison.
 - `text.py` - Aligned columns for terminal
 - `json.py` - Machine-readable JSON
 - `markdown.py` - README-ready tables
+
+### Refactor Module (`refactor/`)
+
+Rename URIs and deprecate entities in ontologies.
+
+**`refactor/__init__.py`**
+- Public API exports
+- `EntityRenamer`, `EntityDeprecator`, `RenameConfig`, `DeprecateConfig`
+
+**`refactor/config.py`**
+- `RenameConfig` dataclass - rename operation settings
+- `DeprecateConfig` dataclass - deprecation settings
+- `DeprecationSpec` dataclass - single deprecation specification
+- YAML configuration loading
+
+**`refactor/renamer.py`**
+- `EntityRenamer` class - rename URIs in graphs
+- Single entity and bulk namespace renames
+- Data graph migration support
+- Dry-run preview mode
+
+**`refactor/deprecator.py`**
+- `EntityDeprecator` class - mark entities as deprecated
+- Adds owl:deprecated, dcterms:isReplacedBy, rdfs:comment
+- Version tagging in deprecation messages
+- Batch deprecation from configuration
+
+**`refactor/formatters/`**
+- `text.py` - Console output with colour support
+
+### Localise Module (`localise/`)
+
+Multi-language translation management for ontologies.
+
+**`localise/__init__.py`**
+- Public API exports
+- `StringExtractor`, `TranslationMerger`, `CoverageReporter`
+- `extract_strings()`, `merge_translations()`, `generate_coverage_report()`
+
+**`localise/config.py`**
+- `TranslationStatus` enum - pending, needs_review, translated, approved
+- `TranslationEntry` dataclass - single translation item
+- `EntityTranslations` dataclass - translations for one entity
+- `TranslationFile` dataclass - complete translation file with YAML I/O
+- `ExtractConfig`, `MergeConfig`, `LocaliseConfig` - operation settings
+
+**`localise/extractor.py`**
+- `StringExtractor` class - extract translatable strings from graphs
+- Property-aware extraction (rdfs:label, rdfs:comment, skos:prefLabel, etc.)
+- Missing-only mode for incremental updates
+- Deprecated entity filtering
+
+**`localise/merger.py`**
+- `TranslationMerger` class - merge translations back into graphs
+- Status filtering (only include translated/approved)
+- Preserve or overwrite existing translations
+- Multi-file merge support
+
+**`localise/reporter.py`**
+- `CoverageReporter` class - analyse translation coverage
+- Per-language and per-property statistics
+- Missing entity tracking
+
+**`localise/formatters/`**
+- `text.py` - Console output with colour support
+- `markdown.py` - Markdown report generation
 
 ### UML Module (`uml/`)
 
@@ -833,6 +832,8 @@ poetry run pytest tests/test_stats.py -v
 poetry run pytest tests/test_lint.py -v
 poetry run pytest tests/test_merge.py -v
 poetry run pytest tests/test_split.py -v
+poetry run pytest tests/test_refactor.py -v
+poetry run pytest tests/test_localise.py -v
 
 # Format code
 black src/ tests/
@@ -865,6 +866,10 @@ mypy src/
 - PlantUML to RDF conversion
 - Competency question testing
 - Ontology statistics with comparison
+- Ontology merging with conflict detection
+- Ontology splitting into modules
+- URI renaming and entity deprecation
+- Multi-language translation management
 - CLI and programmatic API
 
 ### Future Features

--- a/README.md
+++ b/README.md
@@ -19,7 +19,8 @@
 - **Semantic Diff**: Compare ontology versions and identify meaningful changes
 - **Ontology Merging**: Combine multiple ontologies with conflict detection and data migration
 - **Ontology Splitting**: Split monolithic ontologies into modules with dependency tracking
-- **Ontology Refactoring**: Rename URIs (typos, namespace changes) and deprecate entities
+- **Ontology Refactoring**: Rename URIs and deprecate entities with OWL annotations
+- **Multi-Language Support**: Extract, translate, and merge translations for internationalised ontologies
 - **Ontology Linting**: Check quality with 11 configurable rules
 - **Competency Question Testing**: Validate ontologies against SPARQL-based tests
 - **Ontology Statistics**: Comprehensive metrics with comparison mode
@@ -186,6 +187,18 @@ rdf-construct refactor deprecate ontology.ttl \
 rdf-construct refactor rename ontology.ttl --from "ex:Old" --to "ex:New" --dry-run
 ```
 
+### Multi-Language Translations
+```bash
+# Extract strings for German translation
+rdf-construct localise extract ontology.ttl --language de -o translations/de.yml
+
+# Merge completed translations
+rdf-construct localise merge ontology.ttl translations/de.yml -o localised.ttl
+
+# Check translation coverage
+rdf-construct localise report ontology.ttl --languages en,de,fr
+```
+
 ## Documentation
 
 📚 **[Complete Documentation](docs/index.md)** - Start here
@@ -202,6 +215,7 @@ rdf-construct refactor rename ontology.ttl --from "ex:Old" --to "ex:New" --dry-r
 - [Stats Guide](docs/user_guides/STATS_GUIDE.md) - Ontology metrics
 - [Merge Guide](docs/user_guides/MERGE_GUIDE.md) - Combining ontologies
 - [Refactor Guide](docs/user_guides/REFACTOR_GUIDE.md) - Renaming and deprecation
+- [Localise Guide](docs/user_guides/LOCALISE_GUIDE.md) - Multi-language translations
 - [CLI Reference](docs/user_guides/CLI_REFERENCE.md) - All commands and options
 
 **For Developers**:

--- a/docs/index.md
+++ b/docs/index.md
@@ -14,6 +14,7 @@
 **Merge Ontologies?** → [Merge Guide](user_guides/MERGE_GUIDE.md)
 **Split Ontologies?** → [Merge Guide](user_guides/MERGE_GUIDE.md#split-command)
 **Refactor URIs?** → [Refactor Guide](user_guides/REFACTOR_GUIDE.md)
+**Multi-Language Support?** → [Localise Guide](user_guides/LOCALISE_GUIDE.md)
 **Need Command Syntax?** → [CLI Reference](user_guides/CLI_REFERENCE.md)  
 **Quick Cheat Sheet?** → [Quick Reference](user_guides/QUICK_REFERENCE.md)  
 **Contributing?** → [Contributing Guide](../CONTRIBUTING.md)  
@@ -99,6 +100,12 @@ For users of rdf-construct who want to generate diagrams and work with RDF ontol
   - Data migration for instance graphs
   - Dry-run preview mode
 
+- **[Localise Guide](user_guides/LOCALISE_GUIDE.md)** - Multi-language translation
+  - Extract translatable strings to YAML
+  - Merge completed translations back
+  - Translation coverage reports
+  - Status tracking workflow
+
 - **[CLI Reference](user_guides/CLI_REFERENCE.md)** - Command reference
   - All commands with options
   - Configuration file formats
@@ -154,6 +161,7 @@ A Python CLI toolkit for RDF operations:
 - **Ontology Merging**: Combine multiple ontologies with conflict detection and data migration
 - **Ontology Splitting**: Split monolithic ontologies into modules with dependency tracking
 - **Ontology Refactoring**: Rename URIs and deprecate entities with proper OWL annotations
+- **Multi-Language Support**: Extract, translate, and merge translations for internationalised ontologies
 - **Ontology Linting**: Check ontology quality with configurable rules
 - **Competency Question Testing**: Validate ontologies against SPARQL-based tests
 - **Ontology Statistics**: Comprehensive metrics with comparison mode
@@ -317,6 +325,18 @@ poetry run rdf-construct refactor rename ontology.ttl \
 poetry run rdf-construct refactor deprecate ontology.ttl \
   --entity "ex:LegacyClass" --replaced-by "ex:NewClass" \
   --message "Use NewClass instead." -o updated.ttl
+```
+
+### Multi-Language Translations
+```bash
+# Extract strings for German translation
+poetry run rdf-construct localise extract ontology.ttl --language de -o translations/de.yml
+
+# Merge completed translations
+poetry run rdf-construct localise merge ontology.ttl translations/de.yml -o localised.ttl
+
+# Check translation coverage
+poetry run rdf-construct localise report ontology.ttl --languages en,de,fr
 ```
 
 ## Repository

--- a/docs/user_guides/CLI_REFERENCE.md
+++ b/docs/user_guides/CLI_REFERENCE.md
@@ -864,6 +864,223 @@ ex:LegacyTerm
 
 ---
 
+### localise - Multi-Language Translation Management
+
+Manage translations for multi-language ontology support.
+
+```bash
+rdf-construct localise <subcommand> [OPTIONS]
+```
+
+**Subcommands**:
+- `extract` - Extract translatable strings to YAML
+- `merge` - Merge translations back into ontology
+- `report` - Generate translation coverage report
+- `init` - Create empty translation file for new language
+- `config` - Generate default configuration
+
+---
+
+#### localise extract
+
+Extract translatable strings from an ontology to a YAML file.
+
+```bash
+rdf-construct localise extract SOURCE [OPTIONS]
+```
+
+**Arguments**:
+- `SOURCE`: RDF ontology file (.ttl, .rdf, .owl)
+
+**Options**:
+- `-l, --language CODE`: Target language code (required, e.g., de, fr, es)
+- `-o, --output PATH`: Output YAML file (default: {language}.yml)
+- `--source-language CODE`: Source language code (default: en)
+- `-p, --properties PROPS`: Comma-separated properties to extract (e.g., rdfs:label,rdfs:comment)
+- `--include-deprecated`: Include deprecated entities
+- `--missing-only`: Only extract strings missing in target language
+- `-c, --config PATH`: YAML configuration file
+
+**Examples**:
+```bash
+# Basic extraction for German
+rdf-construct localise extract ontology.ttl --language de -o translations/de.yml
+
+# Extract only labels
+rdf-construct localise extract ontology.ttl -l de -p rdfs:label,skos:prefLabel
+
+# Extract missing strings only (for updates)
+rdf-construct localise extract ontology.ttl -l de --missing-only -o de_update.yml
+
+# Include deprecated entities
+rdf-construct localise extract ontology.ttl -l fr --include-deprecated
+```
+
+---
+
+#### localise merge
+
+Merge translation files back into an ontology.
+
+```bash
+rdf-construct localise merge SOURCE TRANSLATIONS... [OPTIONS]
+```
+
+**Arguments**:
+- `SOURCE`: RDF ontology file
+- `TRANSLATIONS`: One or more translation YAML files
+
+**Options**:
+- `-o, --output PATH`: Output file for merged ontology (required)
+- `--status STATUS`: Minimum status to include (pending|needs_review|translated|approved, default: translated)
+- `--existing STRATEGY`: How to handle existing translations (preserve|overwrite, default: preserve)
+- `--dry-run`: Preview changes without writing files
+- `--no-colour`: Disable coloured output
+
+**Examples**:
+```bash
+# Merge single translation file
+rdf-construct localise merge ontology.ttl de.yml -o localised.ttl
+
+# Merge multiple languages
+rdf-construct localise merge ontology.ttl translations/*.yml -o multilingual.ttl
+
+# Merge only approved translations
+rdf-construct localise merge ontology.ttl de.yml --status approved -o localised.ttl
+
+# Overwrite existing translations
+rdf-construct localise merge ontology.ttl de.yml --existing overwrite -o updated.ttl
+
+# Preview changes
+rdf-construct localise merge ontology.ttl de.yml -o output.ttl --dry-run
+```
+
+---
+
+#### localise report
+
+Generate translation coverage report.
+
+```bash
+rdf-construct localise report SOURCE [OPTIONS]
+```
+
+**Arguments**:
+- `SOURCE`: RDF ontology file
+
+**Options**:
+- `-l, --languages CODES`: Comma-separated language codes to check (required, e.g., en,de,fr)
+- `--source-language CODE`: Base language for translations (default: en)
+- `-p, --properties PROPS`: Comma-separated properties to check
+- `-o, --output PATH`: Output file for report
+- `-f, --format FORMAT`: Output format (text|markdown, default: text)
+- `-v, --verbose`: Show detailed missing translation list
+- `--no-colour`: Disable coloured output
+
+**Examples**:
+```bash
+# Basic coverage report
+rdf-construct localise report ontology.ttl --languages en,de,fr
+
+# Detailed report with missing entities
+rdf-construct localise report ontology.ttl -l en,de,fr --verbose
+
+# Markdown report to file
+rdf-construct localise report ontology.ttl -l en,de,fr -f markdown -o coverage.md
+
+# Check specific properties only
+rdf-construct localise report ontology.ttl -l en,de -p rdfs:label,skos:prefLabel
+```
+
+---
+
+#### localise init
+
+Create empty translation file for a new language (equivalent to extract).
+
+```bash
+rdf-construct localise init SOURCE [OPTIONS]
+```
+
+**Arguments**:
+- `SOURCE`: RDF ontology file
+
+**Options**:
+- `-l, --language CODE`: Target language code (required)
+- `-o, --output PATH`: Output YAML file (default: {language}.yml)
+- `--source-language CODE`: Source language code (default: en)
+
+**Examples**:
+```bash
+# Initialise Japanese translation
+rdf-construct localise init ontology.ttl --language ja -o translations/ja.yml
+```
+
+---
+
+#### localise config
+
+Generate or manage localise configuration.
+
+```bash
+rdf-construct localise config [OPTIONS]
+```
+
+**Options**:
+- `--init`: Generate a default localise configuration file
+
+**Examples**:
+```bash
+# Generate default config
+rdf-construct localise config --init
+```
+
+**Translation File Format**:
+```yaml
+metadata:
+  source_file: ontology.ttl
+  source_language: en
+  target_language: de
+  generated: 2025-01-15T10:30:00
+  properties:
+    - rdfs:label
+    - rdfs:comment
+
+entities:
+  - uri: http://example.org/ont#Building
+    type: owl:Class
+    labels:
+      - property: rdfs:label
+        source: Building
+        translation: Gebäude
+        status: translated
+      - property: rdfs:comment
+        source: A permanent structure
+        translation: ""
+        status: pending
+
+summary:
+  total_entities: 42
+  total_strings: 84
+  by_status:
+    pending: 40
+    translated: 44
+  coverage: "52.4%"
+```
+
+**Status Values**:
+- `pending`: Not yet translated (empty translation field)
+- `needs_review`: Translation uncertain, needs review
+- `translated`: Translation complete
+- `approved`: Translation reviewed and approved
+
+**Exit Codes**:
+- `0`: Success
+- `1`: Success with warnings
+- `2`: Error
+
+---
+
 ### cq-test - Run Competency Question Tests
 
 Validate ontologies against SPARQL-based competency questions.

--- a/docs/user_guides/LOCALISE_GUIDE.md
+++ b/docs/user_guides/LOCALISE_GUIDE.md
@@ -1,0 +1,408 @@
+# Localise Guide
+
+The `localise` command helps manage translations in RDF ontologies. It provides tools to extract translatable strings, merge completed translations, and track translation coverage across languages.
+
+## Overview
+
+Standards like IES require labels in multiple languages. The localise workflow makes this manageable:
+
+1. **Extract** translatable strings to YAML files for translators
+2. **Translate** the YAML files (manually or with translation tools)
+3. **Merge** completed translations back into the ontology
+4. **Report** on translation coverage to track progress
+
+## Quick Start
+
+```bash
+# Extract strings for German translation
+rdf-construct localise extract ontology.ttl --language de -o translations/de.yml
+
+# Send de.yml to translator, then merge when complete
+rdf-construct localise merge ontology.ttl translations/de.yml -o localised.ttl
+
+# Check coverage across languages
+rdf-construct localise report ontology.ttl --languages en,de,fr
+```
+
+## Commands
+
+### `localise extract`
+
+Extracts translatable strings from an ontology into a YAML file ready for translation.
+
+```bash
+# Basic extraction
+rdf-construct localise extract ontology.ttl --language de -o de.yml
+
+# Extract specific properties only
+rdf-construct localise extract ontology.ttl -l de \
+    -p rdfs:label,rdfs:comment -o de.yml
+
+# Extract only missing translations (for updates)
+rdf-construct localise extract ontology.ttl -l de --missing-only -o de_update.yml
+
+# Include deprecated entities
+rdf-construct localise extract ontology.ttl -l de --include-deprecated -o de.yml
+```
+
+#### Options
+
+| Option | Description |
+|--------|-------------|
+| `--language, -l` | Target language code (required) |
+| `--output, -o` | Output YAML file (default: `{language}.yml`) |
+| `--source-language` | Source language (default: `en`) |
+| `--properties, -p` | Comma-separated properties to extract |
+| `--include-deprecated` | Include deprecated entities |
+| `--missing-only` | Only extract strings without target translations |
+| `--config, -c` | YAML configuration file |
+
+#### Default Properties
+
+By default, these properties are extracted:
+
+- `rdfs:label`
+- `rdfs:comment`
+- `skos:prefLabel`
+- `skos:definition`
+
+### `localise merge`
+
+Merges completed translation files back into an ontology, adding new language-tagged literals.
+
+```bash
+# Merge single file
+rdf-construct localise merge ontology.ttl de.yml -o localised.ttl
+
+# Merge multiple languages
+rdf-construct localise merge ontology.ttl translations/*.yml -o multilingual.ttl
+
+# Merge only approved translations
+rdf-construct localise merge ontology.ttl de.yml --status approved -o localised.ttl
+
+# Preview without writing (dry run)
+rdf-construct localise merge ontology.ttl de.yml -o test.ttl --dry-run
+```
+
+#### Options
+
+| Option | Description |
+|--------|-------------|
+| `--output, -o` | Output file (required) |
+| `--status` | Minimum status to include: `pending`, `needs_review`, `translated`, `approved` |
+| `--existing` | How to handle existing translations: `preserve` or `overwrite` |
+| `--dry-run` | Show what would happen without writing |
+| `--no-colour` | Disable coloured output |
+
+#### Status Filtering
+
+Translations have a status field that tracks their progress:
+
+- `pending` - Not yet translated
+- `needs_review` - Translated but uncertain
+- `translated` - Translation complete
+- `approved` - Reviewed and approved
+
+By default, only `translated` and `approved` entries are merged. Use `--status pending` to include all entries.
+
+### `localise report`
+
+Generates a translation coverage report showing what percentage of content has been translated.
+
+```bash
+# Basic report
+rdf-construct localise report ontology.ttl --languages en,de,fr
+
+# Detailed report with missing entities
+rdf-construct localise report ontology.ttl -l en,de,fr --verbose
+
+# Markdown report to file
+rdf-construct localise report ontology.ttl -l en,de,fr -f markdown -o coverage.md
+
+# Check specific properties
+rdf-construct localise report ontology.ttl -l en,de -p rdfs:label
+```
+
+#### Options
+
+| Option | Description |
+|--------|-------------|
+| `--languages, -l` | Comma-separated language codes (required) |
+| `--source-language` | Base language (default: `en`) |
+| `--properties, -p` | Comma-separated properties to check |
+| `--output, -o` | Output file for report |
+| `--format, -f` | Output format: `text` or `markdown` |
+| `--verbose, -v` | Show detailed missing translation list |
+| `--no-colour` | Disable coloured output |
+
+#### Example Output
+
+```
+Translation Coverage Report
+========================================
+
+Source: ontology.ttl
+Entities: 57
+Properties: rdfs:label, rdfs:comment
+
+Language    rdfs:label  rdfs:comment  Overall  Status
+--------    ----------  ------------  -------  ------
+en (base)   100%        89%           94%      ✓ Complete
+de          92%         45%           68%      ⚠ 14 pending
+fr          78%         12%           45%      ⚠ 58 pending
+es          0%          0%            0%       ✗ Not started
+```
+
+### `localise init`
+
+Creates an empty translation file for a new language. This is equivalent to `extract` but emphasises starting fresh.
+
+```bash
+rdf-construct localise init ontology.ttl --language ja -o translations/ja.yml
+```
+
+### `localise config`
+
+Generates a default configuration file for localisation workflows.
+
+```bash
+rdf-construct localise config --init
+```
+
+## Translation File Format
+
+The YAML translation file format is designed to be:
+
+- **Readable** - Clear structure for translators
+- **Editable** - Easy to fill in with a text editor
+- **Trackable** - Status field for progress tracking
+
+### Example Translation File
+
+```yaml
+# =============================================================================
+# Translation File
+# =============================================================================
+# Source: ontology.ttl
+# Source language: en
+# Target language: de
+# Generated: 2025-01-15T10:30:00
+#
+# Instructions:
+# 1. Fill in the 'translation' field for each entry
+# 2. Set 'status' to 'translated' when complete
+# 3. Use 'needs_review' if uncertain about translation
+# 4. Leave 'status' as 'pending' for incomplete entries
+# =============================================================================
+
+metadata:
+  source_file: ontology.ttl
+  source_language: en
+  target_language: de
+  generated: 2025-01-15T10:30:00
+  tool: rdf-construct localise
+  properties:
+    - rdfs:label
+    - rdfs:comment
+
+entities:
+  - uri: "http://example.org/ont#Building"
+    type: owl:Class
+    labels:
+      - property: rdfs:label
+        source: "Building"
+        translation: "Gebäude"
+        status: translated
+
+      - property: rdfs:comment
+        source: "A permanent structure with walls and roof."
+        translation: "Ein dauerhaftes Bauwerk mit Wänden und Dach."
+        status: translated
+
+  - uri: "http://example.org/ont#SmartBuilding"
+    type: owl:Class
+    labels:
+      - property: rdfs:label
+        source: "Smart Building"
+        translation: ""
+        status: pending
+
+      - property: rdfs:comment
+        source: "A building with automated systems."
+        translation: ""
+        status: pending
+        notes: "Consider: 'intelligentes Gebäude' or 'Smart Building'"
+
+summary:
+  total_entities: 2
+  total_strings: 4
+  by_status:
+    translated: 2
+    pending: 2
+  coverage: "50.0%"
+```
+
+### Translation Status Values
+
+| Status | Meaning |
+|--------|---------|
+| `pending` | Not yet translated |
+| `needs_review` | Translation needs verification |
+| `translated` | Translation complete |
+| `approved` | Reviewed and confirmed |
+
+### Notes Field
+
+Add the optional `notes` field to include guidance for translators:
+
+```yaml
+- property: rdfs:label
+  source: "Smart Building"
+  translation: ""
+  status: pending
+  notes: "Technical term - consider keeping English or using 'intelligentes Gebäude'"
+```
+
+## Configuration File
+
+For complex workflows, use a YAML configuration file:
+
+```yaml
+# localise.yml
+localise:
+  # Properties to extract (in display order)
+  properties:
+    - rdfs:label
+    - skos:prefLabel
+    - rdfs:comment
+    - skos:definition
+    - skos:altLabel
+
+  # Language configuration
+  languages:
+    source: en
+    targets:
+      - de
+      - fr
+      - es
+
+  # Output settings
+  output:
+    directory: translations/
+    naming: "{language}.yml"
+
+  # Extraction options
+  extract:
+    include_unlabelled: false
+    include_deprecated: false
+
+  # Merge options
+  merge:
+    existing: preserve      # preserve | overwrite
+    min_status: translated  # pending | needs_review | translated | approved
+```
+
+Use the config file:
+
+```bash
+rdf-construct localise extract ontology.ttl -l de -c localise.yml
+```
+
+## Workflow Examples
+
+### Complete Translation Workflow
+
+```bash
+# 1. Set up directory structure
+mkdir -p translations
+
+# 2. Extract for all target languages
+for lang in de fr es; do
+    rdf-construct localise extract ontology.ttl -l $lang -o translations/$lang.yml
+done
+
+# 3. Check initial coverage
+rdf-construct localise report ontology.ttl -l en,de,fr,es
+
+# 4. After translations are complete, merge them
+rdf-construct localise merge ontology.ttl translations/*.yml -o ontology_multilingual.ttl
+
+# 5. Verify final coverage
+rdf-construct localise report ontology_multilingual.ttl -l en,de,fr,es
+```
+
+### Incremental Translation Updates
+
+When the source ontology changes, extract only new strings:
+
+```bash
+# Extract only missing translations
+rdf-construct localise extract ontology.ttl -l de --missing-only -o translations/de_new.yml
+
+# Translator fills in de_new.yml, then merge
+rdf-construct localise merge ontology.ttl translations/de_new.yml -o ontology.ttl
+```
+
+### Quality-Controlled Workflow
+
+Use the status field for a review workflow:
+
+```bash
+# Translator marks entries as 'translated'
+# Reviewer marks approved entries as 'approved'
+
+# First merge: only approved translations
+rdf-construct localise merge ontology.ttl de.yml --status approved -o stable.ttl
+
+# Later: include all translations for testing
+rdf-construct localise merge ontology.ttl de.yml --status translated -o beta.ttl
+```
+
+## Best Practices
+
+### 1. Version Control Translation Files
+
+Keep translation YAML files in version control alongside your ontology. This provides:
+- History of translation changes
+- Easy collaboration with multiple translators
+- Ability to revert problematic translations
+
+### 2. Use Meaningful Status Values
+
+- Mark uncertain translations as `needs_review`
+- Only mark as `translated` when confident
+- Use `approved` for reviewed translations in production workflows
+
+### 3. Document Special Terms
+
+Use the `notes` field to explain:
+- Technical terms that should remain in English
+- Multiple valid translations
+- Context-specific meanings
+
+### 4. Regular Coverage Reports
+
+Generate coverage reports before releases:
+
+```bash
+rdf-construct localise report ontology.ttl -l en,de,fr \
+    -f markdown -o docs/translation_coverage.md
+```
+
+### 5. Handle Untagged Literals
+
+The extractor treats literals without language tags as the source language. If your ontology uses untagged English literals, they will be extracted for translation.
+
+## Exit Codes
+
+| Code | Meaning |
+|------|---------|
+| 0 | Success |
+| 1 | Success with warnings (some translations skipped) |
+| 2 | Error (file not found, invalid format) |
+
+## Related Commands
+
+- `rdf-construct lint` - Check for missing labels (undocumented entities)
+- `rdf-construct docs` - Generate documentation including all language labels
+- `rdf-construct diff` - Compare ontology versions (including label changes)

--- a/examples/localise/config.yml
+++ b/examples/localise/config.yml
@@ -1,0 +1,60 @@
+# rdf-construct localise configuration
+# Example configuration for multi-language translation management
+#
+# Usage:
+#   rdf-construct localise extract ontology.ttl -l de -c localise_config.yml
+#   rdf-construct localise merge ontology.ttl translations/de.yml -o localised.ttl
+
+localise:
+  # Properties to extract/check (in display order)
+  # These are the properties that will be extracted for translation
+  # and checked in coverage reports
+  properties:
+    - rdfs:label
+    - skos:prefLabel
+    - rdfs:comment
+    - skos:definition
+    - skos:altLabel
+    - skos:example
+
+  # Language configuration
+  languages:
+    # Base language - source text will be extracted from this language
+    source: en
+    # Target languages - translation files will be generated for these
+    targets:
+      - de    # German
+      - fr    # French
+      - es    # Spanish
+
+  # Output settings for generated translation files
+  output:
+    # Directory to store translation files
+    directory: translations/
+    # Naming pattern for output files
+    # {language} will be replaced with the language code
+    naming: "{language}.yml"
+
+  # Extraction options
+  extract:
+    # Include entities without source language labels?
+    # If true, extracts all entities even if they don't have English labels
+    include_unlabelled: false
+
+    # Include deprecated entities?
+    # If true, extracts labels from deprecated classes/properties
+    include_deprecated: false
+
+  # Merge options
+  merge:
+    # How to handle existing translations in the ontology
+    # - preserve: Keep existing translations (don't overwrite)
+    # - overwrite: Replace existing translations with new values
+    existing: preserve
+
+    # Minimum status required to include a translation in merge
+    # - pending: Include all entries (even empty)
+    # - needs_review: Include translated entries that need review
+    # - translated: Include only completed translations (default)
+    # - approved: Include only reviewed and approved translations
+    min_status: translated

--- a/src/rdf_construct/localise/__init__.py
+++ b/src/rdf_construct/localise/__init__.py
@@ -1,0 +1,114 @@
+"""Localise module for multi-language translation management.
+
+This module provides tools for managing translations in RDF ontologies:
+- Extract translatable strings to YAML files for translators
+- Merge completed translations back into ontologies
+- Report on translation coverage across languages
+
+Example usage:
+    from rdf_construct.localise import (
+        StringExtractor,
+        TranslationMerger,
+        CoverageReporter,
+        extract_strings,
+        merge_translations,
+        generate_coverage_report,
+    )
+
+    # Extract strings for German translation
+    result = extract_strings(
+        source=Path("ontology.ttl"),
+        target_language="de",
+        output=Path("translations/de.yml"),
+    )
+
+    # Merge completed translations
+    result = merge_translations(
+        source=Path("ontology.ttl"),
+        translation_files=[Path("translations/de.yml")],
+        output=Path("localised.ttl"),
+    )
+
+    # Generate coverage report
+    report = generate_coverage_report(
+        source=Path("ontology.ttl"),
+        languages=["en", "de", "fr"],
+    )
+"""
+
+from rdf_construct.localise.config import (
+    TranslationStatus,
+    TranslationEntry,
+    EntityTranslations,
+    TranslationFile,
+    TranslationFileMetadata,
+    TranslationSummary,
+    ExtractConfig,
+    MergeConfig,
+    ExistingStrategy,
+    LocaliseConfig,
+    create_default_config,
+    load_localise_config,
+)
+
+from rdf_construct.localise.extractor import (
+    StringExtractor,
+    ExtractionResult,
+    extract_strings,
+)
+
+from rdf_construct.localise.merger import (
+    TranslationMerger,
+    MergeResult,
+    MergeStats,
+    merge_translations,
+)
+
+from rdf_construct.localise.reporter import (
+    CoverageReporter,
+    CoverageReport,
+    LanguageCoverage,
+    PropertyCoverage,
+    generate_coverage_report,
+)
+
+from rdf_construct.localise.formatters import (
+    TextFormatter,
+    MarkdownFormatter,
+    get_formatter,
+)
+
+__all__ = [
+    # Config
+    "TranslationStatus",
+    "TranslationEntry",
+    "EntityTranslations",
+    "TranslationFile",
+    "TranslationFileMetadata",
+    "TranslationSummary",
+    "ExtractConfig",
+    "MergeConfig",
+    "ExistingStrategy",
+    "LocaliseConfig",
+    "create_default_config",
+    "load_localise_config",
+    # Extractor
+    "StringExtractor",
+    "ExtractionResult",
+    "extract_strings",
+    # Merger
+    "TranslationMerger",
+    "MergeResult",
+    "MergeStats",
+    "merge_translations",
+    # Reporter
+    "CoverageReporter",
+    "CoverageReport",
+    "LanguageCoverage",
+    "PropertyCoverage",
+    "generate_coverage_report",
+    # Formatters
+    "TextFormatter",
+    "MarkdownFormatter",
+    "get_formatter",
+]

--- a/src/rdf_construct/localise/config.py
+++ b/src/rdf_construct/localise/config.py
@@ -1,0 +1,508 @@
+"""Configuration dataclasses for the localise command.
+
+Defines configuration structures for:
+- Translation entries and files
+- Extraction settings
+- Merge settings
+- Coverage reporting
+"""
+
+from dataclasses import dataclass, field
+from datetime import datetime
+from enum import Enum
+from pathlib import Path
+from typing import Any, Literal
+
+import yaml
+from rdflib import URIRef
+
+
+class TranslationStatus(str, Enum):
+    """Status of a translation entry."""
+
+    PENDING = "pending"
+    TRANSLATED = "translated"
+    NEEDS_REVIEW = "needs_review"
+    APPROVED = "approved"
+
+    def __str__(self) -> str:
+        return self.value
+
+
+@dataclass
+class TranslationEntry:
+    """A single translation entry for a property.
+
+    Attributes:
+        property: URI of the property (e.g., rdfs:label).
+        source_text: Original text in source language.
+        translation: Translated text (empty if pending).
+        status: Translation status.
+        notes: Optional notes for translators.
+    """
+
+    property: str
+    source_text: str
+    translation: str = ""
+    status: TranslationStatus = TranslationStatus.PENDING
+    notes: str | None = None
+
+    def to_dict(self) -> dict[str, Any]:
+        """Convert to dictionary for YAML serialisation."""
+        result: dict[str, Any] = {
+            "property": self.property,
+            "source": self.source_text,
+            "translation": self.translation,
+            "status": str(self.status),
+        }
+        if self.notes:
+            result["notes"] = self.notes
+        return result
+
+    @classmethod
+    def from_dict(cls, data: dict[str, Any]) -> "TranslationEntry":
+        """Create from dictionary."""
+        return cls(
+            property=data["property"],
+            source_text=data["source"],
+            translation=data.get("translation", ""),
+            status=TranslationStatus(data.get("status", "pending")),
+            notes=data.get("notes"),
+        )
+
+
+@dataclass
+class EntityTranslations:
+    """Translation entries for a single entity.
+
+    Attributes:
+        uri: URI of the entity.
+        entity_type: Type of entity (owl:Class, owl:ObjectProperty, etc.).
+        labels: List of translation entries for this entity.
+    """
+
+    uri: str
+    entity_type: str
+    labels: list[TranslationEntry] = field(default_factory=list)
+
+    def to_dict(self) -> dict[str, Any]:
+        """Convert to dictionary for YAML serialisation."""
+        return {
+            "uri": self.uri,
+            "type": self.entity_type,
+            "labels": [entry.to_dict() for entry in self.labels],
+        }
+
+    @classmethod
+    def from_dict(cls, data: dict[str, Any]) -> "EntityTranslations":
+        """Create from dictionary."""
+        return cls(
+            uri=data["uri"],
+            entity_type=data.get("type", "unknown"),
+            labels=[TranslationEntry.from_dict(entry) for entry in data.get("labels", [])],
+        )
+
+
+@dataclass
+class TranslationFileMetadata:
+    """Metadata for a translation file.
+
+    Attributes:
+        source_file: Original ontology file path.
+        source_language: Source language code (e.g., "en").
+        target_language: Target language code (e.g., "de").
+        generated: Timestamp when file was generated.
+        properties: List of properties extracted.
+        tool_version: Version of rdf-construct that generated this file.
+    """
+
+    source_file: str
+    source_language: str
+    target_language: str
+    generated: datetime
+    properties: list[str] = field(default_factory=list)
+    tool_version: str = "rdf-construct"
+
+    def to_dict(self) -> dict[str, Any]:
+        """Convert to dictionary for YAML serialisation."""
+        return {
+            "source_file": self.source_file,
+            "source_language": self.source_language,
+            "target_language": self.target_language,
+            "generated": self.generated.isoformat(),
+            "tool": self.tool_version,
+            "properties": self.properties,
+        }
+
+    @classmethod
+    def from_dict(cls, data: dict[str, Any]) -> "TranslationFileMetadata":
+        """Create from dictionary."""
+        generated = data.get("generated")
+        if isinstance(generated, str):
+            generated = datetime.fromisoformat(generated)
+        elif generated is None:
+            generated = datetime.now()
+
+        return cls(
+            source_file=data.get("source_file", ""),
+            source_language=data.get("source_language", "en"),
+            target_language=data.get("target_language", ""),
+            generated=generated,
+            properties=data.get("properties", []),
+            tool_version=data.get("tool", "rdf-construct"),
+        )
+
+
+@dataclass
+class TranslationSummary:
+    """Summary statistics for a translation file.
+
+    Attributes:
+        total_entities: Total number of entities.
+        total_strings: Total number of translatable strings.
+        by_status: Count of strings by status.
+    """
+
+    total_entities: int = 0
+    total_strings: int = 0
+    by_status: dict[str, int] = field(default_factory=dict)
+
+    @property
+    def translated(self) -> int:
+        """Number of translated strings."""
+        return self.by_status.get("translated", 0) + self.by_status.get("approved", 0)
+
+    @property
+    def coverage(self) -> float:
+        """Translation coverage as percentage."""
+        if self.total_strings == 0:
+            return 0.0
+        return (self.translated / self.total_strings) * 100
+
+    def to_dict(self) -> dict[str, Any]:
+        """Convert to dictionary for YAML serialisation."""
+        return {
+            "total_entities": self.total_entities,
+            "total_strings": self.total_strings,
+            "by_status": self.by_status,
+            "coverage": f"{self.coverage:.1f}%",
+        }
+
+    @classmethod
+    def from_dict(cls, data: dict[str, Any]) -> "TranslationSummary":
+        """Create from dictionary."""
+        return cls(
+            total_entities=data.get("total_entities", 0),
+            total_strings=data.get("total_strings", 0),
+            by_status=data.get("by_status", {}),
+        )
+
+
+@dataclass
+class TranslationFile:
+    """A complete translation file.
+
+    Contains metadata, entity translations, and summary statistics.
+
+    Attributes:
+        metadata: File metadata.
+        entities: List of entity translations.
+        summary: Summary statistics.
+    """
+
+    metadata: TranslationFileMetadata
+    entities: list[EntityTranslations] = field(default_factory=list)
+    summary: TranslationSummary | None = None
+
+    def calculate_summary(self) -> TranslationSummary:
+        """Calculate summary statistics from entities."""
+        total_strings = 0
+        by_status: dict[str, int] = {}
+
+        for entity in self.entities:
+            for label in entity.labels:
+                total_strings += 1
+                status = str(label.status)
+                by_status[status] = by_status.get(status, 0) + 1
+
+        return TranslationSummary(
+            total_entities=len(self.entities),
+            total_strings=total_strings,
+            by_status=by_status,
+        )
+
+    def to_yaml(self) -> str:
+        """Serialise to YAML string."""
+        # Calculate summary before serialisation
+        self.summary = self.calculate_summary()
+
+        header = f"""# =============================================================================
+# Translation File
+# =============================================================================
+# Source: {self.metadata.source_file}
+# Source language: {self.metadata.source_language}
+# Target language: {self.metadata.target_language}
+# Generated: {self.metadata.generated.isoformat()}
+#
+# Instructions:
+# 1. Fill in the 'translation' field for each entry
+# 2. Set 'status' to 'translated' when complete
+# 3. Use 'needs_review' if uncertain about translation
+# 4. Leave 'status' as 'pending' for incomplete entries
+# =============================================================================
+
+"""
+
+        data = {
+            "metadata": self.metadata.to_dict(),
+            "entities": [entity.to_dict() for entity in self.entities],
+            "summary": self.summary.to_dict(),
+        }
+
+        return header + yaml.dump(data, default_flow_style=False, allow_unicode=True, sort_keys=False)
+
+    @classmethod
+    def from_yaml(cls, path: Path) -> "TranslationFile":
+        """Load from YAML file.
+
+        Args:
+            path: Path to YAML file.
+
+        Returns:
+            TranslationFile instance.
+
+        Raises:
+            FileNotFoundError: If file doesn't exist.
+            ValueError: If file format is invalid.
+        """
+        if not path.exists():
+            raise FileNotFoundError(f"Translation file not found: {path}")
+
+        with open(path, encoding="utf-8") as f:
+            data = yaml.safe_load(f)
+
+        if not isinstance(data, dict):
+            raise ValueError(f"Invalid translation file format: {path}")
+
+        metadata = TranslationFileMetadata.from_dict(data.get("metadata", {}))
+        entities = [
+            EntityTranslations.from_dict(entity) for entity in data.get("entities", [])
+        ]
+        summary = None
+        if "summary" in data:
+            summary = TranslationSummary.from_dict(data["summary"])
+
+        return cls(metadata=metadata, entities=entities, summary=summary)
+
+    def save(self, path: Path) -> None:
+        """Save to YAML file.
+
+        Args:
+            path: Output file path.
+        """
+        path.parent.mkdir(parents=True, exist_ok=True)
+        path.write_text(self.to_yaml(), encoding="utf-8")
+
+
+class ExistingStrategy(str, Enum):
+    """How to handle existing translations in ontology."""
+
+    PRESERVE = "preserve"
+    OVERWRITE = "overwrite"
+
+
+@dataclass
+class ExtractConfig:
+    """Configuration for extraction operation.
+
+    Attributes:
+        source_language: Source language code (default: "en").
+        target_language: Target language code.
+        properties: List of properties to extract.
+        include_deprecated: Whether to include deprecated entities.
+        include_unlabelled: Whether to include entities without source labels.
+        missing_only: Only extract strings missing in target language.
+    """
+
+    source_language: str = "en"
+    target_language: str = ""
+    properties: list[str] = field(
+        default_factory=lambda: [
+            "http://www.w3.org/2000/01/rdf-schema#label",
+            "http://www.w3.org/2000/01/rdf-schema#comment",
+        ]
+    )
+    include_deprecated: bool = False
+    include_unlabelled: bool = False
+    missing_only: bool = False
+
+
+@dataclass
+class MergeConfig:
+    """Configuration for merge operation.
+
+    Attributes:
+        min_status: Minimum status required to include translation.
+        existing: How to handle existing translations.
+    """
+
+    min_status: TranslationStatus = TranslationStatus.TRANSLATED
+    existing: ExistingStrategy = ExistingStrategy.PRESERVE
+
+
+@dataclass
+class LocaliseConfig:
+    """Complete configuration for localise operations.
+
+    Attributes:
+        properties: Properties to extract/check.
+        source_language: Base language for translations.
+        target_languages: List of target language codes.
+        extract: Extraction settings.
+        merge: Merge settings.
+        output_dir: Output directory for translation files.
+        output_naming: Naming pattern for output files.
+    """
+
+    properties: list[str] = field(
+        default_factory=lambda: [
+            "http://www.w3.org/2000/01/rdf-schema#label",
+            "http://www.w3.org/2000/01/rdf-schema#comment",
+            "http://www.w3.org/2004/02/skos/core#prefLabel",
+            "http://www.w3.org/2004/02/skos/core#definition",
+        ]
+    )
+    source_language: str = "en"
+    target_languages: list[str] = field(default_factory=list)
+    extract: ExtractConfig = field(default_factory=ExtractConfig)
+    merge: MergeConfig = field(default_factory=MergeConfig)
+    output_dir: Path = field(default_factory=lambda: Path("translations"))
+    output_naming: str = "{language}.yml"
+
+    @classmethod
+    def from_yaml(cls, path: Path) -> "LocaliseConfig":
+        """Load from YAML configuration file.
+
+        Args:
+            path: Path to configuration file.
+
+        Returns:
+            LocaliseConfig instance.
+        """
+        if not path.exists():
+            raise FileNotFoundError(f"Config file not found: {path}")
+
+        with open(path, encoding="utf-8") as f:
+            data = yaml.safe_load(f)
+
+        return cls.from_dict(data.get("localise", data))
+
+    @classmethod
+    def from_dict(cls, data: dict[str, Any]) -> "LocaliseConfig":
+        """Create from dictionary.
+
+        Args:
+            data: Configuration dictionary.
+
+        Returns:
+            LocaliseConfig instance.
+        """
+        # Parse languages section
+        languages = data.get("languages", {})
+        source_language = languages.get("source", data.get("source_language", "en"))
+        target_languages = languages.get("targets", data.get("target_languages", []))
+
+        # Parse extract settings
+        extract_data = data.get("extract", {})
+        extract = ExtractConfig(
+            source_language=source_language,
+            target_language=extract_data.get("target_language", ""),
+            properties=data.get("properties", ExtractConfig().properties),
+            include_deprecated=extract_data.get("include_deprecated", False),
+            include_unlabelled=extract_data.get("include_unlabelled", False),
+            missing_only=extract_data.get("missing_only", False),
+        )
+
+        # Parse merge settings
+        merge_data = data.get("merge", {})
+        min_status_str = merge_data.get("min_status", "translated")
+        existing_str = merge_data.get("existing", "preserve")
+        merge = MergeConfig(
+            min_status=TranslationStatus(min_status_str),
+            existing=ExistingStrategy(existing_str),
+        )
+
+        # Parse output settings
+        output_data = data.get("output", {})
+        output_dir = Path(output_data.get("directory", "translations"))
+        output_naming = output_data.get("naming", "{language}.yml")
+
+        return cls(
+            properties=data.get("properties", cls().properties),
+            source_language=source_language,
+            target_languages=target_languages,
+            extract=extract,
+            merge=merge,
+            output_dir=output_dir,
+            output_naming=output_naming,
+        )
+
+
+def create_default_config() -> str:
+    """Generate default localise configuration as YAML string.
+
+    Returns:
+        YAML configuration template.
+    """
+    return '''# rdf-construct localise configuration
+# See LOCALISE_GUIDE.md for full documentation
+
+localise:
+  # Properties to extract/check (in display order)
+  properties:
+    - rdfs:label
+    - skos:prefLabel
+    - rdfs:comment
+    - skos:definition
+    - skos:altLabel
+    - skos:example
+
+  # Language configuration
+  languages:
+    source: en  # Base language for translations
+    targets:
+      - de
+      - fr
+      - es
+
+  # Output settings
+  output:
+    directory: translations/
+    naming: "{language}.yml"  # e.g., de.yml, fr.yml
+
+  # Extraction options
+  extract:
+    # Include entities without source language labels?
+    include_unlabelled: false
+    # Include deprecated entities?
+    include_deprecated: false
+
+  # Merge options
+  merge:
+    # What to do with existing translations?
+    existing: preserve  # preserve | overwrite
+    # Minimum status to include in merge
+    min_status: translated  # pending | translated | needs_review | approved
+'''
+
+
+def load_localise_config(path: Path) -> LocaliseConfig:
+    """Load localise configuration from a YAML file.
+
+    Args:
+        path: Path to configuration file.
+
+    Returns:
+        LocaliseConfig instance.
+    """
+    return LocaliseConfig.from_yaml(path)

--- a/src/rdf_construct/localise/extractor.py
+++ b/src/rdf_construct/localise/extractor.py
@@ -1,0 +1,427 @@
+"""String extraction from RDF ontologies.
+
+Extracts translatable strings (labels, comments, definitions) from ontology
+files and generates translation files in YAML format.
+"""
+
+from dataclasses import dataclass, field
+from datetime import datetime
+from pathlib import Path
+
+from rdflib import Graph, Literal, URIRef
+from rdflib.namespace import OWL, RDF, RDFS
+
+from rdf_construct.localise.config import (
+    EntityTranslations,
+    ExtractConfig,
+    TranslationEntry,
+    TranslationFile,
+    TranslationFileMetadata,
+    TranslationStatus,
+)
+
+
+# Standard property URIs
+LABEL_PROPERTIES = [
+    "http://www.w3.org/2000/01/rdf-schema#label",
+    "http://www.w3.org/2004/02/skos/core#prefLabel",
+    "http://www.w3.org/2004/02/skos/core#altLabel",
+]
+
+COMMENT_PROPERTIES = [
+    "http://www.w3.org/2000/01/rdf-schema#comment",
+    "http://www.w3.org/2004/02/skos/core#definition",
+    "http://www.w3.org/2004/02/skos/core#example",
+    "http://www.w3.org/2004/02/skos/core#note",
+    "http://www.w3.org/2004/02/skos/core#scopeNote",
+]
+
+DEFAULT_PROPERTIES = LABEL_PROPERTIES[:2] + COMMENT_PROPERTIES[:2]
+
+
+@dataclass
+class ExtractionResult:
+    """Result of a string extraction operation.
+
+    Attributes:
+        success: Whether extraction succeeded.
+        translation_file: Generated translation file.
+        total_entities: Number of entities processed.
+        total_strings: Number of strings extracted.
+        skipped_entities: Number of entities skipped.
+        error: Error message if failed.
+    """
+
+    success: bool
+    translation_file: TranslationFile | None = None
+    total_entities: int = 0
+    total_strings: int = 0
+    skipped_entities: int = 0
+    error: str | None = None
+
+
+class StringExtractor:
+    """Extracts translatable strings from RDF ontologies.
+
+    The extractor identifies entities (classes, properties, individuals) and
+    extracts text values for configured properties (rdfs:label, rdfs:comment, etc.)
+    in the source language. The output is a translation file with empty
+    translation fields ready for translators.
+    """
+
+    def __init__(self, config: ExtractConfig | None = None):
+        """Initialise the extractor.
+
+        Args:
+            config: Extraction configuration. Uses defaults if not provided.
+        """
+        self.config = config or ExtractConfig()
+
+    def extract(
+        self,
+        graph: Graph,
+        source_file: Path | str,
+        target_language: str | None = None,
+    ) -> ExtractionResult:
+        """Extract translatable strings from an RDF graph.
+
+        Args:
+            graph: RDF graph to extract from.
+            source_file: Path to source file (for metadata).
+            target_language: Override target language from config.
+
+        Returns:
+            ExtractionResult with translation file.
+        """
+        target_lang = target_language or self.config.target_language
+        if not target_lang:
+            return ExtractionResult(
+                success=False,
+                error="No target language specified",
+            )
+
+        try:
+            # Get all entities from the graph
+            entities = self._collect_entities(graph)
+
+            # Extract translations for each entity
+            entity_translations: list[EntityTranslations] = []
+            total_strings = 0
+            skipped = 0
+
+            for entity_uri, entity_type in entities:
+                # Check for deprecation
+                if not self.config.include_deprecated and self._is_deprecated(
+                    graph, entity_uri
+                ):
+                    skipped += 1
+                    continue
+
+                # Extract labels for this entity
+                labels = self._extract_entity_labels(
+                    graph,
+                    entity_uri,
+                    target_lang,
+                )
+
+                if not labels:
+                    if self.config.include_unlabelled:
+                        # Include entity with empty labels
+                        pass
+                    else:
+                        skipped += 1
+                        continue
+
+                if labels:
+                    entity_translations.append(
+                        EntityTranslations(
+                            uri=str(entity_uri),
+                            entity_type=entity_type,
+                            labels=labels,
+                        )
+                    )
+                    total_strings += len(labels)
+
+            # Build translation file
+            metadata = TranslationFileMetadata(
+                source_file=str(source_file),
+                source_language=self.config.source_language,
+                target_language=target_lang,
+                generated=datetime.now(),
+                properties=[self._shorten_property(p) for p in self.config.properties],
+            )
+
+            translation_file = TranslationFile(
+                metadata=metadata,
+                entities=entity_translations,
+            )
+
+            return ExtractionResult(
+                success=True,
+                translation_file=translation_file,
+                total_entities=len(entity_translations),
+                total_strings=total_strings,
+                skipped_entities=skipped,
+            )
+
+        except Exception as e:
+            return ExtractionResult(
+                success=False,
+                error=str(e),
+            )
+
+    def _collect_entities(self, graph: Graph) -> list[tuple[URIRef, str]]:
+        """Collect all entities from the graph with their types.
+
+        Args:
+            graph: RDF graph.
+
+        Returns:
+            List of (URI, type_string) tuples.
+        """
+        entities: list[tuple[URIRef, str]] = []
+        seen: set[URIRef] = set()
+
+        # Classes
+        for cls_type in [OWL.Class, RDFS.Class]:
+            for s in graph.subjects(RDF.type, cls_type):
+                if isinstance(s, URIRef) and s not in seen:
+                    seen.add(s)
+                    entities.append((s, "owl:Class"))
+
+        # Object Properties
+        for s in graph.subjects(RDF.type, OWL.ObjectProperty):
+            if isinstance(s, URIRef) and s not in seen:
+                seen.add(s)
+                entities.append((s, "owl:ObjectProperty"))
+
+        # Datatype Properties
+        for s in graph.subjects(RDF.type, OWL.DatatypeProperty):
+            if isinstance(s, URIRef) and s not in seen:
+                seen.add(s)
+                entities.append((s, "owl:DatatypeProperty"))
+
+        # Annotation Properties
+        for s in graph.subjects(RDF.type, OWL.AnnotationProperty):
+            if isinstance(s, URIRef) and s not in seen:
+                seen.add(s)
+                entities.append((s, "owl:AnnotationProperty"))
+
+        # RDF Properties
+        for s in graph.subjects(RDF.type, RDF.Property):
+            if isinstance(s, URIRef) and s not in seen:
+                seen.add(s)
+                entities.append((s, "rdf:Property"))
+
+        # Named Individuals
+        for s in graph.subjects(RDF.type, OWL.NamedIndividual):
+            if isinstance(s, URIRef) and s not in seen:
+                seen.add(s)
+                entities.append((s, "owl:NamedIndividual"))
+
+        # Sort by URI for consistent output
+        entities.sort(key=lambda x: str(x[0]))
+
+        return entities
+
+    def _extract_entity_labels(
+        self,
+        graph: Graph,
+        entity: URIRef,
+        target_lang: str,
+    ) -> list[TranslationEntry]:
+        """Extract label properties for a single entity.
+
+        Args:
+            graph: RDF graph.
+            entity: Entity URI.
+            target_lang: Target language code.
+
+        Returns:
+            List of TranslationEntry objects.
+        """
+        labels: list[TranslationEntry] = []
+        source_lang = self.config.source_language
+
+        for prop_uri_str in self.config.properties:
+            prop_uri = URIRef(self._expand_property(prop_uri_str))
+
+            # Find source language literals
+            source_literals = self._get_language_literals(
+                graph, entity, prop_uri, source_lang
+            )
+
+            if not source_literals:
+                continue
+
+            # Check for existing translation if missing_only mode
+            if self.config.missing_only:
+                existing = self._get_language_literals(
+                    graph, entity, prop_uri, target_lang
+                )
+                if existing:
+                    continue
+
+            for source_text in source_literals:
+                labels.append(
+                    TranslationEntry(
+                        property=self._shorten_property(str(prop_uri)),
+                        source_text=source_text,
+                        translation="",
+                        status=TranslationStatus.PENDING,
+                    )
+                )
+
+        return labels
+
+    def _get_language_literals(
+        self,
+        graph: Graph,
+        subject: URIRef,
+        predicate: URIRef,
+        language: str,
+    ) -> list[str]:
+        """Get literal values for a specific language.
+
+        Args:
+            graph: RDF graph.
+            subject: Subject URI.
+            predicate: Predicate URI.
+            language: Language code.
+
+        Returns:
+            List of literal string values.
+        """
+        results: list[str] = []
+
+        for obj in graph.objects(subject, predicate):
+            if isinstance(obj, Literal):
+                # Match language exactly or match untagged literals for source
+                obj_lang = obj.language
+                if obj_lang == language:
+                    results.append(str(obj))
+                elif obj_lang is None and language == self.config.source_language:
+                    # Treat untagged literals as source language
+                    results.append(str(obj))
+
+        return results
+
+    def _is_deprecated(self, graph: Graph, entity: URIRef) -> bool:
+        """Check if an entity is deprecated.
+
+        Args:
+            graph: RDF graph.
+            entity: Entity URI.
+
+        Returns:
+            True if entity is deprecated.
+        """
+        # Check owl:deprecated
+        for obj in graph.objects(entity, OWL.deprecated):
+            if isinstance(obj, Literal) and obj.toPython() is True:
+                return True
+
+        # Check owl:DeprecatedClass / owl:DeprecatedProperty
+        deprecated_types = [OWL.DeprecatedClass, OWL.DeprecatedProperty]
+        for dtype in deprecated_types:
+            if (entity, RDF.type, dtype) in graph:
+                return True
+
+        return False
+
+    def _expand_property(self, prop: str) -> str:
+        """Expand a CURIE to full URI.
+
+        Args:
+            prop: Property string (CURIE or full URI).
+
+        Returns:
+            Full URI string.
+        """
+        prefixes = {
+            "rdfs:": "http://www.w3.org/2000/01/rdf-schema#",
+            "skos:": "http://www.w3.org/2004/02/skos/core#",
+            "owl:": "http://www.w3.org/2002/07/owl#",
+            "rdf:": "http://www.w3.org/1999/02/22-rdf-syntax-ns#",
+            "dc:": "http://purl.org/dc/elements/1.1/",
+            "dcterms:": "http://purl.org/dc/terms/",
+        }
+
+        for prefix, namespace in prefixes.items():
+            if prop.startswith(prefix):
+                return namespace + prop[len(prefix) :]
+
+        return prop
+
+    def _shorten_property(self, prop: str) -> str:
+        """Shorten a full URI to CURIE if possible.
+
+        Args:
+            prop: Full property URI.
+
+        Returns:
+            CURIE or original URI.
+        """
+        namespaces = {
+            "http://www.w3.org/2000/01/rdf-schema#": "rdfs:",
+            "http://www.w3.org/2004/02/skos/core#": "skos:",
+            "http://www.w3.org/2002/07/owl#": "owl:",
+            "http://www.w3.org/1999/02/22-rdf-syntax-ns#": "rdf:",
+            "http://purl.org/dc/elements/1.1/": "dc:",
+            "http://purl.org/dc/terms/": "dcterms:",
+        }
+
+        for namespace, prefix in namespaces.items():
+            if prop.startswith(namespace):
+                return prefix + prop[len(namespace) :]
+
+        return prop
+
+
+def extract_strings(
+    source: Path,
+    target_language: str,
+    output: Path | None = None,
+    source_language: str = "en",
+    properties: list[str] | None = None,
+    include_deprecated: bool = False,
+    missing_only: bool = False,
+) -> ExtractionResult:
+    """Extract translatable strings from an ontology file.
+
+    Convenience function for simple extraction.
+
+    Args:
+        source: Source ontology file.
+        target_language: Target language code.
+        output: Output file path. Auto-generated if not provided.
+        source_language: Source language code.
+        properties: Properties to extract. Uses defaults if not provided.
+        include_deprecated: Include deprecated entities.
+        missing_only: Only extract missing translations.
+
+    Returns:
+        ExtractionResult with translation file.
+    """
+    # Load graph
+    graph = Graph()
+    graph.parse(source)
+
+    # Build config
+    config = ExtractConfig(
+        source_language=source_language,
+        target_language=target_language,
+        properties=properties or list(DEFAULT_PROPERTIES),
+        include_deprecated=include_deprecated,
+        missing_only=missing_only,
+    )
+
+    # Extract
+    extractor = StringExtractor(config)
+    result = extractor.extract(graph, source, target_language)
+
+    # Save if requested
+    if result.success and output and result.translation_file:
+        result.translation_file.save(output)
+
+    return result

--- a/src/rdf_construct/localise/formatters/__init__.py
+++ b/src/rdf_construct/localise/formatters/__init__.py
@@ -1,0 +1,36 @@
+"""Formatters for localise command output.
+
+Provides output formatting for:
+- Console text output
+- Markdown reports
+"""
+
+from rdf_construct.localise.formatters.text import TextFormatter
+from rdf_construct.localise.formatters.markdown import MarkdownFormatter
+
+__all__ = [
+    "TextFormatter",
+    "MarkdownFormatter",
+    "get_formatter",
+]
+
+
+def get_formatter(format_name: str, use_colour: bool = True) -> TextFormatter | MarkdownFormatter:
+    """Get a formatter by name.
+
+    Args:
+        format_name: Formatter name ("text" or "markdown").
+        use_colour: Whether to use colour output (text only).
+
+    Returns:
+        Formatter instance.
+
+    Raises:
+        ValueError: If format name is unknown.
+    """
+    if format_name == "text":
+        return TextFormatter(use_colour=use_colour)
+    elif format_name in ("markdown", "md"):
+        return MarkdownFormatter()
+    else:
+        raise ValueError(f"Unknown format: {format_name}")

--- a/src/rdf_construct/localise/formatters/markdown.py
+++ b/src/rdf_construct/localise/formatters/markdown.py
@@ -1,0 +1,229 @@
+"""Markdown formatter for coverage reports.
+
+Generates markdown-formatted coverage reports suitable for documentation
+or inclusion in PRs/issues.
+"""
+
+from datetime import datetime
+
+from rdf_construct.localise.extractor import ExtractionResult
+from rdf_construct.localise.merger import MergeResult
+from rdf_construct.localise.reporter import CoverageReport
+
+
+class MarkdownFormatter:
+    """Formats localise results as Markdown."""
+
+    def format_extraction_result(self, result: ExtractionResult) -> str:
+        """Format extraction result as Markdown.
+
+        Args:
+            result: Extraction result.
+
+        Returns:
+            Markdown string.
+        """
+        lines: list[str] = []
+
+        lines.append("# Extraction Result")
+        lines.append("")
+
+        if result.success:
+            lines.append("**Status:** ✅ Success")
+            lines.append("")
+            lines.append("| Metric | Value |")
+            lines.append("|--------|-------|")
+            lines.append(f"| Entities | {result.total_entities} |")
+            lines.append(f"| Strings | {result.total_strings} |")
+            lines.append(f"| Skipped | {result.skipped_entities} |")
+
+            if result.translation_file:
+                tf = result.translation_file
+                lines.append("")
+                lines.append("## Metadata")
+                lines.append("")
+                lines.append(f"- **Source file:** `{tf.metadata.source_file}`")
+                lines.append(f"- **Source language:** {tf.metadata.source_language}")
+                lines.append(f"- **Target language:** {tf.metadata.target_language}")
+        else:
+            lines.append("**Status:** ❌ Failed")
+            lines.append("")
+            lines.append(f"**Error:** {result.error}")
+
+        return "\n".join(lines)
+
+    def format_merge_result(self, result: MergeResult) -> str:
+        """Format merge result as Markdown.
+
+        Args:
+            result: Merge result.
+
+        Returns:
+            Markdown string.
+        """
+        lines: list[str] = []
+
+        lines.append("# Merge Result")
+        lines.append("")
+
+        if result.success:
+            lines.append("**Status:** ✅ Success")
+            lines.append("")
+
+            stats = result.stats
+            lines.append("| Metric | Count |")
+            lines.append("|--------|-------|")
+            lines.append(f"| Added | {stats.added} |")
+            lines.append(f"| Updated | {stats.updated} |")
+            lines.append(f"| Skipped (status) | {stats.skipped_status} |")
+            lines.append(f"| Skipped (existing) | {stats.skipped_existing} |")
+            lines.append(f"| Errors | {stats.errors} |")
+
+            if result.warnings:
+                lines.append("")
+                lines.append("## Warnings")
+                lines.append("")
+                for warning in result.warnings:
+                    lines.append(f"- {warning}")
+        else:
+            lines.append("**Status:** ❌ Failed")
+            lines.append("")
+            lines.append(f"**Error:** {result.error}")
+
+        return "\n".join(lines)
+
+    def format_coverage_report(
+        self,
+        report: CoverageReport,
+        verbose: bool = False,
+    ) -> str:
+        """Format coverage report as Markdown.
+
+        Args:
+            report: Coverage report.
+            verbose: Include detailed missing entity list.
+
+        Returns:
+            Markdown string.
+        """
+        lines: list[str] = []
+
+        # Header
+        lines.append("# Translation Coverage Report")
+        lines.append("")
+        lines.append(f"**Generated:** {datetime.now().strftime('%Y-%m-%d %H:%M')}")
+        lines.append("")
+
+        # Summary
+        lines.append("## Summary")
+        lines.append("")
+        lines.append(f"- **Source file:** `{report.source_file}`")
+        lines.append(f"- **Source language:** {report.source_language}")
+        lines.append(f"- **Total entities:** {report.total_entities}")
+        lines.append(f"- **Properties checked:** {', '.join(report.properties)}")
+        lines.append("")
+
+        # Coverage table
+        lines.append("## Coverage by Language")
+        lines.append("")
+
+        # Build header
+        header = ["Language"]
+        header.extend(report.properties)
+        header.append("Overall")
+        header.append("Status")
+        lines.append("| " + " | ".join(header) + " |")
+        lines.append("| " + " | ".join(["---"] * len(header)) + " |")
+
+        # Data rows
+        for lang, coverage in report.languages.items():
+            row = []
+
+            # Language
+            if coverage.is_source:
+                row.append(f"**{lang}** (base)")
+            else:
+                row.append(lang)
+
+            # Property coverages
+            for prop in report.properties:
+                prop_cov = coverage.by_property.get(prop)
+                if prop_cov:
+                    pct = f"{prop_cov.coverage:.0f}%"
+                else:
+                    pct = "-"
+                row.append(pct)
+
+            # Overall
+            row.append(f"**{coverage.coverage:.0f}%**")
+
+            # Status
+            if coverage.coverage == 100:
+                row.append("✅ Complete")
+            elif coverage.coverage >= 75:
+                row.append(f"⚠️ {coverage.pending} pending")
+            elif coverage.coverage > 0:
+                row.append(f"❌ {coverage.pending} pending")
+            else:
+                row.append("❌ Not started")
+
+            lines.append("| " + " | ".join(row) + " |")
+
+        # Missing translations section
+        if verbose:
+            has_missing = False
+            for lang, coverage in report.languages.items():
+                if coverage.missing_entities and not coverage.is_source:
+                    if not has_missing:
+                        lines.append("")
+                        lines.append("## Missing Translations")
+                        has_missing = True
+
+                    lines.append("")
+                    lines.append(f"### {lang.upper()}")
+                    lines.append("")
+
+                    # Group by entity type based on URI pattern
+                    lines.append("<details>")
+                    lines.append(f"<summary>{len(coverage.missing_entities)} entities missing translations</summary>")
+                    lines.append("")
+                    for uri in coverage.missing_entities:
+                        short_uri = self._shorten_uri(uri)
+                        lines.append(f"- `{short_uri}`")
+                    lines.append("")
+                    lines.append("</details>")
+
+        # Footer
+        lines.append("")
+        lines.append("---")
+        lines.append("*Generated by rdf-construct localise*")
+
+        return "\n".join(lines)
+
+    def _shorten_uri(self, uri: str) -> str:
+        """Shorten a URI for display.
+
+        Args:
+            uri: Full URI.
+
+        Returns:
+            Shortened version.
+        """
+        prefixes = {
+            "http://www.w3.org/2000/01/rdf-schema#": "rdfs:",
+            "http://www.w3.org/2004/02/skos/core#": "skos:",
+            "http://www.w3.org/2002/07/owl#": "owl:",
+            "http://www.w3.org/1999/02/22-rdf-syntax-ns#": "rdf:",
+        }
+
+        for namespace, prefix in prefixes.items():
+            if uri.startswith(namespace):
+                return prefix + uri[len(namespace) :]
+
+        # If no known prefix, just show local name
+        if "#" in uri:
+            return uri.split("#")[-1]
+        elif "/" in uri:
+            return uri.split("/")[-1]
+
+        return uri

--- a/src/rdf_construct/localise/formatters/text.py
+++ b/src/rdf_construct/localise/formatters/text.py
@@ -1,0 +1,224 @@
+"""Text formatter for console output.
+
+Provides formatted text output for extraction results, merge results,
+and coverage reports.
+"""
+
+from rdf_construct.localise.extractor import ExtractionResult
+from rdf_construct.localise.merger import MergeResult
+from rdf_construct.localise.reporter import CoverageReport
+
+
+class TextFormatter:
+    """Formats localise results for console output."""
+
+    def __init__(self, use_colour: bool = True):
+        """Initialise formatter.
+
+        Args:
+            use_colour: Whether to use ANSI colour codes.
+        """
+        self.use_colour = use_colour
+
+    def format_extraction_result(self, result: ExtractionResult) -> str:
+        """Format extraction result for display.
+
+        Args:
+            result: Extraction result.
+
+        Returns:
+            Formatted string.
+        """
+        lines: list[str] = []
+
+        if result.success:
+            lines.append(self._success("✓ Extraction complete"))
+            lines.append("")
+            lines.append(f"  Entities:        {result.total_entities}")
+            lines.append(f"  Strings:         {result.total_strings}")
+            if result.skipped_entities > 0:
+                lines.append(f"  Skipped:         {result.skipped_entities}")
+
+            if result.translation_file:
+                tf = result.translation_file
+                lines.append("")
+                lines.append(f"  Source language: {tf.metadata.source_language}")
+                lines.append(f"  Target language: {tf.metadata.target_language}")
+        else:
+            lines.append(self._error(f"✗ Extraction failed: {result.error}"))
+
+        return "\n".join(lines)
+
+    def format_merge_result(self, result: MergeResult) -> str:
+        """Format merge result for display.
+
+        Args:
+            result: Merge result.
+
+        Returns:
+            Formatted string.
+        """
+        lines: list[str] = []
+
+        if result.success:
+            lines.append(self._success("✓ Merge complete"))
+            lines.append("")
+
+            stats = result.stats
+            lines.append(f"  Added:           {stats.added}")
+            lines.append(f"  Updated:         {stats.updated}")
+
+            if stats.skipped_status > 0:
+                lines.append(f"  Skipped (status): {stats.skipped_status}")
+            if stats.skipped_existing > 0:
+                lines.append(f"  Skipped (exists): {stats.skipped_existing}")
+            if stats.errors > 0:
+                lines.append(self._warning(f"  Errors:          {stats.errors}"))
+
+            if result.warnings:
+                lines.append("")
+                lines.append(self._warning("Warnings:"))
+                for warning in result.warnings[:10]:  # Limit to 10
+                    lines.append(f"  - {warning}")
+                if len(result.warnings) > 10:
+                    lines.append(f"  ... and {len(result.warnings) - 10} more")
+        else:
+            lines.append(self._error(f"✗ Merge failed: {result.error}"))
+
+        return "\n".join(lines)
+
+    def format_coverage_report(
+        self,
+        report: CoverageReport,
+        verbose: bool = False,
+    ) -> str:
+        """Format coverage report for display.
+
+        Args:
+            report: Coverage report.
+            verbose: Include detailed missing entity list.
+
+        Returns:
+            Formatted string.
+        """
+        lines: list[str] = []
+
+        # Header
+        lines.append("Translation Coverage Report")
+        lines.append("=" * 40)
+        lines.append("")
+        lines.append(f"Source: {report.source_file}")
+        lines.append(f"Entities: {report.total_entities}")
+        lines.append(f"Properties: {', '.join(report.properties)}")
+        lines.append("")
+
+        # Table header
+        # Calculate column widths
+        lang_width = max(8, max(len(lang) for lang in report.languages.keys()))
+        prop_width = max(10, max(len(p) for p in report.properties))
+
+        # Build header row
+        header_parts = ["Language".ljust(lang_width)]
+        for prop in report.properties:
+            header_parts.append(prop.ljust(prop_width))
+        header_parts.append("Overall")
+        header_parts.append("Status")
+
+        lines.append("  ".join(header_parts))
+        lines.append("-" * (len("  ".join(header_parts))))
+
+        # Data rows
+        for lang, coverage in report.languages.items():
+            row_parts = []
+
+            # Language name
+            lang_display = f"{lang} (base)" if coverage.is_source else lang
+            row_parts.append(lang_display.ljust(lang_width))
+
+            # Property coverages
+            for prop in report.properties:
+                prop_cov = coverage.by_property.get(prop)
+                if prop_cov:
+                    pct = f"{prop_cov.coverage:.0f}%"
+                else:
+                    pct = "-"
+                row_parts.append(pct.ljust(prop_width))
+
+            # Overall coverage
+            overall_pct = f"{coverage.coverage:.0f}%"
+            row_parts.append(overall_pct.ljust(7))
+
+            # Status indicator
+            if coverage.coverage == 100:
+                status = self._success("✓ Complete")
+            elif coverage.coverage >= 75:
+                status = self._warning(f"⚠ {coverage.pending} pending")
+            elif coverage.coverage > 0:
+                status = f"✗ {coverage.pending} pending"
+            else:
+                status = "✗ Not started"
+            row_parts.append(status)
+
+            lines.append("  ".join(row_parts))
+
+        # Missing entities section
+        if verbose:
+            for lang, coverage in report.languages.items():
+                if coverage.missing_entities and not coverage.is_source:
+                    lines.append("")
+                    lines.append(f"Missing {lang} translations:")
+                    for uri in coverage.missing_entities[:20]:
+                        # Shorten URI for display
+                        short_uri = self._shorten_uri(uri)
+                        lines.append(f"  - {short_uri}")
+                    if len(coverage.missing_entities) > 20:
+                        lines.append(f"  ... and {len(coverage.missing_entities) - 20} more")
+
+        return "\n".join(lines)
+
+    def _success(self, text: str) -> str:
+        """Format as success (green)."""
+        if self.use_colour:
+            return f"\033[32m{text}\033[0m"
+        return text
+
+    def _warning(self, text: str) -> str:
+        """Format as warning (yellow)."""
+        if self.use_colour:
+            return f"\033[33m{text}\033[0m"
+        return text
+
+    def _error(self, text: str) -> str:
+        """Format as error (red)."""
+        if self.use_colour:
+            return f"\033[31m{text}\033[0m"
+        return text
+
+    def _shorten_uri(self, uri: str) -> str:
+        """Shorten a URI for display.
+
+        Args:
+            uri: Full URI.
+
+        Returns:
+            Shortened version.
+        """
+        # Common namespace prefixes
+        prefixes = {
+            "http://www.w3.org/2000/01/rdf-schema#": "rdfs:",
+            "http://www.w3.org/2004/02/skos/core#": "skos:",
+            "http://www.w3.org/2002/07/owl#": "owl:",
+            "http://www.w3.org/1999/02/22-rdf-syntax-ns#": "rdf:",
+        }
+
+        for namespace, prefix in prefixes.items():
+            if uri.startswith(namespace):
+                return prefix + uri[len(namespace) :]
+
+        # If no known prefix, just show local name
+        if "#" in uri:
+            return uri.split("#")[-1]
+        elif "/" in uri:
+            return uri.split("/")[-1]
+
+        return uri

--- a/src/rdf_construct/localise/merger.py
+++ b/src/rdf_construct/localise/merger.py
@@ -1,0 +1,346 @@
+"""Merge translations back into RDF ontologies.
+
+Takes completed translation files and adds translated literals to the
+ontology, creating new language-tagged triples.
+"""
+
+from dataclasses import dataclass, field
+from pathlib import Path
+
+from rdflib import Graph, Literal, URIRef
+
+from rdf_construct.localise.config import (
+    ExistingStrategy,
+    MergeConfig,
+    TranslationFile,
+    TranslationStatus,
+)
+
+
+@dataclass
+class MergeStats:
+    """Statistics for a merge operation.
+
+    Attributes:
+        added: Number of translations added.
+        updated: Number of translations updated.
+        skipped_status: Translations skipped due to status.
+        skipped_existing: Translations skipped (already exist, preserve mode).
+        errors: Number of errors encountered.
+    """
+
+    added: int = 0
+    updated: int = 0
+    skipped_status: int = 0
+    skipped_existing: int = 0
+    errors: int = 0
+
+    @property
+    def total_processed(self) -> int:
+        """Total translations processed."""
+        return self.added + self.updated + self.skipped_status + self.skipped_existing
+
+
+@dataclass
+class MergeResult:
+    """Result of a translation merge operation.
+
+    Attributes:
+        success: Whether merge succeeded.
+        merged_graph: Graph with merged translations.
+        stats: Merge statistics.
+        error: Error message if failed.
+        warnings: List of warning messages.
+    """
+
+    success: bool
+    merged_graph: Graph | None = None
+    stats: MergeStats = field(default_factory=MergeStats)
+    error: str | None = None
+    warnings: list[str] = field(default_factory=list)
+
+
+class TranslationMerger:
+    """Merges translation files back into RDF ontologies.
+
+    The merger takes completed translation YAML files and adds the
+    translations as new language-tagged literals to the ontology.
+    """
+
+    def __init__(self, config: MergeConfig | None = None):
+        """Initialise the merger.
+
+        Args:
+            config: Merge configuration. Uses defaults if not provided.
+        """
+        self.config = config or MergeConfig()
+
+    def merge(
+        self,
+        graph: Graph,
+        translation_file: TranslationFile,
+    ) -> MergeResult:
+        """Merge translations into an RDF graph.
+
+        Args:
+            graph: RDF graph to merge into.
+            translation_file: Completed translation file.
+
+        Returns:
+            MergeResult with merged graph.
+        """
+        try:
+            # Create a copy of the graph to work with
+            merged = Graph()
+            for prefix, namespace in graph.namespaces():
+                merged.bind(prefix, namespace)
+            for triple in graph:
+                merged.add(triple)
+
+            stats = MergeStats()
+            warnings: list[str] = []
+            target_lang = translation_file.metadata.target_language
+
+            # Process each entity
+            for entity in translation_file.entities:
+                entity_uri = URIRef(entity.uri)
+
+                # Check entity exists in graph
+                if not self._entity_exists(merged, entity_uri):
+                    warnings.append(f"Entity not found in graph: {entity.uri}")
+                    stats.errors += 1
+                    continue
+
+                # Process each label
+                for entry in entity.labels:
+                    # Check status threshold
+                    if not self._meets_status(entry.status):
+                        stats.skipped_status += 1
+                        continue
+
+                    # Skip empty translations
+                    if not entry.translation.strip():
+                        stats.skipped_status += 1
+                        continue
+
+                    # Expand property
+                    prop_uri = URIRef(self._expand_property(entry.property))
+
+                    # Check for existing translation
+                    existing = self._get_existing_translation(
+                        merged, entity_uri, prop_uri, target_lang
+                    )
+
+                    if existing:
+                        if self.config.existing == ExistingStrategy.PRESERVE:
+                            stats.skipped_existing += 1
+                            continue
+                        else:
+                            # Remove existing before adding new
+                            for triple in existing:
+                                merged.remove(triple)
+                            stats.updated += 1
+                    else:
+                        stats.added += 1
+
+                    # Add translation
+                    translation_literal = Literal(entry.translation, lang=target_lang)
+                    merged.add((entity_uri, prop_uri, translation_literal))
+
+            return MergeResult(
+                success=True,
+                merged_graph=merged,
+                stats=stats,
+                warnings=warnings,
+            )
+
+        except Exception as e:
+            return MergeResult(
+                success=False,
+                error=str(e),
+            )
+
+    def merge_multiple(
+        self,
+        graph: Graph,
+        translation_files: list[TranslationFile],
+    ) -> MergeResult:
+        """Merge multiple translation files into a graph.
+
+        Args:
+            graph: RDF graph to merge into.
+            translation_files: List of translation files.
+
+        Returns:
+            Combined MergeResult.
+        """
+        # Start with a copy
+        merged = Graph()
+        for prefix, namespace in graph.namespaces():
+            merged.bind(prefix, namespace)
+        for triple in graph:
+            merged.add(triple)
+
+        combined_stats = MergeStats()
+        all_warnings: list[str] = []
+
+        for trans_file in translation_files:
+            result = self.merge(merged, trans_file)
+
+            if not result.success:
+                return MergeResult(
+                    success=False,
+                    error=f"Failed merging {trans_file.metadata.target_language}: {result.error}",
+                )
+
+            # Use the merged graph for next iteration
+            merged = result.merged_graph
+
+            # Combine stats
+            combined_stats.added += result.stats.added
+            combined_stats.updated += result.stats.updated
+            combined_stats.skipped_status += result.stats.skipped_status
+            combined_stats.skipped_existing += result.stats.skipped_existing
+            combined_stats.errors += result.stats.errors
+            all_warnings.extend(result.warnings)
+
+        return MergeResult(
+            success=True,
+            merged_graph=merged,
+            stats=combined_stats,
+            warnings=all_warnings,
+        )
+
+    def _meets_status(self, status: TranslationStatus) -> bool:
+        """Check if status meets minimum threshold.
+
+        Args:
+            status: Translation status to check.
+
+        Returns:
+            True if status meets threshold.
+        """
+        status_order = [
+            TranslationStatus.PENDING,
+            TranslationStatus.NEEDS_REVIEW,
+            TranslationStatus.TRANSLATED,
+            TranslationStatus.APPROVED,
+        ]
+
+        try:
+            status_level = status_order.index(status)
+            min_level = status_order.index(self.config.min_status)
+            return status_level >= min_level
+        except ValueError:
+            return False
+
+    def _entity_exists(self, graph: Graph, entity: URIRef) -> bool:
+        """Check if an entity exists in the graph.
+
+        Args:
+            graph: RDF graph.
+            entity: Entity URI.
+
+        Returns:
+            True if entity has any triples.
+        """
+        # Check if entity appears as subject
+        for _ in graph.triples((entity, None, None)):
+            return True
+
+        return False
+
+    def _get_existing_translation(
+        self,
+        graph: Graph,
+        subject: URIRef,
+        predicate: URIRef,
+        language: str,
+    ) -> list[tuple]:
+        """Get existing translations for a specific language.
+
+        Args:
+            graph: RDF graph.
+            subject: Subject URI.
+            predicate: Predicate URI.
+            language: Language code.
+
+        Returns:
+            List of matching triples.
+        """
+        existing = []
+
+        for obj in graph.objects(subject, predicate):
+            if isinstance(obj, Literal) and obj.language == language:
+                existing.append((subject, predicate, obj))
+
+        return existing
+
+    def _expand_property(self, prop: str) -> str:
+        """Expand a CURIE to full URI.
+
+        Args:
+            prop: Property string (CURIE or full URI).
+
+        Returns:
+            Full URI string.
+        """
+        prefixes = {
+            "rdfs:": "http://www.w3.org/2000/01/rdf-schema#",
+            "skos:": "http://www.w3.org/2004/02/skos/core#",
+            "owl:": "http://www.w3.org/2002/07/owl#",
+            "rdf:": "http://www.w3.org/1999/02/22-rdf-syntax-ns#",
+            "dc:": "http://purl.org/dc/elements/1.1/",
+            "dcterms:": "http://purl.org/dc/terms/",
+        }
+
+        for prefix, namespace in prefixes.items():
+            if prop.startswith(prefix):
+                return namespace + prop[len(prefix) :]
+
+        return prop
+
+
+def merge_translations(
+    source: Path,
+    translation_files: list[Path],
+    output: Path | None = None,
+    min_status: str = "translated",
+    existing: str = "preserve",
+) -> MergeResult:
+    """Merge translation files into an ontology.
+
+    Convenience function for simple merge operations.
+
+    Args:
+        source: Source ontology file.
+        translation_files: List of translation YAML files.
+        output: Output file path. Writes to source if not provided.
+        min_status: Minimum status to include.
+        existing: How to handle existing translations.
+
+    Returns:
+        MergeResult with merged graph.
+    """
+    # Load graph
+    graph = Graph()
+    graph.parse(source)
+
+    # Load translation files
+    trans_files = [TranslationFile.from_yaml(p) for p in translation_files]
+
+    # Build config
+    config = MergeConfig(
+        min_status=TranslationStatus(min_status),
+        existing=ExistingStrategy(existing),
+    )
+
+    # Merge
+    merger = TranslationMerger(config)
+    result = merger.merge_multiple(graph, trans_files)
+
+    # Save if requested
+    if result.success and output and result.merged_graph:
+        result.merged_graph.serialize(destination=output, format="turtle")
+
+    return result

--- a/src/rdf_construct/localise/reporter.py
+++ b/src/rdf_construct/localise/reporter.py
@@ -1,0 +1,356 @@
+"""Translation coverage reporting.
+
+Analyses ontologies and reports translation coverage across languages,
+identifying missing translations and tracking progress.
+"""
+
+from dataclasses import dataclass, field
+from pathlib import Path
+
+from rdflib import Graph, Literal, URIRef
+from rdflib.namespace import OWL, RDF, RDFS
+
+
+@dataclass
+class PropertyCoverage:
+    """Coverage for a single property.
+
+    Attributes:
+        property: Property URI (shortened).
+        total: Total strings in source language.
+        translated: Number translated.
+    """
+
+    property: str
+    total: int = 0
+    translated: int = 0
+
+    @property
+    def coverage(self) -> float:
+        """Coverage percentage."""
+        if self.total == 0:
+            return 0.0
+        return (self.translated / self.total) * 100
+
+
+@dataclass
+class LanguageCoverage:
+    """Coverage statistics for a single language.
+
+    Attributes:
+        language: Language code.
+        is_source: Whether this is the source language.
+        total_strings: Total translatable strings.
+        translated: Number translated.
+        by_property: Coverage broken down by property.
+        missing_entities: URIs of entities missing translations.
+    """
+
+    language: str
+    is_source: bool = False
+    total_strings: int = 0
+    translated: int = 0
+    by_property: dict[str, PropertyCoverage] = field(default_factory=dict)
+    missing_entities: list[str] = field(default_factory=list)
+
+    @property
+    def coverage(self) -> float:
+        """Overall coverage percentage."""
+        if self.total_strings == 0:
+            return 0.0
+        return (self.translated / self.total_strings) * 100
+
+    @property
+    def pending(self) -> int:
+        """Number of pending translations."""
+        return self.total_strings - self.translated
+
+
+@dataclass
+class CoverageReport:
+    """Complete translation coverage report.
+
+    Attributes:
+        source_file: Source ontology file.
+        source_language: Base language.
+        total_entities: Total entities in ontology.
+        properties: Properties analysed.
+        languages: Coverage by language.
+    """
+
+    source_file: str
+    source_language: str
+    total_entities: int = 0
+    properties: list[str] = field(default_factory=list)
+    languages: dict[str, LanguageCoverage] = field(default_factory=dict)
+
+
+class CoverageReporter:
+    """Analyses and reports translation coverage.
+
+    The reporter examines an ontology and determines what percentage
+    of translatable content has been translated into each target language.
+    """
+
+    def __init__(
+        self,
+        source_language: str = "en",
+        properties: list[str] | None = None,
+    ):
+        """Initialise the reporter.
+
+        Args:
+            source_language: Base language code.
+            properties: Properties to check. Uses defaults if not provided.
+        """
+        self.source_language = source_language
+        self.properties = properties or [
+            "http://www.w3.org/2000/01/rdf-schema#label",
+            "http://www.w3.org/2000/01/rdf-schema#comment",
+        ]
+
+    def report(
+        self,
+        graph: Graph,
+        languages: list[str],
+        source_file: str | Path = "",
+    ) -> CoverageReport:
+        """Generate coverage report for specified languages.
+
+        Args:
+            graph: RDF graph to analyse.
+            languages: List of language codes to check.
+            source_file: Source file path for metadata.
+
+        Returns:
+            CoverageReport with detailed statistics.
+        """
+        # Collect entities
+        entities = self._collect_entities(graph)
+
+        # Build report
+        report = CoverageReport(
+            source_file=str(source_file),
+            source_language=self.source_language,
+            total_entities=len(entities),
+            properties=[self._shorten_property(p) for p in self.properties],
+        )
+
+        # Analyse source language first
+        source_coverage = self._analyse_language(
+            graph, entities, self.source_language, is_source=True
+        )
+        report.languages[self.source_language] = source_coverage
+
+        # Analyse each target language
+        for lang in languages:
+            if lang == self.source_language:
+                continue
+
+            lang_coverage = self._analyse_language(
+                graph,
+                entities,
+                lang,
+                is_source=False,
+                source_coverage=source_coverage,
+            )
+            report.languages[lang] = lang_coverage
+
+        return report
+
+    def _collect_entities(self, graph: Graph) -> list[URIRef]:
+        """Collect all entities from the graph.
+
+        Args:
+            graph: RDF graph.
+
+        Returns:
+            List of entity URIs.
+        """
+        entities: set[URIRef] = set()
+
+        # Classes
+        for cls_type in [OWL.Class, RDFS.Class]:
+            for s in graph.subjects(RDF.type, cls_type):
+                if isinstance(s, URIRef):
+                    entities.add(s)
+
+        # Properties
+        property_types = [
+            OWL.ObjectProperty,
+            OWL.DatatypeProperty,
+            OWL.AnnotationProperty,
+            RDF.Property,
+        ]
+        for prop_type in property_types:
+            for s in graph.subjects(RDF.type, prop_type):
+                if isinstance(s, URIRef):
+                    entities.add(s)
+
+        # Named Individuals
+        for s in graph.subjects(RDF.type, OWL.NamedIndividual):
+            if isinstance(s, URIRef):
+                entities.add(s)
+
+        return sorted(entities, key=str)
+
+    def _analyse_language(
+        self,
+        graph: Graph,
+        entities: list[URIRef],
+        language: str,
+        is_source: bool = False,
+        source_coverage: LanguageCoverage | None = None,
+    ) -> LanguageCoverage:
+        """Analyse coverage for a single language.
+
+        Args:
+            graph: RDF graph.
+            entities: List of entity URIs.
+            language: Language code to analyse.
+            is_source: Whether this is the source language.
+            source_coverage: Source language coverage (for comparison).
+
+        Returns:
+            LanguageCoverage statistics.
+        """
+        coverage = LanguageCoverage(
+            language=language,
+            is_source=is_source,
+        )
+
+        # Initialise property coverage
+        for prop_uri_str in self.properties:
+            short_prop = self._shorten_property(prop_uri_str)
+            coverage.by_property[short_prop] = PropertyCoverage(property=short_prop)
+
+        missing: list[str] = []
+
+        for entity in entities:
+            entity_has_any = False
+            entity_missing_any = False
+
+            for prop_uri_str in self.properties:
+                prop_uri = URIRef(prop_uri_str)
+                short_prop = self._shorten_property(prop_uri_str)
+
+                # Count strings in this language
+                count = self._count_language_literals(graph, entity, prop_uri, language)
+
+                if is_source:
+                    # For source language, all found strings count as "total"
+                    coverage.by_property[short_prop].total += count
+                    coverage.by_property[short_prop].translated += count
+                    coverage.total_strings += count
+                    coverage.translated += count
+                    if count > 0:
+                        entity_has_any = True
+                else:
+                    # For target languages, compare against source
+                    if source_coverage:
+                        source_count = self._count_language_literals(
+                            graph, entity, prop_uri, self.source_language
+                        )
+                        coverage.by_property[short_prop].total += source_count
+                        coverage.total_strings += source_count
+
+                        if count > 0:
+                            coverage.by_property[short_prop].translated += count
+                            coverage.translated += count
+                            entity_has_any = True
+
+                        if source_count > 0 and count == 0:
+                            entity_missing_any = True
+
+            # Track missing entities (have source but no target)
+            if entity_missing_any and not is_source:
+                missing.append(str(entity))
+
+        coverage.missing_entities = missing
+        return coverage
+
+    def _count_language_literals(
+        self,
+        graph: Graph,
+        subject: URIRef,
+        predicate: URIRef,
+        language: str,
+    ) -> int:
+        """Count literals with a specific language tag.
+
+        Args:
+            graph: RDF graph.
+            subject: Subject URI.
+            predicate: Predicate URI.
+            language: Language code.
+
+        Returns:
+            Count of matching literals.
+        """
+        count = 0
+
+        for obj in graph.objects(subject, predicate):
+            if isinstance(obj, Literal):
+                if obj.language == language:
+                    count += 1
+                elif obj.language is None and language == self.source_language:
+                    # Treat untagged as source language
+                    count += 1
+
+        return count
+
+    def _shorten_property(self, prop: str) -> str:
+        """Shorten a full URI to CURIE if possible.
+
+        Args:
+            prop: Full property URI.
+
+        Returns:
+            CURIE or original URI.
+        """
+        namespaces = {
+            "http://www.w3.org/2000/01/rdf-schema#": "rdfs:",
+            "http://www.w3.org/2004/02/skos/core#": "skos:",
+            "http://www.w3.org/2002/07/owl#": "owl:",
+            "http://www.w3.org/1999/02/22-rdf-syntax-ns#": "rdf:",
+            "http://purl.org/dc/elements/1.1/": "dc:",
+            "http://purl.org/dc/terms/": "dcterms:",
+        }
+
+        for namespace, prefix in namespaces.items():
+            if prop.startswith(namespace):
+                return prefix + prop[len(namespace) :]
+
+        return prop
+
+
+def generate_coverage_report(
+    source: Path,
+    languages: list[str],
+    source_language: str = "en",
+    properties: list[str] | None = None,
+) -> CoverageReport:
+    """Generate translation coverage report for an ontology.
+
+    Convenience function for simple reporting.
+
+    Args:
+        source: Source ontology file.
+        languages: List of language codes to check.
+        source_language: Base language code.
+        properties: Properties to analyse.
+
+    Returns:
+        CoverageReport with detailed statistics.
+    """
+    # Load graph
+    graph = Graph()
+    graph.parse(source)
+
+    # Report
+    reporter = CoverageReporter(
+        source_language=source_language,
+        properties=properties,
+    )
+
+    return reporter.report(graph, languages, source)

--- a/tests/test_localise.py
+++ b/tests/test_localise.py
@@ -1,0 +1,804 @@
+"""Tests for the localise command.
+
+Tests cover:
+- Extract to YAML
+- Extract with custom properties
+- Extract --missing-only
+- Merge translations
+- Merge with status filtering
+- Coverage report (text)
+- Coverage report (Markdown)
+- Init new language
+- Round-trip: extract → fill → merge
+- Multiple language files
+"""
+
+from datetime import datetime
+from pathlib import Path
+from textwrap import dedent
+
+import pytest
+from rdflib import Graph, Literal, URIRef, Namespace
+from rdflib.namespace import RDF, RDFS, OWL
+
+from rdf_construct.localise import (
+    # Config
+    TranslationStatus,
+    TranslationEntry,
+    EntityTranslations,
+    TranslationFile,
+    TranslationFileMetadata,
+    TranslationSummary,
+    ExtractConfig,
+    MergeConfig,
+    ExistingStrategy,
+    LocaliseConfig,
+    create_default_config,
+    load_localise_config,
+    # Extractor
+    StringExtractor,
+    ExtractionResult,
+    extract_strings,
+    # Merger
+    TranslationMerger,
+    MergeResult,
+    MergeStats,
+    merge_translations,
+    # Reporter
+    CoverageReporter,
+    CoverageReport,
+    generate_coverage_report,
+    # Formatters
+    TextFormatter,
+    MarkdownFormatter,
+    get_formatter,
+)
+
+
+# Test namespaces
+EX = Namespace("http://example.org/ontology#")
+SKOS = Namespace("http://www.w3.org/2004/02/skos/core#")
+
+
+@pytest.fixture
+def temp_dir(tmp_path: Path) -> Path:
+    """Create a temporary directory for test files."""
+    return tmp_path
+
+
+@pytest.fixture
+def simple_ontology() -> Graph:
+    """Create a simple ontology with English labels."""
+    g = Graph()
+    g.bind("ex", EX)
+    g.bind("rdfs", RDFS)
+    g.bind("owl", OWL)
+
+    # Define a class with English label and comment
+    g.add((EX.Building, RDF.type, OWL.Class))
+    g.add((EX.Building, RDFS.label, Literal("Building", lang="en")))
+    g.add((EX.Building, RDFS.comment, Literal("A permanent structure", lang="en")))
+
+    # Another class
+    g.add((EX.Person, RDF.type, OWL.Class))
+    g.add((EX.Person, RDFS.label, Literal("Person", lang="en")))
+
+    # A property
+    g.add((EX.hasLocation, RDF.type, OWL.ObjectProperty))
+    g.add((EX.hasLocation, RDFS.label, Literal("has location", lang="en")))
+
+    return g
+
+
+@pytest.fixture
+def multilingual_ontology() -> Graph:
+    """Create an ontology with multiple language labels."""
+    g = Graph()
+    g.bind("ex", EX)
+    g.bind("rdfs", RDFS)
+    g.bind("owl", OWL)
+
+    # Class with English and German
+    g.add((EX.Building, RDF.type, OWL.Class))
+    g.add((EX.Building, RDFS.label, Literal("Building", lang="en")))
+    g.add((EX.Building, RDFS.label, Literal("Gebäude", lang="de")))
+    g.add((EX.Building, RDFS.comment, Literal("A permanent structure", lang="en")))
+    # Note: German comment missing
+
+    # Class with English only
+    g.add((EX.Person, RDF.type, OWL.Class))
+    g.add((EX.Person, RDFS.label, Literal("Person", lang="en")))
+
+    return g
+
+
+@pytest.fixture
+def deprecated_ontology() -> Graph:
+    """Create an ontology with deprecated entities."""
+    g = Graph()
+    g.bind("ex", EX)
+    g.bind("rdfs", RDFS)
+    g.bind("owl", OWL)
+
+    # Active class
+    g.add((EX.Building, RDF.type, OWL.Class))
+    g.add((EX.Building, RDFS.label, Literal("Building", lang="en")))
+
+    # Deprecated class
+    g.add((EX.OldBuilding, RDF.type, OWL.Class))
+    g.add((EX.OldBuilding, RDFS.label, Literal("Old Building", lang="en")))
+    g.add((EX.OldBuilding, OWL.deprecated, Literal(True)))
+
+    return g
+
+
+@pytest.fixture
+def simple_ontology_file(temp_dir: Path, simple_ontology: Graph) -> Path:
+    """Save simple ontology to file."""
+    path = temp_dir / "ontology.ttl"
+    simple_ontology.serialize(destination=path, format="turtle")
+    return path
+
+
+@pytest.fixture
+def multilingual_ontology_file(temp_dir: Path, multilingual_ontology: Graph) -> Path:
+    """Save multilingual ontology to file."""
+    path = temp_dir / "multilingual.ttl"
+    multilingual_ontology.serialize(destination=path, format="turtle")
+    return path
+
+
+class TestTranslationEntry:
+    """Tests for TranslationEntry dataclass."""
+
+    def test_create_entry(self):
+        """Test creating a translation entry."""
+        entry = TranslationEntry(
+            property="rdfs:label",
+            source_text="Building",
+            translation="Gebäude",
+            status=TranslationStatus.TRANSLATED,
+        )
+        assert entry.property == "rdfs:label"
+        assert entry.source_text == "Building"
+        assert entry.translation == "Gebäude"
+        assert entry.status == TranslationStatus.TRANSLATED
+
+    def test_to_dict(self):
+        """Test serialisation to dict."""
+        entry = TranslationEntry(
+            property="rdfs:label",
+            source_text="Building",
+            translation="Gebäude",
+            status=TranslationStatus.TRANSLATED,
+            notes="Confirmed by native speaker",
+        )
+        d = entry.to_dict()
+        assert d["property"] == "rdfs:label"
+        assert d["source"] == "Building"
+        assert d["translation"] == "Gebäude"
+        assert d["status"] == "translated"
+        assert d["notes"] == "Confirmed by native speaker"
+
+    def test_from_dict(self):
+        """Test creation from dict."""
+        d = {
+            "property": "rdfs:comment",
+            "source": "A structure",
+            "translation": "Ein Bauwerk",
+            "status": "needs_review",
+        }
+        entry = TranslationEntry.from_dict(d)
+        assert entry.property == "rdfs:comment"
+        assert entry.source_text == "A structure"
+        assert entry.translation == "Ein Bauwerk"
+        assert entry.status == TranslationStatus.NEEDS_REVIEW
+
+
+class TestTranslationFile:
+    """Tests for TranslationFile serialisation."""
+
+    def test_to_yaml(self):
+        """Test YAML serialisation."""
+        metadata = TranslationFileMetadata(
+            source_file="test.ttl",
+            source_language="en",
+            target_language="de",
+            generated=datetime(2025, 1, 15, 10, 30),
+            properties=["rdfs:label"],
+        )
+        entities = [
+            EntityTranslations(
+                uri="http://example.org/Building",
+                entity_type="owl:Class",
+                labels=[
+                    TranslationEntry(
+                        property="rdfs:label",
+                        source_text="Building",
+                        translation="Gebäude",
+                        status=TranslationStatus.TRANSLATED,
+                    )
+                ],
+            )
+        ]
+        tf = TranslationFile(metadata=metadata, entities=entities)
+
+        yaml_str = tf.to_yaml()
+        assert "target_language: de" in yaml_str
+        assert "Building" in yaml_str
+        assert "Gebäude" in yaml_str
+
+    def test_from_yaml(self, temp_dir: Path):
+        """Test loading from YAML file."""
+        yaml_content = dedent('''
+            metadata:
+              source_file: test.ttl
+              source_language: en
+              target_language: de
+              generated: 2025-01-15T10:30:00
+              properties:
+                - rdfs:label
+            entities:
+              - uri: "http://example.org/Building"
+                type: owl:Class
+                labels:
+                  - property: rdfs:label
+                    source: Building
+                    translation: Gebäude
+                    status: translated
+            summary:
+              total_entities: 1
+              total_strings: 1
+              by_status:
+                translated: 1
+              coverage: "100%"
+        ''')
+
+        path = temp_dir / "translations.yml"
+        path.write_text(yaml_content)
+
+        tf = TranslationFile.from_yaml(path)
+        assert tf.metadata.target_language == "de"
+        assert len(tf.entities) == 1
+        assert tf.entities[0].labels[0].translation == "Gebäude"
+
+
+class TestStringExtractor:
+    """Tests for string extraction."""
+
+    def test_extract_basic(self, simple_ontology: Graph, temp_dir: Path):
+        """Test basic extraction."""
+        config = ExtractConfig(
+            source_language="en",
+            target_language="de",
+            properties=[
+                "http://www.w3.org/2000/01/rdf-schema#label",
+                "http://www.w3.org/2000/01/rdf-schema#comment",
+            ],
+        )
+        extractor = StringExtractor(config)
+        result = extractor.extract(simple_ontology, "test.ttl", "de")
+
+        assert result.success
+        assert result.total_entities == 3  # Building, Person, hasLocation
+        assert result.total_strings == 4  # 2 labels + 1 comment + 1 label
+
+    def test_extract_with_custom_properties(self, temp_dir: Path):
+        """Test extraction with custom properties."""
+        g = Graph()
+        g.bind("ex", EX)
+        g.bind("skos", SKOS)
+        g.add((EX.Concept, RDF.type, OWL.Class))
+        g.add((EX.Concept, SKOS.prefLabel, Literal("Concept", lang="en")))
+        g.add((EX.Concept, SKOS.definition, Literal("A general notion", lang="en")))
+
+        config = ExtractConfig(
+            source_language="en",
+            target_language="de",
+            properties=[
+                "http://www.w3.org/2004/02/skos/core#prefLabel",
+                "http://www.w3.org/2004/02/skos/core#definition",
+            ],
+        )
+        extractor = StringExtractor(config)
+        result = extractor.extract(g, "test.ttl", "de")
+
+        assert result.success
+        assert result.total_strings == 2
+
+    def test_extract_missing_only(self, multilingual_ontology: Graph):
+        """Test extraction of missing translations only."""
+        config = ExtractConfig(
+            source_language="en",
+            target_language="de",
+            missing_only=True,
+        )
+        extractor = StringExtractor(config)
+        result = extractor.extract(multilingual_ontology, "test.ttl", "de")
+
+        assert result.success
+        # Building label exists in German, so only comment + Person label
+        assert result.total_strings == 2  # Building comment + Person label
+
+    def test_extract_excludes_deprecated(self, deprecated_ontology: Graph):
+        """Test that deprecated entities are excluded by default."""
+        config = ExtractConfig(
+            source_language="en",
+            target_language="de",
+            include_deprecated=False,
+        )
+        extractor = StringExtractor(config)
+        result = extractor.extract(deprecated_ontology, "test.ttl", "de")
+
+        assert result.success
+        assert result.total_entities == 1  # Only Building
+        assert result.skipped_entities == 1  # OldBuilding skipped
+
+    def test_extract_includes_deprecated(self, deprecated_ontology: Graph):
+        """Test including deprecated entities."""
+        config = ExtractConfig(
+            source_language="en",
+            target_language="de",
+            include_deprecated=True,
+        )
+        extractor = StringExtractor(config)
+        result = extractor.extract(deprecated_ontology, "test.ttl", "de")
+
+        assert result.success
+        assert result.total_entities == 2  # Both classes
+
+
+class TestTranslationMerger:
+    """Tests for translation merging."""
+
+    def test_merge_basic(self, simple_ontology: Graph):
+        """Test basic merge."""
+        # Create translation file
+        metadata = TranslationFileMetadata(
+            source_file="test.ttl",
+            source_language="en",
+            target_language="de",
+            generated=datetime.now(),
+            properties=["rdfs:label"],
+        )
+        entities = [
+            EntityTranslations(
+                uri=str(EX.Building),
+                entity_type="owl:Class",
+                labels=[
+                    TranslationEntry(
+                        property="rdfs:label",
+                        source_text="Building",
+                        translation="Gebäude",
+                        status=TranslationStatus.TRANSLATED,
+                    )
+                ],
+            )
+        ]
+        tf = TranslationFile(metadata=metadata, entities=entities)
+
+        # Merge
+        merger = TranslationMerger()
+        result = merger.merge(simple_ontology, tf)
+
+        assert result.success
+        assert result.stats.added == 1
+
+        # Check translation was added
+        german_labels = list(result.merged_graph.objects(EX.Building, RDFS.label))
+        german = [l for l in german_labels if l.language == "de"]
+        assert len(german) == 1
+        assert str(german[0]) == "Gebäude"
+
+    def test_merge_with_status_filtering(self, simple_ontology: Graph):
+        """Test merge respects status threshold."""
+        metadata = TranslationFileMetadata(
+            source_file="test.ttl",
+            source_language="en",
+            target_language="de",
+            generated=datetime.now(),
+            properties=["rdfs:label"],
+        )
+        entities = [
+            EntityTranslations(
+                uri=str(EX.Building),
+                entity_type="owl:Class",
+                labels=[
+                    TranslationEntry(
+                        property="rdfs:label",
+                        source_text="Building",
+                        translation="Gebäude",
+                        status=TranslationStatus.PENDING,  # Below threshold
+                    )
+                ],
+            )
+        ]
+        tf = TranslationFile(metadata=metadata, entities=entities)
+
+        config = MergeConfig(min_status=TranslationStatus.TRANSLATED)
+        merger = TranslationMerger(config)
+        result = merger.merge(simple_ontology, tf)
+
+        assert result.success
+        assert result.stats.skipped_status == 1
+        assert result.stats.added == 0
+
+    def test_merge_preserve_existing(self, multilingual_ontology: Graph):
+        """Test preserve mode doesn't overwrite existing."""
+        metadata = TranslationFileMetadata(
+            source_file="test.ttl",
+            source_language="en",
+            target_language="de",
+            generated=datetime.now(),
+            properties=["rdfs:label"],
+        )
+        entities = [
+            EntityTranslations(
+                uri=str(EX.Building),
+                entity_type="owl:Class",
+                labels=[
+                    TranslationEntry(
+                        property="rdfs:label",
+                        source_text="Building",
+                        translation="NEUES Gebäude",  # Different from existing
+                        status=TranslationStatus.TRANSLATED,
+                    )
+                ],
+            )
+        ]
+        tf = TranslationFile(metadata=metadata, entities=entities)
+
+        config = MergeConfig(existing=ExistingStrategy.PRESERVE)
+        merger = TranslationMerger(config)
+        result = merger.merge(multilingual_ontology, tf)
+
+        assert result.success
+        assert result.stats.skipped_existing == 1
+
+        # Check original was preserved
+        german_labels = [
+            l for l in result.merged_graph.objects(EX.Building, RDFS.label)
+            if l.language == "de"
+        ]
+        assert len(german_labels) == 1
+        assert str(german_labels[0]) == "Gebäude"  # Original, not new
+
+    def test_merge_overwrite_existing(self, multilingual_ontology: Graph):
+        """Test overwrite mode replaces existing."""
+        metadata = TranslationFileMetadata(
+            source_file="test.ttl",
+            source_language="en",
+            target_language="de",
+            generated=datetime.now(),
+            properties=["rdfs:label"],
+        )
+        entities = [
+            EntityTranslations(
+                uri=str(EX.Building),
+                entity_type="owl:Class",
+                labels=[
+                    TranslationEntry(
+                        property="rdfs:label",
+                        source_text="Building",
+                        translation="Bauwerk",  # Different
+                        status=TranslationStatus.TRANSLATED,
+                    )
+                ],
+            )
+        ]
+        tf = TranslationFile(metadata=metadata, entities=entities)
+
+        config = MergeConfig(existing=ExistingStrategy.OVERWRITE)
+        merger = TranslationMerger(config)
+        result = merger.merge(multilingual_ontology, tf)
+
+        assert result.success
+        assert result.stats.updated == 1
+
+        # Check translation was updated
+        german_labels = [
+            l for l in result.merged_graph.objects(EX.Building, RDFS.label)
+            if l.language == "de"
+        ]
+        assert len(german_labels) == 1
+        assert str(german_labels[0]) == "Bauwerk"
+
+
+class TestCoverageReporter:
+    """Tests for coverage reporting."""
+
+    def test_report_basic(self, multilingual_ontology: Graph):
+        """Test basic coverage report."""
+        reporter = CoverageReporter(source_language="en")
+        report = reporter.report(multilingual_ontology, ["en", "de"], "test.ttl")
+
+        assert report.total_entities == 2  # Building, Person
+        assert "en" in report.languages
+        assert "de" in report.languages
+
+        en_coverage = report.languages["en"]
+        assert en_coverage.is_source
+        assert en_coverage.coverage == 100.0
+
+        de_coverage = report.languages["de"]
+        assert not de_coverage.is_source
+        # Building label translated, Person label missing, comment missing
+        assert de_coverage.coverage < 100.0
+
+    def test_report_missing_entities(self, multilingual_ontology: Graph):
+        """Test missing entity tracking."""
+        reporter = CoverageReporter(source_language="en")
+        report = reporter.report(multilingual_ontology, ["en", "de"], "test.ttl")
+
+        de_coverage = report.languages["de"]
+        # Person should be in missing list
+        assert len(de_coverage.missing_entities) > 0
+
+
+class TestFormatters:
+    """Tests for output formatters."""
+
+    def test_text_formatter_extraction(self, simple_ontology: Graph):
+        """Test text formatter for extraction result."""
+        config = ExtractConfig(source_language="en", target_language="de")
+        extractor = StringExtractor(config)
+        result = extractor.extract(simple_ontology, "test.ttl", "de")
+
+        formatter = TextFormatter(use_colour=False)
+        output = formatter.format_extraction_result(result)
+
+        assert "Extraction complete" in output
+        assert "Entities:" in output
+        assert "Strings:" in output
+
+    def test_text_formatter_coverage(self, multilingual_ontology: Graph):
+        """Test text formatter for coverage report."""
+        reporter = CoverageReporter(source_language="en")
+        report = reporter.report(multilingual_ontology, ["en", "de"], "test.ttl")
+
+        formatter = TextFormatter(use_colour=False)
+        output = formatter.format_coverage_report(report)
+
+        assert "Translation Coverage Report" in output
+        assert "en (base)" in output
+        assert "de" in output
+
+    def test_markdown_formatter_coverage(self, multilingual_ontology: Graph):
+        """Test markdown formatter for coverage report."""
+        reporter = CoverageReporter(source_language="en")
+        report = reporter.report(multilingual_ontology, ["en", "de"], "test.ttl")
+
+        formatter = MarkdownFormatter()
+        output = formatter.format_coverage_report(report)
+
+        assert "# Translation Coverage Report" in output
+        assert "| Language |" in output
+        assert "**en**" in output
+
+
+class TestConvenienceFunctions:
+    """Tests for convenience functions."""
+
+    def test_extract_strings(self, simple_ontology_file: Path, temp_dir: Path):
+        """Test extract_strings function."""
+        output = temp_dir / "de.yml"
+        result = extract_strings(
+            source=simple_ontology_file,
+            target_language="de",
+            output=output,
+        )
+
+        assert result.success
+        assert output.exists()
+
+        # Load and verify
+        tf = TranslationFile.from_yaml(output)
+        assert tf.metadata.target_language == "de"
+
+    def test_merge_translations(self, simple_ontology_file: Path, temp_dir: Path):
+        """Test merge_translations function."""
+        # First extract
+        trans_file = temp_dir / "de.yml"
+        extract_result = extract_strings(
+            source=simple_ontology_file,
+            target_language="de",
+            output=trans_file,
+        )
+        assert extract_result.success
+
+        # Fill in a translation
+        tf = TranslationFile.from_yaml(trans_file)
+        for entity in tf.entities:
+            for label in entity.labels:
+                if label.source_text == "Building":
+                    label.translation = "Gebäude"
+                    label.status = TranslationStatus.TRANSLATED
+        tf.save(trans_file)
+
+        # Merge
+        output = temp_dir / "merged.ttl"
+        merge_result = merge_translations(
+            source=simple_ontology_file,
+            translation_files=[trans_file],
+            output=output,
+        )
+
+        assert merge_result.success
+        assert merge_result.stats.added >= 1
+        assert output.exists()
+
+    def test_generate_coverage_report(self, multilingual_ontology_file: Path):
+        """Test generate_coverage_report function."""
+        report = generate_coverage_report(
+            source=multilingual_ontology_file,
+            languages=["en", "de", "fr"],
+        )
+
+        assert report.total_entities == 2
+        assert "en" in report.languages
+        assert "de" in report.languages
+        assert "fr" in report.languages
+
+
+class TestRoundTrip:
+    """Test extract → translate → merge roundtrip."""
+
+    def test_roundtrip(self, simple_ontology_file: Path, temp_dir: Path):
+        """Test complete roundtrip workflow."""
+        # 1. Extract
+        trans_file = temp_dir / "de.yml"
+        extract_result = extract_strings(
+            source=simple_ontology_file,
+            target_language="de",
+            output=trans_file,
+        )
+        assert extract_result.success
+
+        # 2. Simulate translation
+        tf = TranslationFile.from_yaml(trans_file)
+        translations = {
+            "Building": "Gebäude",
+            "Person": "Person",  # Same in German
+            "has location": "hat Standort",
+            "A permanent structure": "Eine dauerhafte Struktur",
+        }
+        for entity in tf.entities:
+            for label in entity.labels:
+                if label.source_text in translations:
+                    label.translation = translations[label.source_text]
+                    label.status = TranslationStatus.TRANSLATED
+        tf.save(trans_file)
+
+        # 3. Merge back
+        output = temp_dir / "localised.ttl"
+        merge_result = merge_translations(
+            source=simple_ontology_file,
+            translation_files=[trans_file],
+            output=output,
+        )
+        assert merge_result.success
+
+        # 4. Verify result
+        g = Graph()
+        g.parse(output)
+
+        # Check German labels exist
+        building_labels = list(g.objects(EX.Building, RDFS.label))
+        german_labels = [l for l in building_labels if l.language == "de"]
+        assert len(german_labels) == 1
+        assert str(german_labels[0]) == "Gebäude"
+
+
+class TestConfigYAML:
+    """Tests for configuration file handling."""
+
+    def test_create_default_config(self):
+        """Test default config generation."""
+        config_str = create_default_config()
+        assert "localise:" in config_str
+        assert "properties:" in config_str
+        assert "languages:" in config_str
+
+    def test_load_config(self, temp_dir: Path):
+        """Test loading config from YAML."""
+        config_content = dedent('''
+            localise:
+              properties:
+                - rdfs:label
+                - skos:prefLabel
+              languages:
+                source: en
+                targets:
+                  - de
+                  - fr
+              output:
+                directory: translations/
+                naming: "{language}.yml"
+              extract:
+                include_deprecated: false
+              merge:
+                existing: preserve
+                min_status: translated
+        ''')
+
+        config_path = temp_dir / "localise.yml"
+        config_path.write_text(config_content)
+
+        config = load_localise_config(config_path)
+        assert config.source_language == "en"
+        assert "de" in config.target_languages
+        assert config.merge.existing == ExistingStrategy.PRESERVE
+
+
+class TestMultipleLanguages:
+    """Tests for handling multiple languages."""
+
+    def test_extract_multiple_languages(
+        self, simple_ontology_file: Path, temp_dir: Path
+    ):
+        """Test extracting for multiple languages."""
+        languages = ["de", "fr", "es"]
+        files: list[Path] = []
+
+        for lang in languages:
+            output = temp_dir / f"{lang}.yml"
+            result = extract_strings(
+                source=simple_ontology_file,
+                target_language=lang,
+                output=output,
+            )
+            assert result.success
+            files.append(output)
+
+        # Verify all files created
+        for f in files:
+            assert f.exists()
+            tf = TranslationFile.from_yaml(f)
+            assert tf.metadata.target_language in languages
+
+    def test_merge_multiple_files(self, simple_ontology_file: Path, temp_dir: Path):
+        """Test merging multiple translation files."""
+        # Create German and French translations
+        languages_data = [
+            ("de", {"Building": "Gebäude", "Person": "Person"}),
+            ("fr", {"Building": "Bâtiment", "Person": "Personne"}),
+        ]
+
+        trans_files: list[Path] = []
+        for lang, translations in languages_data:
+            # Extract
+            trans_file = temp_dir / f"{lang}.yml"
+            extract_strings(
+                source=simple_ontology_file,
+                target_language=lang,
+                output=trans_file,
+            )
+
+            # Fill translations
+            tf = TranslationFile.from_yaml(trans_file)
+            for entity in tf.entities:
+                for label in entity.labels:
+                    if label.source_text in translations:
+                        label.translation = translations[label.source_text]
+                        label.status = TranslationStatus.TRANSLATED
+            tf.save(trans_file)
+            trans_files.append(trans_file)
+
+        # Merge all
+        output = temp_dir / "multilingual.ttl"
+        result = merge_translations(
+            source=simple_ontology_file,
+            translation_files=trans_files,
+            output=output,
+        )
+
+        assert result.success
+
+        # Verify both languages present
+        g = Graph()
+        g.parse(output)
+
+        building_labels = list(g.objects(EX.Building, RDFS.label))
+        languages_found = {l.language for l in building_labels if hasattr(l, "language")}
+        assert "de" in languages_found
+        assert "fr" in languages_found


### PR DESCRIPTION
# Add `localise` command for multi-language label management

**Branch:** `dev/localise-tool-26`  
**Related Issue:** #26  - Add `localise` command for multi-language label management  
**Depends On:** None (independent module)

---

## Summary

Adds the `localise` command for managing multi-language labels in ontologies:
- `localise extract` — Export translatable strings to YAML
- `localise merge` — Import translations back into ontology
- `localise report` — Check translation coverage
- `localise init` — Create empty translation file for new language

## Changes

### New Files

```
src/rdf_construct/localise/
├── __init__.py
├── config.py          # LocaliseConfig, TranslationFile
├── extractor.py       # Extract translatable strings
├── merger.py          # Merge translations back
├── reporter.py        # Coverage analysis
└── formatters/
    ├── __init__.py
    ├── yaml_format.py # YAML file handling
    ├── text.py        # Console output
    └── markdown.py    # Markdown reports

tests/
├── test_localise.py
└── fixtures/localise/
    ├── ontology.ttl
    ├── de.yml
    ├── partial_fr.yml
    └── localise.yml

docs/user_guides/LOCALISE_GUIDE.md
```

### Modified Files

- `src/rdf_construct/cli.py` — Add `localise` command group
- `docs/user_guides/CLI_REFERENCE.md` — Document new commands
- `CHANGELOG.md` — Add entry
- `README.md` — Update feature list

## CLI Usage

```bash
# Extract for German translation
rdf-construct localise extract ontology.ttl --language de -o translations/de.yml

# Merge completed translations
rdf-construct localise merge ontology.ttl translations/de.yml -o localised.ttl

# Check coverage
rdf-construct localise report ontology.ttl --languages en,de,fr,es

# Initialise new language
rdf-construct localise init ontology.ttl --language ja -o translations/ja.yml
```

## Key Behaviours

- **YAML format**: Human-readable, editable translation files
- **Status tracking**: pending → translated → needs_review → approved
- **Property support**: rdfs:label, rdfs:comment, skos:prefLabel, etc.
- **Missing-only extraction**: Update files with only untranslated strings
- **Coverage reporting**: Track progress across languages
- **Preserve existing**: Don't overwrite translations already in ontology

## Translation File Format

```yaml
metadata:
  source_language: en
  target_language: de

entities:
  - uri: "ex:Building"
    labels:
      - property: rdfs:label
        source: "Building"
        translation: "Gebäude"
        status: translated

summary:
  total_strings: 156
  translated: 98
  coverage: 63%
```

## Testing

```bash
poetry run pytest tests/test_localise.py -v
```

### Test Coverage

- [x] Extract to YAML
- [x] Extract with custom properties
- [x] Extract --missing-only
- [x] Merge translations
- [x] Merge with status filtering
- [x] Coverage report (text)
- [x] Coverage report (Markdown)
- [x] Init new language
- [x] Round-trip: extract → fill → merge
- [x] Multiple language files

## Checklist

- [x] All tests passing
- [x] Type hints complete
- [x] Docstrings complete
- [x] `black` formatted
- [x] `ruff` clean
- [x] `mypy` clean
- [x] Documentation complete
- [x] CHANGELOG updated
- [x] YAML format documented
- [x] Tested with IES ontology