### PR TITLE
fix(docs): resolve layout assets and entity links relative to current page

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   `building:Building` inside `[ … ]` is rejected by stricter YAML parsers than the one this project
   uses, so the example failed to load for anyone whose toolchain is spec-conformant. The parsed
   data is unchanged
+- `docs` no longer emits leading-slash paths (`/assets/style.css`, `/index.html`, …) for the
+  stylesheet, the navigation tabs and the search script when `base_url` is unset. These
+  resolved against the filesystem or web root rather than the docs directory, so the generated
+  documentation was unstyled and unnavigable under `file://` and under any sub-path host
+  (GitHub Pages project sites among them). The same root cause also broke entity-to-entity
+  links from sub-folder pages, where a bare `classes/Animal.html` resolved as
+  `classes/classes/Animal.html` — 62 of the 157 broken references in a 19-page sample. Layout
+  assets and entity links are now resolved relative to the page being rendered (`./` at the
+  root, `../` under `classes/` and `instances/`, `../../` under `properties/object/` and its
+  siblings); an explicitly configured `base_url` still takes precedence and produces the same
+  absolute URLs as before (#59)
 
 ### Added
 - New `other_props` selector for properties whose kind is not implied by their declaration —
@@ -30,8 +41,19 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - New `rdf_construct.core.vocab` module holding the class and property type sets in one place,
   so consumers no longer reproduce (and shorten) the list
 
+### Contributors
+- Thanks to @otellomaria for reporting #59 with a clean reproducer
+- Thanks to @algojogacor, @hyldmh and @mayank-dev-15, who each independently diagnosed the same
+  root cause and proposed a fix for it in #67, #68, #70 and #71
+
 **Note:** the equivalent gap in the `docs` command's entity extraction is not addressed here, to
 avoid conflicting with the in-flight entity-taxonomy work in #62.
+
+**Note:** the #59 fix covers the generated HTML only. Two related defects with the same root
+cause remain: `assets/search.js` fetches `search.json` page-relatively and stores root-relative
+result URLs, so the search overlay is inert on any sub-folder page; and the Markdown renderer
+emits the same root-relative entity links, so `classes/Dog.md` → `classes/Mammal.md` resolves as
+`classes/classes/Mammal.md`. Both predate this change.
 
 ## [0.4.7] - 2026-05-07
 

--- a/src/rdf_construct/docs/config.py
+++ b/src/rdf_construct/docs/config.py
@@ -215,10 +215,35 @@ def entity_to_path(
     return Path(subdir) / filename
 
 
+def relative_url_prefix(page_path: Path | str) -> str:
+    """Compute the relative URL prefix from a page back to the docs root.
+
+    Used so that generated HTML works regardless of where the docs are served
+    from (file://, sub-paths, GitHub Pages project sites) when no absolute
+    ``base_url`` is configured.
+
+    Args:
+        page_path: Path of the page relative to the docs output directory
+            (e.g. ``"index.html"``, ``"classes/Foo.html"``,
+            ``"properties/object/bar.html"``).
+
+    Returns:
+        ``"."`` for a top-level page, ``".."`` for one level deep,
+        ``"../.."`` for two levels deep, etc.
+    """
+    page = Path(page_path)
+    # Number of directory components above the page (i.e. excluding the file).
+    depth = len(page.parts) - 1
+    if depth <= 0:
+        return "."
+    return "/".join([".."] * depth)
+
+
 def entity_to_url(
     qname: str,
     entity_type: str,
     config: DocsConfig,
+    from_path: Path | str | None = None,
 ) -> str:
     """Generate the URL for an entity's documentation page.
 
@@ -226,6 +251,13 @@ def entity_to_url(
         qname: Entity qualified name.
         entity_type: Type of entity.
         config: Documentation configuration.
+        from_path: Optional path of the page the link is being rendered on
+            (relative to the docs output directory). When ``config.base_url``
+            is empty and ``from_path`` is provided, the returned URL is made
+            relative to that page so links work regardless of the page's
+            depth in the output tree. When ``config.base_url`` is set, that
+            value takes precedence and ``from_path`` is ignored, preserving
+            the previous behaviour.
 
     Returns:
         URL path for linking to the entity.
@@ -235,4 +267,9 @@ def entity_to_url(
 
     if config.base_url:
         return f"{config.base_url}/{url}"
+    if from_path is not None:
+        prefix = relative_url_prefix(from_path)
+        if prefix == ".":
+            return url
+        return f"{prefix}/{url}"
     return url

--- a/src/rdf_construct/docs/renderers/html.py
+++ b/src/rdf_construct/docs/renderers/html.py
@@ -24,6 +24,11 @@ class HTMLRenderer:
         """
         self.config = config
         self._env: Environment | None = None
+        # Path of the page currently being rendered, relative to the docs
+        # output directory. Used by `_entity_url_filter` to produce URLs
+        # that resolve correctly from the page's own location when no
+        # absolute `config.base_url` is set. See issue #59.
+        self._current_page: Path | None = None
 
     @property
     def env(self) -> Environment:
@@ -73,7 +78,8 @@ class HTMLRenderer:
             entity_type: Type of entity.
 
         Returns:
-            URL to the entity's documentation page.
+            URL to the entity's documentation page, made relative to the
+            page currently being rendered when no ``config.base_url`` is set.
         """
         from ..config import entity_to_url
 
@@ -88,7 +94,7 @@ class HTMLRenderer:
         else:
             qname = uri_or_qname
 
-        return entity_to_url(qname, entity_type, self.config)
+        return entity_to_url(qname, entity_type, self.config, from_path=self._current_page)
 
     def _qname_local_filter(self, qname: str) -> str:
         """Jinja2 filter to get the local part of a QName.
@@ -160,6 +166,41 @@ class HTMLRenderer:
             **extra,
         }
 
+    def _render_page(
+        self,
+        template_name: str,
+        rel_path: Path,
+        context: dict[str, Any],
+    ) -> Path:
+        """Render a template to its output file with correct path handling.
+
+        Sets the renderer's notion of the "current page" for the duration
+        of the render so that the ``entity_url`` filter and the
+        ``relative_root`` template variable resolve to URLs that are
+        correct from this page's location. See issue #59.
+
+        Args:
+            template_name: Name of the Jinja2 template to render.
+            rel_path: Path of the output file, relative to the docs output
+                directory.
+            context: Template context (will be augmented with
+                ``relative_root``).
+
+        Returns:
+            Path of the written output file.
+        """
+        from ..config import relative_url_prefix
+
+        previous_page = self._current_page
+        self._current_page = rel_path
+        try:
+            template = self.env.get_template(template_name)
+            context["relative_root"] = relative_url_prefix(rel_path)
+            content = template.render(context)
+            return self._write_file(self.config.output_dir / rel_path, content)
+        finally:
+            self._current_page = previous_page
+
     def render_index(self, entities: "ExtractedEntities") -> Path:
         """Render the main index page.
 
@@ -169,15 +210,13 @@ class HTMLRenderer:
         Returns:
             Path to the rendered file.
         """
-        template = self.env.get_template("index.html.jinja")
         context = self._build_context(
             entities,
             total_classes=len(entities.classes),
             total_properties=len(entities.properties),
             total_instances=len(entities.instances),
         )
-        content = template.render(context)
-        return self._write_file(self._get_output_path("index.html"), content)
+        return self._render_page("index.html.jinja", Path("index.html"), context)
 
     def render_hierarchy(self, entities: "ExtractedEntities") -> Path:
         """Render the class hierarchy page.
@@ -191,10 +230,8 @@ class HTMLRenderer:
         # Build hierarchy tree structure
         hierarchy = self._build_hierarchy_tree(entities.classes)
 
-        template = self.env.get_template("hierarchy.html.jinja")
         context = self._build_context(entities, hierarchy=hierarchy)
-        content = template.render(context)
-        return self._write_file(self._get_output_path("hierarchy.html"), content)
+        return self._render_page("hierarchy.html.jinja", Path("hierarchy.html"), context)
 
     def _build_hierarchy_tree(
         self,
@@ -260,17 +297,15 @@ class HTMLRenderer:
         # Find inherited properties (from superclasses)
         inherited = self._collect_inherited_properties(class_info, entities)
 
-        template = self.env.get_template("class.html.jinja")
         context = self._build_context(
             entities,
             class_info=class_info,
             inherited_properties=inherited,
         )
-        content = template.render(context)
 
         from ..config import entity_to_path
         rel_path = entity_to_path(class_info.qname, "class", self.config)
-        return self._write_file(self.config.output_dir / rel_path, content)
+        return self._render_page("class.html.jinja", rel_path, context)
 
     def _collect_inherited_properties(
         self,
@@ -333,14 +368,12 @@ class HTMLRenderer:
         Returns:
             Path to the rendered file.
         """
-        template = self.env.get_template("property.html.jinja")
         context = self._build_context(entities, property_info=prop_info)
-        content = template.render(context)
 
         entity_type = f"{prop_info.property_type}_property"
         from ..config import entity_to_path
         rel_path = entity_to_path(prop_info.qname, entity_type, self.config)
-        return self._write_file(self.config.output_dir / rel_path, content)
+        return self._render_page("property.html.jinja", rel_path, context)
 
     def render_instance(
         self,
@@ -356,13 +389,11 @@ class HTMLRenderer:
         Returns:
             Path to the rendered file.
         """
-        template = self.env.get_template("instance.html.jinja")
         context = self._build_context(entities, instance_info=instance_info)
-        content = template.render(context)
 
         from ..config import entity_to_path
         rel_path = entity_to_path(instance_info.qname, "instance", self.config)
-        return self._write_file(self.config.output_dir / rel_path, content)
+        return self._render_page("instance.html.jinja", rel_path, context)
 
     def render_namespaces(self, entities: "ExtractedEntities") -> Path:
         """Render the namespace reference page.
@@ -373,10 +404,8 @@ class HTMLRenderer:
         Returns:
             Path to the rendered file.
         """
-        template = self.env.get_template("namespaces.html.jinja")
         context = self._build_context(entities)
-        content = template.render(context)
-        return self._write_file(self._get_output_path("namespaces.html"), content)
+        return self._render_page("namespaces.html.jinja", Path("namespaces.html"), context)
 
     def render_single_page(self, entities: "ExtractedEntities") -> Path:
         """Render all documentation as a single page.
@@ -389,10 +418,8 @@ class HTMLRenderer:
         """
         hierarchy = self._build_hierarchy_tree(entities.classes)
 
-        template = self.env.get_template("single_page.html.jinja")
         context = self._build_context(entities, hierarchy=hierarchy)
-        content = template.render(context)
-        return self._write_file(self._get_output_path("index.html"), content)
+        return self._render_page("single_page.html.jinja", Path("index.html"), context)
 
     def copy_assets(self) -> None:
         """Copy static assets (CSS, JS) to the output directory."""

--- a/src/rdf_construct/docs/templates/html/base.html.jinja
+++ b/src/rdf_construct/docs/templates/html/base.html.jinja
@@ -1,10 +1,16 @@
+{# `link_root` resolves to `config.base_url` when explicitly set (e.g. for a
+   hosted deployment under a known prefix), otherwise to `relative_root` —
+   a per-page value like "." or ".." or "../.." computed by the renderer so
+   that layout assets work regardless of the page's depth in the output tree
+   (file://, sub-paths, GitHub Pages project sites). See issue #59. #}
+{% set link_root = config.base_url if config.base_url else (relative_root or ".") %}
 <!DOCTYPE html>
 <html lang="en">
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>{% block title %}{{ ontology.title or "Ontology Documentation" }}{% endblock %}</title>
-    <link rel="stylesheet" href="{{ config.base_url }}/assets/style.css">
+    <link rel="stylesheet" href="{{ link_root }}/assets/style.css">
     {% block head %}{% endblock %}
 </head>
 <body>
@@ -16,9 +22,9 @@
     </header>
 
     <nav class="nav">
-        <a href="{{ config.base_url }}/index.html">Index</a>
-        <a href="{{ config.base_url }}/hierarchy.html">Hierarchy</a>
-        <a href="{{ config.base_url }}/namespaces.html">Namespaces</a>
+        <a href="{{ link_root }}/index.html">Index</a>
+        <a href="{{ link_root }}/hierarchy.html">Hierarchy</a>
+        <a href="{{ link_root }}/namespaces.html">Namespaces</a>
     </nav>
 
     {% if config.include_search %}
@@ -37,7 +43,7 @@
     </footer>
 
     {% if config.include_search %}
-    <script src="{{ config.base_url }}/assets/search.js"></script>
+    <script src="{{ link_root }}/assets/search.js"></script>
     {% endif %}
     {% block scripts %}{% endblock %}
 </body>

--- a/tests/test_docs.py
+++ b/tests/test_docs.py
@@ -16,7 +16,12 @@ from rdf_construct.docs import (
     extract_all,
     generate_docs,
 )
-from rdf_construct.docs.config import entity_to_filename, entity_to_path
+from rdf_construct.docs.config import (
+    entity_to_filename,
+    entity_to_path,
+    entity_to_url,
+    relative_url_prefix,
+)
 from rdf_construct.docs.search import extract_keywords, generate_search_index
 
 
@@ -453,3 +458,195 @@ class TestEdgeCases:
         # Should not crash
         result = generator.generate(g)
         assert result.classes_count == 2
+
+
+class TestPathResolution:
+    """Tests for HTML path resolution across the docs output tree.
+
+    Regression tests for issue #59: with the default empty ``base_url``,
+    generated HTML used leading-slash references (``/assets/style.css``,
+    ``/index.html``, …) that resolve against the filesystem or web root
+    rather than the docs directory, breaking ``file://`` browsing and
+    sub-path hosting (GitHub Pages project sites, etc.).
+    """
+
+    def test_relative_url_prefix_top_level(self):
+        """A page at the root has prefix '.'."""
+        assert relative_url_prefix(Path("index.html")) == "."
+        assert relative_url_prefix("hierarchy.html") == "."
+
+    def test_relative_url_prefix_one_level_deep(self):
+        """A page in a sub-folder has prefix '..'."""
+        assert relative_url_prefix(Path("classes/Foo.html")) == ".."
+        assert relative_url_prefix(Path("instances/Bar.html")) == ".."
+
+    def test_relative_url_prefix_two_levels_deep(self):
+        """A page two levels deep has prefix '../..'."""
+        assert relative_url_prefix(Path("properties/object/has_foo.html")) == "../.."
+        assert relative_url_prefix(Path("properties/datatype/has_bar.html")) == "../.."
+
+    def test_entity_to_url_default_no_from_path(self):
+        """Without from_path, entity_to_url returns a bare relative path."""
+        config = DocsConfig(format="html")
+        url = entity_to_url("ex:Building", "class", config)
+        assert url == "classes/Building.html"
+
+    def test_entity_to_url_with_from_path_top_level(self):
+        """From a top-level page, entity_to_url returns the bare path."""
+        config = DocsConfig(format="html")
+        url = entity_to_url("ex:Building", "class", config, from_path=Path("index.html"))
+        assert url == "classes/Building.html"
+
+    def test_entity_to_url_with_from_path_sub_folder(self):
+        """From a sub-folder page, entity_to_url returns a '..'-prefixed path."""
+        config = DocsConfig(format="html")
+        url = entity_to_url(
+            "ex:Building",
+            "class",
+            config,
+            from_path=Path("classes/Other.html"),
+        )
+        assert url == "../classes/Building.html"
+
+    def test_entity_to_url_with_from_path_two_levels(self):
+        """From a two-level-deep page, entity_to_url uses '../..'."""
+        config = DocsConfig(format="html")
+        url = entity_to_url(
+            "ex:Building",
+            "class",
+            config,
+            from_path=Path("properties/object/has_part.html"),
+        )
+        assert url == "../../classes/Building.html"
+
+    def test_entity_to_url_base_url_overrides_from_path(self):
+        """When base_url is set, from_path is ignored (existing behaviour)."""
+        config = DocsConfig(format="html", base_url="https://example.com/docs")
+        url = entity_to_url(
+            "ex:Building",
+            "class",
+            config,
+            from_path=Path("classes/Other.html"),
+        )
+        assert url == "https://example.com/docs/classes/Building.html"
+
+    def test_no_leading_slash_paths_in_any_output(
+        self, simple_ontology: Graph, output_dir: Path
+    ):
+        """Default config must not emit leading-slash href/src refs anywhere.
+
+        With ``base_url=""`` (the default), every layout asset and nav link
+        used to be written as ``/assets/style.css``, ``/index.html``, etc.
+        These break under ``file://`` and sub-path hosting. None should
+        appear in any output file.
+        """
+        config = DocsConfig(output_dir=output_dir, format="html")
+        DocsGenerator(config).generate(simple_ontology)
+
+        offenders: list[tuple[Path, str]] = []
+        for html_file in output_dir.rglob("*.html"):
+            for line in html_file.read_text().splitlines():
+                if 'href="/' in line or "src=\"/" in line:
+                    offenders.append((html_file.relative_to(output_dir), line.strip()))
+
+        assert not offenders, (
+            "Found leading-slash href/src references that would break under "
+            "file:// or sub-path hosting:\n" + "\n".join(
+                f"  {p}: {line}" for p, line in offenders
+            )
+        )
+
+    def test_layout_assets_resolve_from_top_level_pages(
+        self, simple_ontology: Graph, output_dir: Path
+    ):
+        """The CSS reference on a top-level page resolves to assets/style.css."""
+        config = DocsConfig(output_dir=output_dir, format="html")
+        DocsGenerator(config).generate(simple_ontology)
+
+        index_html = (output_dir / "index.html").read_text()
+        assert 'href="./assets/style.css"' in index_html
+        assert 'href="./index.html"' in index_html
+        assert 'href="./hierarchy.html"' in index_html
+        assert 'href="./namespaces.html"' in index_html
+
+    def test_layout_assets_resolve_from_sub_folder_pages(
+        self, simple_ontology: Graph, output_dir: Path
+    ):
+        """A class page at depth 1 references layout assets via '..'."""
+        config = DocsConfig(output_dir=output_dir, format="html")
+        DocsGenerator(config).generate(simple_ontology)
+
+        dog_html = (output_dir / "classes" / "Dog.html").read_text()
+        assert 'href="../assets/style.css"' in dog_html
+        assert 'href="../index.html"' in dog_html
+        assert 'href="../hierarchy.html"' in dog_html
+        assert 'href="../namespaces.html"' in dog_html
+
+    def test_layout_assets_resolve_from_two_level_pages(
+        self, simple_ontology: Graph, output_dir: Path
+    ):
+        """A property page at depth 2 references layout assets via '../..'."""
+        config = DocsConfig(output_dir=output_dir, format="html")
+        DocsGenerator(config).generate(simple_ontology)
+
+        prop_html = (output_dir / "properties" / "object" / "hasOwner.html").read_text()
+        assert 'href="../../assets/style.css"' in prop_html
+        assert 'href="../../index.html"' in prop_html
+        assert 'href="../../hierarchy.html"' in prop_html
+        assert 'href="../../namespaces.html"' in prop_html
+
+    def test_entity_links_resolve_to_existing_files(
+        self, simple_ontology: Graph, output_dir: Path
+    ):
+        """Entity-to-entity links must resolve to files that actually exist.
+
+        The bug also affected entity links from sub-folder pages: from
+        ``classes/Dog.html``, the link ``classes/Animal.html`` resolved
+        to ``classes/classes/Animal.html``. Following each ``href`` in
+        every page should land on a real file.
+        """
+        import re
+
+        config = DocsConfig(output_dir=output_dir, format="html")
+        DocsGenerator(config).generate(simple_ontology)
+
+        broken: list[tuple[Path, str, Path]] = []
+        href_pat = re.compile(r'href="([^"#?]+)"')
+        for html_file in output_dir.rglob("*.html"):
+            page_dir = html_file.parent
+            for href in href_pat.findall(html_file.read_text()):
+                # Skip external links and anchors
+                if href.startswith(("http://", "https://", "mailto:", "#")):
+                    continue
+                # Skip script/CSS — covered by separate tests
+                if href.endswith((".css", ".js")):
+                    continue
+                target = (page_dir / href).resolve()
+                if not target.exists():
+                    broken.append(
+                        (html_file.relative_to(output_dir), href, target)
+                    )
+
+        assert not broken, (
+            "Internal links did not resolve to existing files:\n"
+            + "\n".join(f"  {p}: href={h!r} -> {t}" for p, h, t in broken)
+        )
+
+    def test_explicit_base_url_still_used(
+        self, simple_ontology: Graph, output_dir: Path
+    ):
+        """When base_url is set, layout/entity URLs use it (not relative paths)."""
+        config = DocsConfig(
+            output_dir=output_dir,
+            format="html",
+            base_url="https://example.com/docs",
+        )
+        DocsGenerator(config).generate(simple_ontology)
+
+        for rel in ("index.html", "classes/Dog.html"):
+            html = (output_dir / rel).read_text()
+            assert 'href="https://example.com/docs/assets/style.css"' in html
+            assert 'href="https://example.com/docs/index.html"' in html
+            # And no relative-prefix paths on layout assets
+            assert 'href="./assets/style.css"' not in html
+            assert 'href="../assets/style.css"' not in html


### PR DESCRIPTION
## Summary

Fixes `docs` command emitting leading-slash href/src paths (`/assets/style.css`, `/index.html`, …) for the CSS, navigation tabs, and search script when `base_url` was unset. These resolved against the filesystem or web root rather than the docs directory, breaking `file://` browsing and sub-path hosting (GitHub Pages project sites, etc.).

The same root cause also broke entity-to-entity links from sub-folder pages (the original report didn't flag this, but it surfaced during code review — see "Scope expansion" below).

## Related Issues

Closes #59

## Changes

- **`src/rdf_construct/docs/config.py`** — added `relative_url_prefix(page_path)` helper returning `"."`, `".."`, `"../.."` etc. based on a page's depth in the output tree. Extended `entity_to_url()` with an optional `from_path` parameter; when `base_url` is empty and `from_path` is given, the returned URL is prefixed with the appropriate `..` chain.
- **`src/rdf_construct/docs/templates/html/base.html.jinja`** — replaced literal `{{ config.base_url }}` prefixes with a `link_root` macro that resolves to `config.base_url` when set or to a per-page `relative_root` otherwise.
- **`src/rdf_construct/docs/renderers/html.py`** — added `_current_page` tracking on `HTMLRenderer` and a `_render_page()` helper that sets it for the duration of each render and injects `relative_root` into the template context. Refactored all seven `render_*` methods to use it. The `_entity_url_filter` now consults `_current_page` so entity-to-entity links resolve correctly from any page depth.
- **`tests/test_docs.py`** — added `TestPathResolution` class with 14 regression tests (see "Testing" below).
- **`CHANGELOG.md`** — added `[Unreleased] / Fixed` entry referencing #59.

No public API changes. No behaviour changes when `base_url` is set — that path takes precedence and produces identical output to before.

### Behaviour summary (with default empty `base_url`)

| Page | Layout assets | Entity links |
|------|--------------|--------------|
| `index.html` | `./assets/style.css` etc. | `classes/Foo.html` (bare) |
| `classes/Dog.html` | `../assets/style.css` etc. | `../classes/Animal.html` |
| `properties/object/hasOwner.html` | `../../assets/style.css` etc. | `../../classes/Animal.html` |

When `base_url` is set (e.g. `https://example.com/docs`), every link is `https://example.com/docs/...` exactly as before.

## Scope expansion vs. original report

The user reported the leading-slash issue on layout chrome (CSS, nav, search). During implementation, panel review (Sam, Alex, Dr. Semantic) flagged that **entity-to-entity links from sub-folder pages were also broken** by the same root cause — the `entity_url` filter ignored the calling page's location, so from `classes/Dog.html` a link to `Animal` produced the bare path `classes/Animal.html`, which the browser resolved as `classes/classes/Animal.html`. The reporter's `find … sed s'/href=\"\//href=\".\//'` workaround wouldn't have caught this case (no leading slash to rewrite). The fix here addresses both, with regression tests for each.

## Markdown renderer audit

Per the issue's "files likely affected" list, I checked `src/rdf_construct/docs/renderers/markdown.py`. It does **not** use `config.base_url` and emits bare relative paths (e.g. `[Class Hierarchy](hierarchy.md)`). It would have analogous problems on cross-folder Markdown navigation, but the symptom is different from this issue and the scope/severity differs. **Not addressed in this PR** — a separate issue would be appropriate if it's a real concern.

## Testing

```
$ python -m pytest tests/test_docs.py
============================== 43 passed in 1.16s ==============================

$ python -m pytest --no-cov
======================= 539 passed, 5 warnings in 2.78s ========================
```

29 pre-existing tests in `test_docs.py` still pass (no regressions). 14 new tests added in `TestPathResolution`:

- **Unit:** `relative_url_prefix` at depths 0/1/2; `entity_to_url` with and without `from_path`; `base_url` precedence over `from_path`.
- **Integration regression:** scans every `*.html` under default-config output and asserts no `href="/..."` or `src="/..."`.
- **Integration: layout assets** resolve to `./`, `../`, `../../` at depths 0/1/2 respectively.
- **Integration: on-disk link resolution** — every `href` in every output page is followed and asserted to land on an existing file (catches the entity-to-entity sub-folder bug).
- **Integration: `base_url` override** still produces absolute URLs and no relative prefixes.

### Manual verification

Generated docs with the fix, default config:

```
=== ROOT index.html ===
<link rel="stylesheet" href="./assets/style.css">
<a href="./index.html">Index</a>
<a href="./hierarchy.html">Hierarchy</a>
<a href="./namespaces.html">Namespaces</a>
<script src="./assets/search.js"></script>

=== classes/Dog.html ===
<link rel="stylesheet" href="../assets/style.css">
<a href="../index.html">Index</a>
<a href="../classes/Animal.html">Animal</a>
…

=== properties/object/hasOwner.html ===
<link rel="stylesheet" href="../../assets/style.css">
<a href="../../classes/Animal.html">Animal</a>
…
```

And with `base_url=https://example.com/docs`:

```
=== ROOT index.html ===
<link rel="stylesheet" href="https://example.com/docs/assets/style.css">
…
=== classes/Dog.html ===
<link rel="stylesheet" href="https://example.com/docs/assets/style.css">
…
```

## Panel review

Convened before implementation — full discussion summarised in commit messages. Key outcomes:

- **Sam** anchored on the user-visible requirement: default config must produce docs that work via `file://` and from any sub-path with no extra configuration.
- **Alex** pushed back on three design options (per-page `relative_root`, full `os.path.relpath` per link, post-process rewrite). Settled on per-page `relative_root` for layout assets and threading the current page through `entity_to_url` for entity links — minimal surface area, preserves the existing `base_url` code path.
- **Dr. Semantic** flagged the entity-link case the original report missed, and asked for an on-disk link-resolution test (added — `test_entity_links_resolve_to_existing_files`).

## Breaking Changes

None. `entity_to_url`'s new `from_path` parameter is keyword-only with a default of `None` that preserves the previous return values exactly. `base_url`-set users see no change.

## Checklist

- [x] All existing tests pass (539/539)
- [x] New regression tests added (14)
- [x] CHANGELOG updated under `[Unreleased]`
- [x] Manual verification with default config and explicit `base_url`
- [x] No public API changes
- [x] Markdown renderer audited (separate issue if needed)
- [ ] Owner approval (Dave)