### PR TITLE
fix: lint tool broken

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Nothing yet.
 
+## [0.4.1] - 2026-01-06
+
+### Fixed
+- Fixed `lint` command crash with `AttributeError: 'TextFormatter' object has no attribute 'format_summary'` caused by import name collision between `rdf_construct.lint.get_formatter` and `rdf_construct.merge.get_formatter`
+
 ## [0.4.0] - 2026-01-03
 
 ### Added
@@ -373,12 +378,14 @@ Initial public release.
 
 | Version | Date       | Highlights                                                                                          |
 |---------|------------|-----------------------------------------------------------------------------------------------------|
+| [0.4.1] | 2026-01-06 | Fix lint command import collision |
 | [0.4.0] | 2026-01-03 | Add describe command, documentation improvements |
 | [0.3.0] | 2025-12-04 | Add merge/split, refactor, and localise |
 | [0.2.0] | 2025-12-03 | Stats, CQ testing, SHACL gen, docs gen, diff, lint, puml2rdf                                        |
 | [0.1.0] | 2025-11-30 | Initial release: ordering, UML generation, styling                                                  |
 
-[Unreleased]: https://github.com/aigora-de/rdf-construct/compare/v0.4.0...HEAD
+[Unreleased]: https://github.com/aigora-de/rdf-construct/compare/v0.4.1...HEAD
+[0.4.1]: https://github.com/aigora-de/rdf-construct/releases/tag/v0.4.1
 [0.4.0]: https://github.com/aigora-de/rdf-construct/releases/tag/v0.4.0
 [0.3.0]: https://github.com/aigora-de/rdf-construct/releases/tag/v0.3.0
 [0.2.1]: https://github.com/aigora-de/rdf-construct/releases/tag/v0.2.1

--- a/README.md
+++ b/README.md
@@ -387,7 +387,7 @@ properties:
 
 ## Project Status
 
-**Current**: v0.4.0 - Feature complete for core ontology workflows  
+**Current**: v0.4.1 - Feature complete for core ontology workflows  
 **License**: MIT
 
 ### Implemented
@@ -474,6 +474,6 @@ MIT License - see [LICENSE](LICENSE) file for details.
 
 ---
 
-**Status**: v0.4.0  
+**Status**: v0.4.1
 **Python**: 3.10+ required  
 **Maintainer**: See [CONTRIBUTING.md](CONTRIBUTING.md)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "poetry.core.masonry.api"
 
 [project]
 name = "rdf-construct"
-version = "0.4.0"
+version = "0.4.1"
 description = "Semantic RDF manipulation toolkit - order, serialize, and diff RDF ontologies"
 license = "MIT"
 readme = "README.md"

--- a/src/rdf_construct/__init__.py
+++ b/src/rdf_construct/__init__.py
@@ -4,7 +4,7 @@ Named after the ROM construct from William Gibson's Neuromancer -
 preserved, structured knowledge that can be queried and transformed.
 """
 
-__version__ = "0.4.0"
+__version__ = "0.4.1"
 
 from . import core, uml
 from .cli import cli

--- a/src/rdf_construct/cli.py
+++ b/src/rdf_construct/cli.py
@@ -33,7 +33,7 @@ from rdf_construct.lint import (
     LintConfig,
     load_lint_config,
     find_config_file,
-    get_formatter,
+    get_formatter as get_lint_formatter,
     list_rules,
     get_all_rules,
 )
@@ -691,7 +691,7 @@ def lint(
 
     # Format and output results
     use_colour = not no_colour and output_format == "text"
-    formatter = get_formatter(output_format, use_colour=use_colour)
+    formatter = get_lint_formatter(output_format, use_colour=use_colour)
 
     output = formatter.format_summary(summary)
     click.echo(output)


### PR DESCRIPTION
## Bug

The `lint` command crashes when processing any ontology file:

```
$ rdf-construct lint ./examples/ies-common.ttl
Scanning 1 file(s)...

Traceback (most recent call last):
  ...
  File ".../cli.py", line 696, in lint
    output = formatter.format_summary(summary)
AttributeError: 'TextFormatter' object has no attribute 'format_summary'
```

## Cause

Import name collision in `cli.py`: `get_formatter` is imported from both `rdf_construct.lint` and `rdf_construct.merge`. The merge import overwrites the lint import, so the lint command gets a merge formatter instead of a lint formatter.

## Fix

Alias the lint import: `get_formatter as get_lint_formatter`