### PR TITLE
fix(serialiser): use @prefix directive instead of SPARQL PREFIX syntax

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Nothing yet.
 
+## [0.4.6] - 2026-03-27
+
+### Fixed
+- Fixed `order` command emitting SPARQL-style `PREFIX` declarations instead of valid Turtle
+  `@prefix … .` directives. Strictly conformant parsers (triple stores, validators, rdflib in
+  strict mode) reject the `PREFIX` form, which is N3/SPARQL syntax not valid Turtle per the
+  W3C spec (#56)
+
 ## [0.4.5] - 2026-03-17
 
 ### Added
@@ -438,6 +446,7 @@ Initial public release.
 
 | Version | Date       | Highlights                                                                                          |
 |---------|------------|-----------------------------------------------------------------------------------------------------|
+| [0.4.6] | 2026-03-27 | Fix invalid Turtle prefix declarations in `order` output |
 | [0.4.5] | 2026-03-17 | Documentation for `cast` command |
 | [0.4.4] | 2026-03-17 | Add `cast` command for pipe-friendly RDF format conversion |
 | [0.4.3] | 2026-03-17 | Fix inline blank node serialisation in `order` output |
@@ -448,7 +457,8 @@ Initial public release.
 | [0.2.0] | 2025-12-03 | Stats, CQ testing, SHACL gen, docs gen, diff, lint, puml2rdf                                        |
 | [0.1.0] | 2025-11-30 | Initial release: ordering, UML generation, styling                                                  |
 
-[Unreleased]: https://github.com/aigora-de/rdf-construct/compare/v0.4.5...HEAD
+[Unreleased]: https://github.com/aigora-de/rdf-construct/compare/v0.4.6...HEAD
+[0.4.6]: https://github.com/aigora-de/rdf-construct/releases/tag/v0.4.6
 [0.4.5]: https://github.com/aigora-de/rdf-construct/releases/tag/v0.4.5
 [0.4.4]: https://github.com/aigora-de/rdf-construct/releases/tag/v0.4.4
 [0.4.3]: https://github.com/aigora-de/rdf-construct/releases/tag/v0.4.3

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "poetry.core.masonry.api"
 
 [project]
 name = "rdf-construct"
-version = "0.4.5"
+version = "0.4.6"
 description = "Semantic RDF manipulation toolkit - order, serialize, and diff RDF ontologies"
 license = "MIT"
 readme = "README.md"

--- a/src/rdf_construct/__init__.py
+++ b/src/rdf_construct/__init__.py
@@ -4,7 +4,7 @@ Named after the ROM construct from William Gibson's Neuromancer -
 preserved, structured knowledge that can be queried and transformed.
 """
 
-__version__ = "0.4.2"
+__version__ = "0.4.6"
 
 from . import core, uml
 from .cli import cli

--- a/src/rdf_construct/core/serialiser.py
+++ b/src/rdf_construct/core/serialiser.py
@@ -276,12 +276,13 @@ def serialise_turtle(
     # Pre-pass: identify blank nodes to be rendered inline.
     inline_bnodes = collect_inline_bnodes(graph)
 
-    # Write prefixes \u2014 only those actually used in the graph
+    # Write prefixes — only those actually used in the graph.
+    # Turtle requires the @prefix directive with a trailing ' .' (not SPARQL PREFIX).
     used_ns = collect_used_namespaces(graph)
     prefixes = sorted(graph.namespace_manager.namespaces(), key=lambda x: x[0])
     for prefix, namespace in prefixes:
         if prefix and str(namespace) in used_ns:
-            lines.append(f"PREFIX {prefix}: <{namespace}>")
+            lines.append(f"@prefix {prefix}: <{namespace}> .")
     lines.append("")  # Blank line after prefixes
 
     # Write subjects in order

--- a/tests/test_serialiser_prefixes.py
+++ b/tests/test_serialiser_prefixes.py
@@ -137,11 +137,11 @@ class TestSerialiseTurtlePrefixes:
 
         content = out.read_text(encoding="utf-8")
         prefix_lines = [
-            line for line in content.splitlines() if line.startswith("PREFIX ")
+            line for line in content.splitlines() if line.startswith("@prefix ")
         ]
 
         # Extract declared prefix names
-        declared = {line.split(":")[0].replace("PREFIX ", "") for line in prefix_lines}
+        declared = {line.split(":")[0].replace("@prefix ", "") for line in prefix_lines}
 
         # Should include prefixes we actually use
         assert "ex" in declared
@@ -157,6 +157,48 @@ class TestSerialiseTurtlePrefixes:
         assert "prov" not in declared
         assert "sosa" not in declared
 
+    def test_prefix_declarations_use_turtle_syntax(
+        self, small_graph: Graph, tmp_path: Path
+    ) -> None:
+        """Every prefix line must use Turtle @prefix syntax, not SPARQL PREFIX.
+
+        Turtle requires ``@prefix ex: <…> .`` — the SPARQL form ``PREFIX ex: <…>``
+        (without ``@`` and without a trailing period) is not valid Turtle per the
+        W3C spec (https://www.w3.org/TR/turtle/#prefixed-name).
+        """
+        out = tmp_path / "output.ttl"
+        subjects = [EX.Animal, EX.Dog]
+
+        serialise_turtle(small_graph, subjects, out)
+
+        content = out.read_text(encoding="utf-8")
+        for line in content.splitlines():
+            if line.startswith("@prefix ") or line.startswith("PREFIX "):
+                assert line.startswith("@prefix "), (
+                    f"Prefix declaration uses invalid syntax (expected @prefix): {line!r}"
+                )
+                assert line.endswith(" ."), (
+                    f"Turtle @prefix declaration must end with ' .': {line!r}"
+                )
+
+    def test_no_sparql_prefix_in_output(
+        self, small_graph: Graph, tmp_path: Path
+    ) -> None:
+        """Output must not contain any bare SPARQL-style PREFIX declarations."""
+        out = tmp_path / "output.ttl"
+        subjects = [EX.Animal, EX.Dog]
+
+        serialise_turtle(small_graph, subjects, out)
+
+        content = out.read_text(encoding="utf-8")
+        sparql_prefix_lines = [
+            line for line in content.splitlines() if line.startswith("PREFIX ")
+        ]
+        assert sparql_prefix_lines == [], (
+            f"Output contains SPARQL PREFIX declarations (invalid Turtle): "
+            f"{sparql_prefix_lines}"
+        )
+
     def test_output_with_overlapping_namespaces(
         self, overlapping_ns_graph: Graph, tmp_path: Path
     ) -> None:
@@ -168,9 +210,9 @@ class TestSerialiseTurtlePrefixes:
 
         content = out.read_text(encoding="utf-8")
         prefix_lines = [
-            line for line in content.splitlines() if line.startswith("PREFIX ")
+            line for line in content.splitlines() if line.startswith("@prefix ")
         ]
-        declared = {line.split(":")[0].replace("PREFIX ", "") for line in prefix_lines}
+        declared = {line.split(":")[0].replace("@prefix ", "") for line in prefix_lines}
 
         assert "dc" in declared
         assert "dcterms" in declared


### PR DESCRIPTION
## Summary

The `order` command was emitting SPARQL-style `PREFIX` declarations in Turtle output. `PREFIX` without `@` and without a trailing ` .` is not valid Turtle (W3C spec). Strictly conformant parsers — triple stores loaded via a Turtle endpoint, validators, and rdflib in strict mode — reject the output.

## Related Issues

Closes #56

## Changes

- `src/rdf_construct/core/serialiser.py`: one-line change in `serialise_turtle()` — `f"PREFIX {prefix}: <{namespace}>"` → `f"@prefix {prefix}: <{namespace}> ."`
- `tests/test_serialiser_prefixes.py`: two new regression tests asserting that every prefix line uses `@prefix … .` form and that no bare `PREFIX` lines appear; existing test updated to match on `@prefix ` rather than `PREFIX `

## Testing

Full test suite passes locally, including the new tests.

## Breaking Changes

None. Output format corrected to valid Turtle; any tool that was inadvertently tolerating the invalid `PREFIX` form will continue to work.