### PR TITLE
feat(docs): add SHACL shapes as a first-class entity type

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -76,9 +76,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   `EntityKind` enum members. Default values: `[CLASS]` for classes,
   `[PROPERTY, <type>_PROPERTY]` for properties, `[INSTANCE]` for instances,
   and `[SHAPE, NODE_SHAPE]` / `[SHAPE, PROPERTY_SHAPE]` for shapes. A NodeShape
-  that's also typed `owl:NamedIndividual` carries both kinds and is placed in
-  the Shapes section (not Instances). This is the extension point for
-  upcoming work on SKOS support and `owl:NamedIndividual` recognition
+  that is also typed `owl:NamedIndividual` is placed in the Shapes section
+  rather than Instances, so it is documented once rather than twice. It does
+  not yet carry a named-individual kind — there is no `NAMED_INDIVIDUAL` member
+  in the enum, and recognising that type is stage 2/3 work. The `kinds` list is
+  the extension point for it, and for SKOS support
 - New `EntityKind` enum (str-mixin) exported from `rdf_construct.docs`,
   centralising kind values. Members: `CLASS`, `PROPERTY`, `OBJECT_PROPERTY`,
   `DATATYPE_PROPERTY`, `ANNOTATION_PROPERTY`, `RDF_PROPERTY`, `INSTANCE`,

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,6 +32,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   root, `../` under `classes/` and `instances/`, `../../` under `properties/object/` and its
   siblings); an explicitly configured `base_url` still takes precedence and produces the same
   absolute URLs as before (#59)
+- Fixed `_walk_rdf_list` and `extract_property_shape_info` silently truncating
+  `rdf:List` members at the first cell when the list-rest pointer was a blank
+  node (the rdflib default representation). In practice this meant `sh:in`
+  constraints with multiple values lost everything except the first member
+  during extraction. Both call sites now accept blank-node list pointers.
+  Found while writing tests for #60
 
 ### Added
 - New `other_props` selector for properties whose kind is not implied by their declaration —
@@ -40,6 +46,88 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   section before `individuals` groups them instead
 - New `rdf_construct.core.vocab` module holding the class and property type sets in one place,
   so consumers no longer reproduce (and shorten) the list
+- **First-class SHACL shape support in the `docs` command** (#60). NodeShapes
+  (`sh:NodeShape`) and named PropertyShapes (`sh:PropertyShape` with their own
+  URI) are now rendered as a distinct entity type alongside Classes, Properties,
+  and Instances, in HTML, Markdown, and JSON output:
+  - Each shape gets its own page under `shapes/`, with kind badges
+    (`shape`, `node_shape`, `property_shape`) distinguishing NodeShapes from
+    named PropertyShapes
+  - The 21 most-used SHACL constraints (`sh:path`, `sh:minCount`, `sh:maxCount`,
+    `sh:datatype`, `sh:class`, `sh:nodeKind`, `sh:in`, `sh:hasValue`,
+    `sh:pattern`, `sh:minLength`, `sh:maxLength`, `sh:minInclusive`,
+    `sh:maxInclusive`, `sh:targetClass`, `sh:targetNode`, `sh:targetSubjectsOf`,
+    `sh:targetObjectsOf`, `sh:closed`, `sh:ignoredProperties`, `sh:name`,
+    `sh:description`) get explicit per-format rendering; everything else
+    (including `sh:severity`, `sh:order`, `sh:qualifiedValueShape`, etc.) falls
+    back to a generic visible-but-plain key-value display rather than being
+    silently dropped
+  - Blank-node PropertyShapes attached to a NodeShape via `sh:property` render
+    inline on the parent shape's page as a constraint table; named
+    PropertyShapes get their own pages plus an inline reference + link from any
+    NodeShape that uses them
+  - `sh:targetClass`, `sh:path`, and references to named PropertyShapes resolve
+    to clickable cross-references when the target is in the ontology, falling
+    back to plain code-formatted URIs otherwise
+  - Logical operators (`sh:and`, `sh:or`, `sh:xone`) and `sh:qualifiedValueShape`
+    are deferred — they need their own design pass and will be handled in a
+    future release
+- **Multi-kind data model.** Entities now carry a `kinds` list of
+  `EntityKind` enum members. Default values: `[CLASS]` for classes,
+  `[PROPERTY, <type>_PROPERTY]` for properties, `[INSTANCE]` for instances,
+  and `[SHAPE, NODE_SHAPE]` / `[SHAPE, PROPERTY_SHAPE]` for shapes. A NodeShape
+  that's also typed `owl:NamedIndividual` carries both kinds and is placed in
+  the Shapes section (not Instances). This is the extension point for
+  upcoming work on SKOS support and `owl:NamedIndividual` recognition
+- New `EntityKind` enum (str-mixin) exported from `rdf_construct.docs`,
+  centralising kind values. Members: `CLASS`, `PROPERTY`, `OBJECT_PROPERTY`,
+  `DATATYPE_PROPERTY`, `ANNOTATION_PROPERTY`, `RDF_PROPERTY`, `INSTANCE`,
+  `SHAPE`, `NODE_SHAPE`, `PROPERTY_SHAPE`. Compares equal to its string
+  values and serialises to JSON as plain strings
+- New `ShapeInfo` and `PropertyShapeInfo` dataclasses, exported from
+  `rdf_construct.docs`. `ShapeInfo` covers NodeShapes and named PropertyShapes;
+  `PropertyShapeInfo` covers individual property constraint blocks (whether
+  blank-node arcs of a NodeShape or top-level constraint sets of a named
+  PropertyShape)
+- New `extract_all_shapes()` extractor and `extract_shape_info()` /
+  `extract_property_shape_info()` helpers
+- New `ExtractedEntities.shapes`, `node_shapes`, and `property_shapes` fields
+  / computed properties
+- New `DocsConfig.include_shapes` flag (default `True`) parallels
+  `include_instances`. When `False`, shapes are excluded from the output
+  pages and from the search index
+- New `--no-shapes` CLI flag and `shapes` accepted in the `--include` /
+  `--exclude` filter values
+- New `shape.html.jinja` template; `shape` entity type added to
+  `entity_to_path` / `entity_to_url` routing under `shapes/`
+- CSS for shape badges in HTML output: `.entity-type.shape` (`#dc2626`,
+  4.83:1 contrast), `.entity-type.node_shape` (`#b91c1c`, 6.47:1),
+  `.entity-type.property_shape` (`#e11d48`, 4.70:1) — all WCAG AA against
+  the badge's white text. Single hue family (red-rose) signals
+  NodeShape/PropertyShape kinship; brightness gradient reads as
+  parent-child. Distinct from the existing purple/cyan/amber/green
+  badges under common colour-vision deficiencies; descriptive uppercase
+  badge text labels (`"NODE SHAPE"`, `"PROPERTY SHAPE"`) carry the
+  category meaning regardless of perceived colour
+- `BaseRenderer.render_shape()` abstract method, implemented in all three
+  renderers (HTML / Markdown / JSON)
+- Comprehensive test coverage: 44 new tests in 7 classes covering shape
+  extraction, multi-kind handling, all three renderers, JSON schema, search
+  index integration, the `include_shapes` toggle, routing, and the
+  `EntityKind` enum contract
+
+### Changed
+- **Breaking change to JSON output**: SHACL shapes used to appear in the
+  `instances` array of `index.json` and `ontology.json` because the extractor
+  didn't filter them out. They now have their own top-level `shapes` array,
+  and shapes have been removed from `instances`. JSON consumers updating from
+  v0.4.x must read both arrays to see all entities. The new top-level
+  `shapes` array contains complete `ShapeInfo` JSON for each shape (single-page
+  mode) or summary entries (index mode) — see `docs/user_guides/DOCS_GUIDE.md`
+  for the full schema. The `statistics` object also gains a `shapes` count (#60)
+- All entity entries in JSON output now include a `kinds` array carrying the
+  full multi-kind list. Existing fields are unchanged. This is additive —
+  consumers that ignore unknown fields are unaffected (#60)
 
 ### Contributors
 - Thanks to @otellomaria for reporting #59 with a clean reproducer

--- a/docs/user_guides/DOCS_GUIDE.md
+++ b/docs/user_guides/DOCS_GUIDE.md
@@ -84,6 +84,141 @@ The JSON output includes:
 - Hierarchy structure
 - Suitable for building custom documentation UIs
 
+#### JSON schema (v0.5.0+)
+
+The top-level shape of `index.json` is:
+
+```json
+{
+  "ontology": { "uri": "...", "title": "...", ... },
+  "statistics": {
+    "classes": 12,
+    "object_properties": 8,
+    "datatype_properties": 5,
+    "annotation_properties": 2,
+    "instances": 3,
+    "shapes": 4
+  },
+  "classes":               [{ "uri": "...", "qname": "...", "label": "..." }, ...],
+  "object_properties":     [{ "uri": "...", "qname": "...", "label": "..." }, ...],
+  "datatype_properties":   [{ "uri": "...", "qname": "...", "label": "..." }, ...],
+  "annotation_properties": [{ "uri": "...", "qname": "...", "label": "..." }, ...],
+  "instances":             [{ "uri": "...", "qname": "...", "label": "..." }, ...],
+  "shapes":                [{ "uri": "...", "qname": "...", "label": "...",
+                              "kinds": ["shape", "node_shape"] }, ...]
+}
+```
+
+Each entity also gets a full per-page JSON file under its type directory
+(`classes/`, `properties/object/`, `properties/datatype/`,
+`properties/annotation/`, `instances/`, or `shapes/`). Per-page files
+contain the complete entity record including all fields.
+
+> **Breaking change in v0.5.0.** SHACL shapes
+> (`sh:NodeShape` / `sh:PropertyShape` instances) used to appear in the
+> `instances` array because the extractor didn't filter them out.
+> v0.5.0 introduces a top-level `shapes` array; shapes no longer appear
+> in `instances`. JSON consumers updating from v0.4.x must read both
+> arrays. See "SHACL Shapes" below for the per-page schema.
+
+## SHACL Shapes
+
+`rdf-construct docs` recognises SHACL shapes (`sh:NodeShape` and
+`sh:PropertyShape`) as a first-class entity type, alongside Classes,
+Properties, and Instances. NodeShapes and named PropertyShapes get
+their own pages; blank-node PropertyShapes attached to a NodeShape via
+`sh:property` are rendered inline on the parent shape's page.
+
+A NodeShape that is also typed as `owl:NamedIndividual` is treated as a
+shape (it appears in the Shapes section, not in Instances). The
+`kinds` field on each shape entry carries the full multi-kind list so
+JSON consumers can distinguish, for example, an
+`owl:NamedIndividual`-flagged NodeShape from a plain one.
+
+Twenty-one SHACL constraints get explicit per-format rendering:
+
+`sh:path`, `sh:minCount`, `sh:maxCount`, `sh:datatype`, `sh:class`,
+`sh:nodeKind`, `sh:in`, `sh:hasValue`, `sh:pattern`, `sh:minLength`,
+`sh:maxLength`, `sh:minInclusive`, `sh:maxInclusive`, `sh:targetClass`,
+`sh:targetNode`, `sh:targetSubjectsOf`, `sh:targetObjectsOf`,
+`sh:closed`, `sh:ignoredProperties`, `sh:name`, `sh:description`.
+
+Anything outside that list (e.g. `sh:severity`, `sh:order`,
+`sh:qualifiedValueShape`) is rendered in a generic key-value fallback
+so it stays visible without bespoke template work. Logical operators
+(`sh:and` / `sh:or` / `sh:xone`) are deferred — a future release will
+give them dedicated rendering.
+
+### Shape JSON schema
+
+A full shape entry (in per-page files and in the `shapes` array of
+`render_single_page` output) looks like:
+
+```json
+{
+  "uri": "http://example.org/PersonShape",
+  "qname": "ex:PersonShape",
+  "kinds": ["shape", "node_shape"],
+  "label": "Person Shape",
+  "definition": "Constraints on Person instances.",
+  "target_classes":      ["http://example.org/Person"],
+  "target_nodes":        [],
+  "target_subjects_of":  [],
+  "target_objects_of":   [],
+  "closed": false,
+  "ignored_properties": [],
+  "properties": [
+    {
+      "uri": null,
+      "qname": null,
+      "is_blank": true,
+      "path": "http://example.org/hasName",
+      "name": null,
+      "description": null,
+      "datatype": "http://www.w3.org/2001/XMLSchema#string",
+      "class": null,
+      "node_kind": null,
+      "min_count": 1,
+      "max_count": 1,
+      "min_length": null,
+      "max_length": 100,
+      "min_inclusive": null,
+      "max_inclusive": null,
+      "pattern": null,
+      "has_value": null,
+      "in_values": [],
+      "other_constraints": {
+        "http://www.w3.org/ns/shacl#severity": [
+          "http://www.w3.org/ns/shacl#Violation"
+        ]
+      }
+    }
+  ],
+  "property_shape": null,
+  "annotations": {},
+  "other_constraints": {}
+}
+```
+
+Schema notes:
+
+- `kinds` is the multi-kind list (always includes `"shape"`; also
+  contains `"node_shape"` and/or `"property_shape"` as appropriate).
+- `class` (without trailing underscore) is used as the JSON key for
+  the `sh:class` constraint on PropertyShapes — matching the SHACL
+  spec.
+- `in_values` (rather than `in`) avoids the Python keyword issue at
+  the consumer end too.
+- `is_blank` distinguishes blank-node PropertyShapes (no stable URI)
+  from named PropertyShapes (which also appear as standalone entries
+  in the `shapes` array).
+- `property_shape` is non-`null` only when the entity is itself a
+  PropertyShape; for NodeShapes it is `null` and the property
+  constraints live in `properties`.
+- `other_constraints` is a `predicate URI -> [values]` map for any
+  SHACL predicate not in the first-class set. Order is the order in
+  which the predicates were encountered.
+
 ## Command Options
 
 ```bash
@@ -101,6 +236,7 @@ rdf-construct docs [OPTIONS] SOURCES...
 | `--title TEXT` | Override ontology title |
 | `--no-search` | Disable search index (HTML only) |
 | `--no-instances` | Exclude instances from output |
+| `--no-shapes` | Exclude SHACL shapes from output |
 | `--include TYPES` | Include only these types (comma-separated) |
 | `--exclude TYPES` | Exclude these types (comma-separated) |
 
@@ -109,17 +245,17 @@ rdf-construct docs [OPTIONS] SOURCES...
 Filter which entity types appear in the documentation:
 
 ```bash
-# Only classes and properties (no instances)
-poetry run rdf-construct docs ontology.ttl --exclude instances
+# Only classes and properties (no instances or shapes)
+poetry run rdf-construct docs ontology.ttl --exclude instances,shapes
 
 # Only classes
 poetry run rdf-construct docs ontology.ttl --include classes
 
-# Classes and object properties only
-poetry run rdf-construct docs ontology.ttl --include classes,object_properties
+# Classes and shapes only
+poetry run rdf-construct docs ontology.ttl --include classes,shapes
 ```
 
-Valid type names: `classes`, `properties`, `object_properties`, `datatype_properties`, `annotation_properties`, `instances`
+Valid type names: `classes`, `properties`, `object_properties`, `datatype_properties`, `annotation_properties`, `instances`, `shapes`
 
 ## Configuration File
 
@@ -137,6 +273,7 @@ include_object_properties: true
 include_datatype_properties: true
 include_annotation_properties: false
 include_instances: true
+include_shapes: true
 
 include_search: true
 include_hierarchy: true
@@ -191,6 +328,9 @@ All templates receive these context variables:
 | `datatype_properties` | List of datatype PropertyInfo objects |
 | `annotation_properties` | List of annotation PropertyInfo objects |
 | `instances` | List of InstanceInfo objects |
+| `shapes` | List of all ShapeInfo objects (NodeShapes and named PropertyShapes) |
+| `node_shapes` | NodeShapes only (filtered subset of `shapes`) |
+| `property_shapes` | Named PropertyShapes only (filtered subset of `shapes`) |
 | `config` | DocsConfig settings |
 
 Entity-specific templates also receive:
@@ -198,6 +338,7 @@ Entity-specific templates also receive:
 - `class.html.jinja`: `class_info`, `inherited_properties`
 - `property.html.jinja`: `property_info`
 - `instance.html.jinja`: `instance_info`
+- `shape.html.jinja`: `shape_info`
 - `hierarchy.html.jinja`: `hierarchy` (tree structure)
 
 ### Custom Filters

--- a/src/rdf_construct/cli.py
+++ b/src/rdf_construct/cli.py
@@ -1025,14 +1025,19 @@ def diff(
     help="Exclude instances from documentation",
 )
 @click.option(
+    "--no-shapes",
+    is_flag=True,
+    help="Exclude SHACL shapes from documentation",
+)
+@click.option(
     "--include",
     type=str,
-    help="Include only these entity types (comma-separated: classes,properties,instances)",
+    help="Include only these entity types (comma-separated: classes,properties,instances,shapes)",
 )
 @click.option(
     "--exclude",
     type=str,
-    help="Exclude these entity types (comma-separated: classes,properties,instances)",
+    help="Exclude these entity types (comma-separated: classes,properties,instances,shapes)",
 )
 def docs(
     sources: tuple[Path, ...],
@@ -1044,6 +1049,7 @@ def docs(
     title: str | None,
     no_search: bool,
     no_instances: bool,
+    no_shapes: bool,
     include: str | None,
     exclude: str | None,
 ):
@@ -1093,6 +1099,7 @@ def docs(
     doc_config.single_page = single_page
     doc_config.include_search = not no_search
     doc_config.include_instances = not no_instances
+    doc_config.include_shapes = not no_shapes
 
     if template:
         doc_config.template_dir = template
@@ -1107,6 +1114,7 @@ def docs(
         doc_config.include_datatype_properties = "properties" in types or "datatype_properties" in types
         doc_config.include_annotation_properties = "properties" in types or "annotation_properties" in types
         doc_config.include_instances = "instances" in types
+        doc_config.include_shapes = "shapes" in types
 
     if exclude:
         types = [t.strip().lower() for t in exclude.split(",")]
@@ -1118,6 +1126,8 @@ def docs(
             doc_config.include_annotation_properties = False
         if "instances" in types:
             doc_config.include_instances = False
+        if "shapes" in types:
+            doc_config.include_shapes = False
 
     # Load RDF sources
     click.echo(f"Loading {len(sources)} source file(s)...")

--- a/src/rdf_construct/docs/__init__.py
+++ b/src/rdf_construct/docs/__init__.py
@@ -29,10 +29,13 @@ For more control, use the DocsGenerator class directly:
 from rdf_construct.docs.config import DocsConfig, load_docs_config
 from rdf_construct.docs.extractors import (
     ClassInfo,
+    EntityKind,
     ExtractedEntities,
     InstanceInfo,
     OntologyInfo,
     PropertyInfo,
+    PropertyShapeInfo,
+    ShapeInfo,
     extract_all,
 )
 from rdf_construct.docs.generator import DocsGenerator, GenerationResult, generate_docs
@@ -52,6 +55,9 @@ __all__ = [
     "InstanceInfo",
     "OntologyInfo",
     "ExtractedEntities",
+    "ShapeInfo",
+    "PropertyShapeInfo",
+    "EntityKind",
     # Extraction
     "extract_all",
     # Search

--- a/src/rdf_construct/docs/config.py
+++ b/src/rdf_construct/docs/config.py
@@ -21,6 +21,10 @@ class DocsConfig:
         template_dir: Custom template directory (overrides defaults).
         single_page: Generate single-page documentation.
         include_instances: Whether to include instances in output.
+        include_shapes: Whether to include SHACL shapes (NodeShapes and
+            named PropertyShapes) as a first-class entity type. Default
+            True. When False, shapes are excluded entirely from output
+            and from the search index.
         include_imports: List of namespaces to treat as "internal".
         exclude_namespaces: List of namespaces to exclude from output.
         language: Preferred language for labels/definitions.
@@ -39,6 +43,7 @@ class DocsConfig:
     template_dir: Path | None = None
     single_page: bool = False
     include_instances: bool = True
+    include_shapes: bool = True
     include_imports: list[str] = field(default_factory=list)
     exclude_namespaces: list[str] = field(default_factory=list)
     language: str = "en"
@@ -81,6 +86,8 @@ class DocsConfig:
             config.single_page = data["single_page"]
         if "include_instances" in data:
             config.include_instances = data["include_instances"]
+        if "include_shapes" in data:
+            config.include_shapes = data["include_shapes"]
         if "include_imports" in data:
             config.include_imports = data["include_imports"]
         if "exclude_namespaces" in data:
@@ -186,7 +193,11 @@ def entity_to_path(
 
     Args:
         qname: Entity qualified name.
-        entity_type: Type of entity (class, object_property, datatype_property, instance).
+        entity_type: Type of entity. Accepts ``"class"``,
+            ``"object_property"``, ``"datatype_property"``,
+            ``"annotation_property"``, ``"instance"``, or ``"shape"``.
+            ``EntityKind`` members are also accepted directly (they
+            compare equal to their string values).
         config: Documentation configuration.
         extension: File extension (defaults based on format).
 
@@ -202,13 +213,16 @@ def entity_to_path(
 
     filename = entity_to_filename(qname) + extension
 
-    # Organise by entity type
+    # Organise by entity type. NodeShapes and named PropertyShapes share
+    # the shapes/ directory — the kind badge on the page distinguishes
+    # them. See issue #60.
     type_dirs = {
         "class": "classes",
         "object_property": "properties/object",
         "datatype_property": "properties/datatype",
         "annotation_property": "properties/annotation",
         "instance": "instances",
+        "shape": "shapes",
     }
 
     subdir = type_dirs.get(entity_type, "other")

--- a/src/rdf_construct/docs/extractors.py
+++ b/src/rdf_construct/docs/extractors.py
@@ -10,7 +10,7 @@ from dataclasses import dataclass, field
 from enum import Enum
 from typing import TYPE_CHECKING
 
-from rdflib import RDF, RDFS, Literal, URIRef
+from rdflib import BNode, RDF, RDFS, Literal, URIRef
 from rdflib.namespace import DCTERMS, OWL, SH, SKOS
 
 if TYPE_CHECKING:
@@ -625,12 +625,18 @@ def extract_instance_info(graph: Graph, uri: URIRef) -> InstanceInfo:
     return info
 
 
-def _walk_rdf_list(graph: Graph, head: URIRef | None) -> list[URIRef | str]:
+def _walk_rdf_list(graph: Graph, head: URIRef | BNode | None) -> list[URIRef | str]:
     """Walk an ``rdf:List`` and return its members as a Python list.
 
     SHACL uses ``rdf:List`` for ``sh:in``, ``sh:ignoredProperties``, and
     similar collection constraints. Returns raw terms (URIRefs preserved
     as URIRef, Literals as ``str``); non-list inputs return empty.
+
+    rdflib represents the list cells as blank nodes by default, so the
+    walker accepts both ``URIRef`` and ``BNode`` as valid list-pointers
+    — earlier versions that only accepted ``URIRef`` silently truncated
+    lists at the first cell because the ``rdf:rest`` pointer is a
+    blank node, not a URI.
 
     Args:
         graph: RDF graph to query.
@@ -640,14 +646,13 @@ def _walk_rdf_list(graph: Graph, head: URIRef | None) -> list[URIRef | str]:
         List of members. Empty if ``head`` is None or rdf:nil.
     """
     members: list[URIRef | str] = []
-    current = head
-    seen: set[URIRef] = set()
+    current: URIRef | BNode | None = head
+    seen: set[URIRef | BNode] = set()
     while current is not None and current != RDF.nil:
         # Cycle protection — malformed lists shouldn't loop forever.
-        if isinstance(current, URIRef):
-            if current in seen:
-                break
-            seen.add(current)
+        if current in seen:
+            break
+        seen.add(current)
         first = next(iter(graph.objects(current, RDF.first)), None)
         if first is not None:
             if isinstance(first, Literal):
@@ -655,7 +660,7 @@ def _walk_rdf_list(graph: Graph, head: URIRef | None) -> list[URIRef | str]:
             elif isinstance(first, URIRef):
                 members.append(first)
         rest = next(iter(graph.objects(current, RDF.rest)), None)
-        current = rest if isinstance(rest, URIRef) else None
+        current = rest if isinstance(rest, (URIRef, BNode)) else None
     return members
 
 
@@ -756,7 +761,7 @@ def extract_property_shape_info(
             elif isinstance(obj, URIRef):
                 info.has_value = obj
         elif pred == SH["in"]:
-            if isinstance(obj, URIRef):
+            if isinstance(obj, (URIRef, BNode)):
                 info.in_values = _walk_rdf_list(graph, obj)
         else:
             # Generic fallback for anything not first-class.

--- a/src/rdf_construct/docs/extractors.py
+++ b/src/rdf_construct/docs/extractors.py
@@ -7,13 +7,55 @@ from RDF ontologies for use in generating navigable documentation.
 from __future__ import annotations
 
 from dataclasses import dataclass, field
+from enum import Enum
 from typing import TYPE_CHECKING
 
 from rdflib import RDF, RDFS, Literal, URIRef
-from rdflib.namespace import DCTERMS, OWL, SKOS
+from rdflib.namespace import DCTERMS, OWL, SH, SKOS
 
 if TYPE_CHECKING:
     from rdflib import Graph
+
+
+class EntityKind(str, Enum):
+    """Discrete entity kinds for the docs taxonomy.
+
+    Subclassing ``str`` is the pre-3.11 idiom for what 3.11's ``StrEnum``
+    does natively: members compare equal to their string values
+    (``EntityKind.SHAPE == "shape"`` is ``True``), serialise to JSON as
+    plain strings, and work as dict keys interchangeably with strings.
+
+    The ``__str__`` override below restores the 3.10-era behaviour of
+    returning the value (``"shape"``) rather than ``"EntityKind.SHAPE"``
+    — Python 3.11 changed the default for ``str`` mixin enums in a way
+    that breaks f-string and template rendering. Without the override,
+    a Jinja template ``{{ kind }}`` would emit ``"EntityKind.SHAPE"``.
+
+    This is the central registry of kind values across the docs module.
+    Adding a new kind (e.g. for SKOS support in stage 2 of the v0.5.0
+    milestone) should land here first; everything else flows through.
+    See issue #60 panel review for the rationale on the multi-kind
+    data model.
+    """
+
+    # Existing taxonomy
+    CLASS = "class"
+    PROPERTY = "property"
+    OBJECT_PROPERTY = "object_property"
+    DATATYPE_PROPERTY = "datatype_property"
+    ANNOTATION_PROPERTY = "annotation_property"
+    RDF_PROPERTY = "rdf_property"
+    INSTANCE = "instance"
+
+    # SHACL shapes (#60)
+    SHAPE = "shape"
+    NODE_SHAPE = "node_shape"
+    PROPERTY_SHAPE = "property_shape"
+
+    def __str__(self) -> str:
+        # Return the string value so f-strings and Jinja render
+        # "shape" rather than "EntityKind.SHAPE". See class docstring.
+        return self.value
 
 
 # Common annotation predicates for extracting labels and definitions
@@ -36,6 +78,7 @@ class PropertyInfo:
 
     uri: URIRef
     qname: str
+    kinds: list[EntityKind] = field(default_factory=list)
     label: str | None = None
     definition: str | None = None
     property_type: str = "property"  # object, datatype, annotation, rdf
@@ -55,6 +98,7 @@ class ClassInfo:
 
     uri: URIRef
     qname: str
+    kinds: list[EntityKind] = field(default_factory=list)
     label: str | None = None
     definition: str | None = None
     superclasses: list[URIRef] = field(default_factory=list)
@@ -74,6 +118,7 @@ class InstanceInfo:
 
     uri: URIRef
     qname: str
+    kinds: list[EntityKind] = field(default_factory=list)
     label: str | None = None
     definition: str | None = None
     types: list[URIRef] = field(default_factory=list)
@@ -94,6 +139,115 @@ class OntologyInfo:
     imports: list[URIRef] = field(default_factory=list)
     namespaces: dict[str, str] = field(default_factory=dict)
     annotations: dict[str, list[str]] = field(default_factory=dict)
+
+
+# First-class SHACL constraints rendered explicitly by the renderers.
+# Anything not in this list falls back to the generic key-value display
+# in PropertyShapeInfo.other_constraints / ShapeInfo.other_constraints.
+# See issue #60 panel review for the rationale on what's included.
+FIRST_CLASS_SHACL_CONSTRAINTS = frozenset(
+    [
+        SH.path,
+        SH.minCount,
+        SH.maxCount,
+        SH.datatype,
+        SH["class"],  # 'class' is a Python keyword
+        SH.nodeKind,
+        SH["in"],  # 'in' is a Python keyword
+        SH.hasValue,
+        SH.pattern,
+        SH.minLength,
+        SH.maxLength,
+        SH.minInclusive,
+        SH.maxInclusive,
+        SH.targetClass,
+        SH.targetNode,
+        SH.targetSubjectsOf,
+        SH.targetObjectsOf,
+        SH.closed,
+        SH.ignoredProperties,
+        SH.name,
+        SH.description,
+    ]
+)
+
+
+@dataclass
+class PropertyShapeInfo:
+    """Information about a SHACL PropertyShape (named or blank-node).
+
+    PropertyShapes attached to a NodeShape via ``sh:property`` are usually
+    blank nodes — they represent constraints on a single property and have
+    no stable identity outside their parent shape. Named PropertyShapes
+    (with their own URI) can be referenced from multiple NodeShapes and
+    are also rendered as standalone pages — see :class:`ShapeInfo`.
+
+    Constraint values are stored as raw RDF terms (URIRef or Literal) so
+    renderers can format them per-output-format. The 20 first-class
+    constraints (see ``FIRST_CLASS_SHACL_CONSTRAINTS``) are stored in
+    named fields; everything else lands in ``other_constraints`` keyed by
+    the predicate URI for visible-but-plain rendering.
+    """
+
+    # Identity. URI is None for blank-node PropertyShapes.
+    uri: URIRef | None = None
+    qname: str | None = None
+    is_blank: bool = True
+
+    # First-class constraints. Most are at-most-one; sh:in is a list.
+    path: URIRef | None = None
+    name: str | None = None
+    description: str | None = None
+    datatype: URIRef | None = None
+    class_: URIRef | None = None  # sh:class
+    node_kind: URIRef | None = None
+    min_count: int | None = None
+    max_count: int | None = None
+    min_length: int | None = None
+    max_length: int | None = None
+    min_inclusive: str | None = None
+    max_inclusive: str | None = None
+    pattern: str | None = None
+    has_value: URIRef | str | None = None
+    in_values: list[URIRef | str] = field(default_factory=list)
+
+    # Anything not first-class: predicate URI -> list of raw object terms.
+    other_constraints: dict[URIRef, list[URIRef | str]] = field(default_factory=dict)
+
+
+@dataclass
+class ShapeInfo:
+    """Information about a SHACL shape (NodeShape or named PropertyShape).
+
+    Captures top-level shape metadata, target declarations, and any
+    PropertyShape arcs (``sh:property``). PropertyShape arcs are
+    extracted as :class:`PropertyShapeInfo` instances so renderers can
+    show them inline on the parent NodeShape's page.
+    """
+
+    uri: URIRef
+    qname: str
+    kinds: list[EntityKind] = field(default_factory=list)  # e.g. [SHAPE, NODE_SHAPE]
+    label: str | None = None
+    definition: str | None = None
+
+    # Target declarations
+    target_classes: list[URIRef] = field(default_factory=list)
+    target_nodes: list[URIRef] = field(default_factory=list)
+    target_subjects_of: list[URIRef] = field(default_factory=list)
+    target_objects_of: list[URIRef] = field(default_factory=list)
+
+    # NodeShape-only structural fields
+    closed: bool = False
+    ignored_properties: list[URIRef] = field(default_factory=list)
+    properties: list[PropertyShapeInfo] = field(default_factory=list)
+
+    # When this is itself a PropertyShape, its own constraints
+    property_shape: PropertyShapeInfo | None = None
+
+    # Generic annotations and any unknown SHACL predicates on the shape
+    annotations: dict[str, list[str]] = field(default_factory=dict)
+    other_constraints: dict[URIRef, list[URIRef | str]] = field(default_factory=dict)
 
 
 def get_qname(graph: Graph, uri: URIRef) -> str:
@@ -296,6 +450,7 @@ def extract_class_info(graph: Graph, uri: URIRef) -> ClassInfo:
     info = ClassInfo(
         uri=uri,
         qname=get_qname(graph, uri),
+        kinds=[EntityKind.CLASS],
         label=get_label(graph, uri),
         definition=get_definition(graph, uri),
         annotations=get_annotations(graph, uri),
@@ -374,6 +529,21 @@ def extract_property_info(graph: Graph, uri: URIRef) -> PropertyInfo:
     elif (uri, RDF.type, RDF.Property) in graph:
         info.property_type = "rdf"
 
+    # Kinds: [PROPERTY, <type>_PROPERTY] — base PROPERTY plus the
+    # specific subtype, so renderers can match on either. The string
+    # value of property_type ("object", "datatype", ...) maps to the
+    # corresponding EntityKind member.
+    _PROPERTY_TYPE_TO_KIND = {
+        "object": EntityKind.OBJECT_PROPERTY,
+        "datatype": EntityKind.DATATYPE_PROPERTY,
+        "annotation": EntityKind.ANNOTATION_PROPERTY,
+        "rdf": EntityKind.RDF_PROPERTY,
+    }
+    info.kinds = [EntityKind.PROPERTY]
+    specific = _PROPERTY_TYPE_TO_KIND.get(info.property_type)
+    if specific is not None:
+        info.kinds.append(specific)
+
     # Domain
     for obj in graph.objects(uri, RDFS.domain):
         if isinstance(obj, URIRef):
@@ -422,6 +592,7 @@ def extract_instance_info(graph: Graph, uri: URIRef) -> InstanceInfo:
     info = InstanceInfo(
         uri=uri,
         qname=get_qname(graph, uri),
+        kinds=[EntityKind.INSTANCE],
         label=get_label(graph, uri),
         definition=get_definition(graph, uri),
         annotations=get_annotations(graph, uri),
@@ -452,6 +623,293 @@ def extract_instance_info(graph: Graph, uri: URIRef) -> InstanceInfo:
             info.properties[pred].append(obj)
 
     return info
+
+
+def _walk_rdf_list(graph: Graph, head: URIRef | None) -> list[URIRef | str]:
+    """Walk an ``rdf:List`` and return its members as a Python list.
+
+    SHACL uses ``rdf:List`` for ``sh:in``, ``sh:ignoredProperties``, and
+    similar collection constraints. Returns raw terms (URIRefs preserved
+    as URIRef, Literals as ``str``); non-list inputs return empty.
+
+    Args:
+        graph: RDF graph to query.
+        head: Head of the rdf:List (or None).
+
+    Returns:
+        List of members. Empty if ``head`` is None or rdf:nil.
+    """
+    members: list[URIRef | str] = []
+    current = head
+    seen: set[URIRef] = set()
+    while current is not None and current != RDF.nil:
+        # Cycle protection — malformed lists shouldn't loop forever.
+        if isinstance(current, URIRef):
+            if current in seen:
+                break
+            seen.add(current)
+        first = next(iter(graph.objects(current, RDF.first)), None)
+        if first is not None:
+            if isinstance(first, Literal):
+                members.append(str(first))
+            elif isinstance(first, URIRef):
+                members.append(first)
+        rest = next(iter(graph.objects(current, RDF.rest)), None)
+        current = rest if isinstance(rest, URIRef) else None
+    return members
+
+
+def _coerce_int(value: object) -> int | None:
+    """Coerce a Literal-or-string SHACL constraint value to an int.
+
+    SHACL count constraints are typed ``xsd:integer`` but rdflib hands
+    them to us as Literals. We convert through ``str`` -> ``int`` and
+    swallow conversion failures rather than crash on malformed shapes.
+    """
+    if value is None:
+        return None
+    try:
+        return int(str(value))
+    except (TypeError, ValueError):
+        return None
+
+
+def extract_property_shape_info(
+    graph: Graph,
+    node: URIRef | None,
+) -> PropertyShapeInfo:
+    """Extract constraint information from a PropertyShape node.
+
+    Works for both named PropertyShapes (when ``node`` is a URIRef and
+    has its own URI) and blank-node PropertyShapes (when ``node`` is a
+    blank node — represented in rdflib as a ``BNode``). The ``is_blank``
+    field on the result reflects the input shape.
+
+    First-class constraints (see ``FIRST_CLASS_SHACL_CONSTRAINTS``) are
+    stored in named fields; everything else lands in
+    ``other_constraints`` keyed by the predicate URI for visible-but-
+    plain rendering.
+
+    Args:
+        graph: RDF graph to query.
+        node: The PropertyShape node (URIRef or blank node).
+
+    Returns:
+        PropertyShapeInfo with extracted constraints.
+    """
+    info = PropertyShapeInfo()
+
+    if isinstance(node, URIRef):
+        info.uri = node
+        info.qname = get_qname(graph, node)
+        info.is_blank = False
+    else:
+        info.is_blank = True
+
+    if node is None:
+        return info
+
+    for pred, obj in graph.predicate_objects(node):
+        if not isinstance(pred, URIRef):
+            continue
+        # Skip rdf:type — handled at the shape level
+        if pred == RDF.type:
+            continue
+
+        # First-class: dispatch by predicate URI.
+        if pred == SH.path:
+            if isinstance(obj, URIRef):
+                info.path = obj
+        elif pred == SH.name:
+            if isinstance(obj, Literal):
+                info.name = str(obj)
+        elif pred == SH.description:
+            if isinstance(obj, Literal):
+                info.description = str(obj)
+        elif pred == SH.datatype:
+            if isinstance(obj, URIRef):
+                info.datatype = obj
+        elif pred == SH["class"]:
+            if isinstance(obj, URIRef):
+                info.class_ = obj
+        elif pred == SH.nodeKind:
+            if isinstance(obj, URIRef):
+                info.node_kind = obj
+        elif pred == SH.minCount:
+            info.min_count = _coerce_int(obj)
+        elif pred == SH.maxCount:
+            info.max_count = _coerce_int(obj)
+        elif pred == SH.minLength:
+            info.min_length = _coerce_int(obj)
+        elif pred == SH.maxLength:
+            info.max_length = _coerce_int(obj)
+        elif pred == SH.minInclusive:
+            info.min_inclusive = str(obj)
+        elif pred == SH.maxInclusive:
+            info.max_inclusive = str(obj)
+        elif pred == SH.pattern:
+            if isinstance(obj, Literal):
+                info.pattern = str(obj)
+        elif pred == SH.hasValue:
+            if isinstance(obj, Literal):
+                info.has_value = str(obj)
+            elif isinstance(obj, URIRef):
+                info.has_value = obj
+        elif pred == SH["in"]:
+            if isinstance(obj, URIRef):
+                info.in_values = _walk_rdf_list(graph, obj)
+        else:
+            # Generic fallback for anything not first-class.
+            if pred not in info.other_constraints:
+                info.other_constraints[pred] = []
+            if isinstance(obj, Literal):
+                info.other_constraints[pred].append(str(obj))
+            elif isinstance(obj, URIRef):
+                info.other_constraints[pred].append(obj)
+
+    return info
+
+
+def extract_shape_info(graph: Graph, uri: URIRef) -> ShapeInfo:
+    """Extract comprehensive information about a SHACL shape.
+
+    Handles both NodeShapes and named PropertyShapes (distinguished
+    via the ``kinds`` field). For NodeShapes, ``sh:property`` arcs
+    are recursively extracted as :class:`PropertyShapeInfo` entries
+    so renderers can inline them on the shape's page.
+
+    Args:
+        graph: RDF graph to query.
+        uri: Shape URI to extract info for.
+
+    Returns:
+        ShapeInfo with all available metadata.
+    """
+    info = ShapeInfo(
+        uri=uri,
+        qname=get_qname(graph, uri),
+        label=get_label(graph, uri),
+        definition=get_definition(graph, uri),
+        annotations=get_annotations(graph, uri),
+    )
+
+    is_node_shape = (uri, RDF.type, SH.NodeShape) in graph
+    is_property_shape = (uri, RDF.type, SH.PropertyShape) in graph
+
+    info.kinds = [EntityKind.SHAPE]
+    if is_node_shape:
+        info.kinds.append(EntityKind.NODE_SHAPE)
+    if is_property_shape:
+        info.kinds.append(EntityKind.PROPERTY_SHAPE)
+    # If neither (shouldn't happen since the caller only passes shape URIs)
+    # we still mark it as a shape so renderers don't crash on missing kind.
+
+    # Top-level (NodeShape and PropertyShape both can have these)
+    for obj in graph.objects(uri, SH.targetClass):
+        if isinstance(obj, URIRef):
+            info.target_classes.append(obj)
+    for obj in graph.objects(uri, SH.targetNode):
+        if isinstance(obj, URIRef):
+            info.target_nodes.append(obj)
+    for obj in graph.objects(uri, SH.targetSubjectsOf):
+        if isinstance(obj, URIRef):
+            info.target_subjects_of.append(obj)
+    for obj in graph.objects(uri, SH.targetObjectsOf):
+        if isinstance(obj, URIRef):
+            info.target_objects_of.append(obj)
+
+    # NodeShape structural fields
+    if is_node_shape:
+        for obj in graph.objects(uri, SH.closed):
+            if isinstance(obj, Literal):
+                info.closed = bool(obj)
+                break
+        ignored_head = next(iter(graph.objects(uri, SH.ignoredProperties)), None)
+        if ignored_head is not None:
+            members = _walk_rdf_list(graph, ignored_head)
+            info.ignored_properties = [m for m in members if isinstance(m, URIRef)]
+
+        # Property shape arcs — extract each as a PropertyShapeInfo
+        for prop_node in graph.objects(uri, SH.property):
+            # prop_node is typically a blank node; extract_property_shape_info
+            # handles both blank and named cases.
+            info.properties.append(extract_property_shape_info(graph, prop_node))
+
+    # If this shape is itself a PropertyShape, capture its own constraints.
+    if is_property_shape:
+        info.property_shape = extract_property_shape_info(graph, uri)
+
+    # Generic fallback for any non-first-class SHACL predicate at the
+    # top level — same approach as PropertyShapeInfo.other_constraints.
+    handled_at_top_level = {
+        SH.targetClass,
+        SH.targetNode,
+        SH.targetSubjectsOf,
+        SH.targetObjectsOf,
+        SH.closed,
+        SH.ignoredProperties,
+        SH.property,
+        # Also skip things already captured via get_label/get_definition/etc.
+        RDFS.label,
+        RDFS.comment,
+        RDF.type,
+    }
+    for pred, obj in graph.predicate_objects(uri):
+        if not isinstance(pred, URIRef):
+            continue
+        if pred in handled_at_top_level:
+            continue
+        # Only collect predicates in the SHACL namespace as "other constraints";
+        # arbitrary annotations are already captured via get_annotations().
+        if not str(pred).startswith(str(SH)):
+            continue
+        # Skip predicates we capture per-PropertyShape (they shouldn't
+        # appear at the top level of a NodeShape, but PropertyShape-as-shape
+        # captures them via info.property_shape above).
+        if is_property_shape and pred in FIRST_CLASS_SHACL_CONSTRAINTS:
+            continue
+        if pred not in info.other_constraints:
+            info.other_constraints[pred] = []
+        if isinstance(obj, Literal):
+            info.other_constraints[pred].append(str(obj))
+        elif isinstance(obj, URIRef):
+            info.other_constraints[pred].append(obj)
+
+    return info
+
+
+def extract_all_shapes(graph: Graph) -> list[ShapeInfo]:
+    """Extract information for all SHACL shapes in the graph.
+
+    Returns NodeShapes and *named* PropertyShapes. Blank-node
+    PropertyShapes attached to NodeShapes via ``sh:property`` are
+    extracted as part of their parent shape (see
+    :func:`extract_shape_info`) and do not appear as standalone entries.
+
+    Args:
+        graph: RDF graph to query.
+
+    Returns:
+        List of ShapeInfo objects, sorted by qname.
+    """
+    shapes = []
+    seen: set[URIRef] = set()
+
+    # NodeShapes (named only — blank-node NodeShapes are unusual but
+    # would be unreachable in our docs anyway, so we ignore them).
+    for uri in graph.subjects(RDF.type, SH.NodeShape):
+        if isinstance(uri, URIRef) and uri not in seen:
+            seen.add(uri)
+            shapes.append(extract_shape_info(graph, uri))
+
+    # Named PropertyShapes
+    for uri in graph.subjects(RDF.type, SH.PropertyShape):
+        if isinstance(uri, URIRef) and uri not in seen:
+            seen.add(uri)
+            shapes.append(extract_shape_info(graph, uri))
+
+    shapes.sort(key=lambda s: s.qname)
+    return shapes
 
 
 def extract_all_classes(graph: Graph) -> list[ClassInfo]:
@@ -517,7 +975,7 @@ def extract_all_instances(graph: Graph) -> list[InstanceInfo]:
     """Extract information for all instances in the graph.
 
     Instances are entities that have rdf:type but are not themselves
-    classes or properties.
+    classes, properties, or SHACL shapes.
 
     Args:
         graph: RDF graph to query.
@@ -549,10 +1007,25 @@ def extract_all_instances(graph: Graph) -> list[InstanceInfo]:
         if isinstance(uri, URIRef):
             class_uris.add(uri)
 
-    # Find all subjects with rdf:type that aren't classes or properties
+    # Exclude SHACL shapes (#60) — they have their own bucket via
+    # extract_all_shapes(). Without this filter shapes would render as
+    # generic instances. Only excludes URIs (named shapes); blank-node
+    # PropertyShapes never had URIs to begin with so they don't reach
+    # the instance loop.
+    shape_uris: set[URIRef] = set()
+    for shape_type in [SH.NodeShape, SH.PropertyShape]:
+        for uri in graph.subjects(RDF.type, shape_type):
+            if isinstance(uri, URIRef):
+                shape_uris.add(uri)
+
+    # Find all subjects with rdf:type that aren't classes, properties, or shapes
     for subj, _, obj in graph.triples((None, RDF.type, None)):
         if isinstance(subj, URIRef) and subj not in seen:
-            if subj not in class_uris and subj not in property_uris:
+            if (
+                subj not in class_uris
+                and subj not in property_uris
+                and subj not in shape_uris
+            ):
                 seen.add(subj)
                 instances.append(extract_instance_info(graph, subj))
 
@@ -569,6 +1042,7 @@ class ExtractedEntities:
     classes: list[ClassInfo]
     properties: list[PropertyInfo]
     instances: list[InstanceInfo]
+    shapes: list[ShapeInfo] = field(default_factory=list)
 
     @property
     def object_properties(self) -> list[PropertyInfo]:
@@ -585,6 +1059,20 @@ class ExtractedEntities:
         """Get only annotation properties."""
         return [p for p in self.properties if p.property_type == "annotation"]
 
+    @property
+    def node_shapes(self) -> list[ShapeInfo]:
+        """Get only NodeShapes (named only — blank-node NodeShapes are not extracted)."""
+        return [s for s in self.shapes if EntityKind.NODE_SHAPE in s.kinds]
+
+    @property
+    def property_shapes(self) -> list[ShapeInfo]:
+        """Get only named PropertyShapes.
+
+        Blank-node PropertyShapes attached via ``sh:property`` are
+        captured inline on their parent NodeShape and do not appear here.
+        """
+        return [s for s in self.shapes if EntityKind.PROPERTY_SHAPE in s.kinds]
+
 
 def extract_all(graph: Graph) -> ExtractedEntities:
     """Extract all entities from an ontology graph.
@@ -593,11 +1081,13 @@ def extract_all(graph: Graph) -> ExtractedEntities:
         graph: RDF graph to extract from.
 
     Returns:
-        ExtractedEntities containing all classes, properties, and instances.
+        ExtractedEntities containing all classes, properties, instances,
+        and SHACL shapes.
     """
     return ExtractedEntities(
         ontology=extract_ontology_info(graph),
         classes=extract_all_classes(graph),
         properties=extract_all_properties(graph),
         instances=extract_all_instances(graph),
+        shapes=extract_all_shapes(graph),
     )

--- a/src/rdf_construct/docs/generator.py
+++ b/src/rdf_construct/docs/generator.py
@@ -136,6 +136,16 @@ class DocsGenerator:
                     result.files_created.append(instance_path)
                     result.instances_count += 1
 
+            # SHACL shapes (#60). NodeShapes and named PropertyShapes
+            # both go through render_shape — the kind badges differentiate
+            # them on the page. Blank-node PropertyShapes render inline
+            # on their parent NodeShape's page and do not iterate here.
+            if self.config.include_shapes:
+                for shape_info in entities.shapes:
+                    shape_path = self.renderer.render_shape(shape_info, entities)
+                    result.files_created.append(shape_path)
+                    result.shapes_count += 1
+
             # Namespace page
             namespace_path = self.renderer.render_namespaces(entities)
             result.files_created.append(namespace_path)
@@ -202,6 +212,7 @@ class GenerationResult:
         self.classes_count = 0
         self.properties_count = 0
         self.instances_count = 0
+        self.shapes_count = 0
 
     @property
     def total_pages(self) -> int:
@@ -210,12 +221,15 @@ class GenerationResult:
 
     def __str__(self) -> str:
         """Get a summary string."""
-        return (
-            f"Generated {self.total_pages} files to {self.output_dir}/\n"
-            f"  Classes: {self.classes_count}\n"
-            f"  Properties: {self.properties_count}\n"
-            f"  Instances: {self.instances_count}"
-        )
+        lines = [
+            f"Generated {self.total_pages} files to {self.output_dir}/",
+            f"  Classes: {self.classes_count}",
+            f"  Properties: {self.properties_count}",
+            f"  Instances: {self.instances_count}",
+        ]
+        if self.shapes_count > 0:
+            lines.append(f"  Shapes: {self.shapes_count}")
+        return "\n".join(lines)
 
 
 # Public interface from this module

--- a/src/rdf_construct/docs/generator.py
+++ b/src/rdf_construct/docs/generator.py
@@ -303,6 +303,27 @@ class BaseRenderer:
         """
         raise NotImplementedError
 
+    def render_shape(
+        self,
+        shape_info: "ShapeInfo",
+        entities: ExtractedEntities,
+    ) -> Path:
+        """Render a SHACL shape documentation page.
+
+        Renders both NodeShapes and named PropertyShapes; the kind
+        badges on the page distinguish them. Inline (blank-node)
+        PropertyShapes are rendered within their parent NodeShape and
+        do not get standalone pages.
+
+        Args:
+            shape_info: Shape to render.
+            entities: All extracted entities (for cross-references).
+
+        Returns:
+            Path to the rendered file.
+        """
+        raise NotImplementedError
+
     def render_namespaces(self, entities: ExtractedEntities) -> Path:
         """Render the namespace reference page.
 

--- a/src/rdf_construct/docs/renderers/html.py
+++ b/src/rdf_construct/docs/renderers/html.py
@@ -10,7 +10,13 @@ from jinja2 import Environment, FileSystemLoader, PackageLoader, select_autoesca
 
 if TYPE_CHECKING:
     from ..config import DocsConfig
-    from ..extractors import ClassInfo, ExtractedEntities, InstanceInfo, PropertyInfo
+    from ..extractors import (
+        ClassInfo,
+        ExtractedEntities,
+        InstanceInfo,
+        PropertyInfo,
+        ShapeInfo,
+    )
 
 
 class HTMLRenderer:
@@ -162,6 +168,9 @@ class HTMLRenderer:
             "datatype_properties": entities.datatype_properties,
             "annotation_properties": entities.annotation_properties,
             "instances": entities.instances,
+            "shapes": entities.shapes,
+            "node_shapes": entities.node_shapes,
+            "property_shapes": entities.property_shapes,
             "config": self.config,
             **extra,
         }
@@ -395,6 +404,34 @@ class HTMLRenderer:
         rel_path = entity_to_path(instance_info.qname, "instance", self.config)
         return self._render_page("instance.html.jinja", rel_path, context)
 
+    def render_shape(
+        self,
+        shape_info: "ShapeInfo",
+        entities: "ExtractedEntities",
+    ) -> Path:
+        """Render a SHACL shape documentation page.
+
+        Renders both NodeShapes and named PropertyShapes from the same
+        template; the kind badges on the page distinguish them. Inline
+        PropertyShape arcs (blank-node ``sh:property`` children of a
+        NodeShape) are rendered as a constraint table within the parent
+        NodeShape's page — they do not get their own pages.
+
+        Args:
+            shape_info: Shape to render.
+            entities: All extracted entities (for cross-references).
+
+        Returns:
+            Path to the rendered file.
+        """
+        template = self.env.get_template("shape.html.jinja")
+        context = self._build_context(entities, shape_info=shape_info)
+        content = template.render(context)
+
+        from ..config import entity_to_path
+        rel_path = entity_to_path(shape_info.qname, "shape", self.config)
+        return self._write_file(self.config.output_dir / rel_path, content)
+
     def render_namespaces(self, entities: "ExtractedEntities") -> Path:
         """Render the namespace reference page.
 
@@ -621,6 +658,52 @@ h4 { font-size: 1.1rem; }
 .entity-type.datatype { background: #06b6d4; }
 .entity-type.annotation { background: #f59e0b; }
 .entity-type.instance { background: #10b981; }
+
+/* Shape badges (#60). Red-to-rose hue family signals kinship between
+   NodeShape and PropertyShape; brightness gradient (NodeShape darker
+   than PropertyShape) reads as parent-child. All three pass WCAG AA
+   contrast against the badge's white text:
+     .shape          #dc2626  4.83:1
+     .node_shape     #b91c1c  6.47:1
+     .property_shape #e11d48  4.70:1
+   The hue family is distinct from the other four badges under common
+   colour-vision deficiencies (amber goes pale-yellow under
+   deuteranopia; reds stay warm-saturated). Badge text labels
+   ("node shape" / "property shape") carry the category regardless of
+   perceived colour. */
+.entity-type.shape { background: #dc2626; }
+.entity-type.node_shape { background: #b91c1c; }
+.entity-type.property_shape { background: #e11d48; }
+
+/* PropertyShape constraint table on shape pages. Tighter than the
+   default annotations table — the `th` is the constraint name, the
+   `td` is the value. */
+.property-shape-constraints {
+    margin: 0.5rem 0 1rem 0;
+}
+.property-shape-constraints th {
+    width: 10rem;
+    font-weight: 600;
+    text-align: left;
+    background: var(--surface);
+    padding: 0.5rem 0.75rem;
+}
+.property-shape-constraints td {
+    padding: 0.5rem 0.75rem;
+}
+
+.property-shape {
+    background: var(--background);
+    border: 1px solid var(--border);
+    border-radius: 0.375rem;
+    padding: 0.75rem 1rem;
+    margin-bottom: 0.75rem;
+}
+.property-shape h4 {
+    margin-top: 0;
+    margin-bottom: 0.5rem;
+    font-size: 1rem;
+}
 
 .definition {
     color: var(--text-muted);

--- a/src/rdf_construct/docs/renderers/html.py
+++ b/src/rdf_construct/docs/renderers/html.py
@@ -424,13 +424,11 @@ class HTMLRenderer:
         Returns:
             Path to the rendered file.
         """
-        template = self.env.get_template("shape.html.jinja")
         context = self._build_context(entities, shape_info=shape_info)
-        content = template.render(context)
 
         from ..config import entity_to_path
         rel_path = entity_to_path(shape_info.qname, "shape", self.config)
-        return self._write_file(self.config.output_dir / rel_path, content)
+        return self._render_page("shape.html.jinja", rel_path, context)
 
     def render_namespaces(self, entities: "ExtractedEntities") -> Path:
         """Render the namespace reference page.

--- a/src/rdf_construct/docs/renderers/json.py
+++ b/src/rdf_construct/docs/renderers/json.py
@@ -8,7 +8,14 @@ from typing import TYPE_CHECKING, Any
 
 if TYPE_CHECKING:
     from ..config import DocsConfig
-    from ..extractors import ClassInfo, ExtractedEntities, InstanceInfo, PropertyInfo
+    from ..extractors import (
+        ClassInfo,
+        ExtractedEntities,
+        InstanceInfo,
+        PropertyInfo,
+        PropertyShapeInfo,
+        ShapeInfo,
+    )
 
 
 class JSONRenderer:
@@ -71,6 +78,7 @@ class JSONRenderer:
         return {
             "uri": str(class_info.uri),
             "qname": class_info.qname,
+            "kinds": [str(k) for k in class_info.kinds],
             "label": class_info.label,
             "definition": class_info.definition,
             "superclasses": [str(uri) for uri in class_info.superclasses],
@@ -95,6 +103,7 @@ class JSONRenderer:
         return {
             "uri": str(prop_info.uri),
             "qname": prop_info.qname,
+            "kinds": [str(k) for k in prop_info.kinds],
             "label": prop_info.label,
             "definition": prop_info.definition,
             "property_type": prop_info.property_type,
@@ -126,11 +135,95 @@ class JSONRenderer:
         return {
             "uri": str(instance_info.uri),
             "qname": instance_info.qname,
+            "kinds": [str(k) for k in instance_info.kinds],
             "label": instance_info.label,
             "definition": instance_info.definition,
             "types": [str(uri) for uri in instance_info.types],
             "properties": properties,
             "annotations": instance_info.annotations,
+        }
+
+    def _property_shape_to_dict(
+        self,
+        ps: "PropertyShapeInfo",
+    ) -> dict[str, Any]:
+        """Convert a PropertyShapeInfo to a dictionary.
+
+        Schema is stable for downstream consumers (#60). Naming choices:
+        ``class`` (matches the SHACL spec key) instead of the dataclass
+        field ``class_`` which was renamed for Python keyword reasons;
+        ``in_values`` (more readable in JSON than ``in`` and avoids the
+        keyword issue at the consumer end too).
+
+        Args:
+            ps: PropertyShape info.
+
+        Returns:
+            Dictionary representation.
+        """
+        return {
+            "uri": str(ps.uri) if ps.uri is not None else None,
+            "qname": ps.qname,
+            "is_blank": ps.is_blank,
+            "path": str(ps.path) if ps.path is not None else None,
+            "name": ps.name,
+            "description": ps.description,
+            "datatype": str(ps.datatype) if ps.datatype is not None else None,
+            "class": str(ps.class_) if ps.class_ is not None else None,
+            "node_kind": str(ps.node_kind) if ps.node_kind is not None else None,
+            "min_count": ps.min_count,
+            "max_count": ps.max_count,
+            "min_length": ps.min_length,
+            "max_length": ps.max_length,
+            "min_inclusive": ps.min_inclusive,
+            "max_inclusive": ps.max_inclusive,
+            "pattern": ps.pattern,
+            "has_value": str(ps.has_value) if ps.has_value is not None else None,
+            "in_values": [str(v) for v in ps.in_values],
+            "other_constraints": {
+                str(pred): [str(v) for v in vals]
+                for pred, vals in ps.other_constraints.items()
+            },
+        }
+
+    def _shape_to_dict(self, shape_info: "ShapeInfo") -> dict[str, Any]:
+        """Convert a ShapeInfo to a dictionary.
+
+        Args:
+            shape_info: Shape to convert.
+
+        Returns:
+            Dictionary representation.
+        """
+        return {
+            "uri": str(shape_info.uri),
+            "qname": shape_info.qname,
+            "kinds": [str(k) for k in shape_info.kinds],
+            "label": shape_info.label,
+            "definition": shape_info.definition,
+            "target_classes": [str(uri) for uri in shape_info.target_classes],
+            "target_nodes": [str(uri) for uri in shape_info.target_nodes],
+            "target_subjects_of": [
+                str(uri) for uri in shape_info.target_subjects_of
+            ],
+            "target_objects_of": [
+                str(uri) for uri in shape_info.target_objects_of
+            ],
+            "closed": shape_info.closed,
+            "ignored_properties": [str(uri) for uri in shape_info.ignored_properties],
+            "properties": [
+                self._property_shape_to_dict(ps) for ps in shape_info.properties
+            ],
+            "property_shape": (
+                self._property_shape_to_dict(shape_info.property_shape)
+                if shape_info.property_shape is not None
+                else None
+            ),
+            "annotations": shape_info.annotations,
+            "other_constraints": {
+                str(pred): [str(v) for v in vals]
+                for pred, vals in shape_info.other_constraints.items()
+            },
         }
 
     def _ontology_to_dict(self, entities: "ExtractedEntities") -> dict[str, Any]:
@@ -172,6 +265,7 @@ class JSONRenderer:
                 "datatype_properties": len(entities.datatype_properties),
                 "annotation_properties": len(entities.annotation_properties),
                 "instances": len(entities.instances),
+                "shapes": len(entities.shapes),
             },
             "classes": [
                 {
@@ -212,6 +306,21 @@ class JSONRenderer:
                     "label": i.label,
                 }
                 for i in entities.instances
+            ],
+            # Top-level shapes array (#60). Breaking change from v0.4.x:
+            # shapes used to appear in the 'instances' array because the
+            # extractor didn't filter them out; they're now their own
+            # bucket. Each entry includes the multi-kind list so
+            # consumers can distinguish NodeShape, PropertyShape, and
+            # any further kinds added in later milestone stages.
+            "shapes": [
+                {
+                    "uri": str(s.uri),
+                    "qname": s.qname,
+                    "kinds": [str(k) for k in s.kinds],
+                    "label": s.label,
+                }
+                for s in entities.shapes
             ],
         }
 
@@ -343,6 +452,31 @@ class JSONRenderer:
         rel_path = entity_to_path(instance_info.qname, "instance", self.config, extension=".json")
         return self._write_json(self.config.output_dir / rel_path, data)
 
+    def render_shape(
+        self,
+        shape_info: "ShapeInfo",
+        entities: "ExtractedEntities",
+    ) -> Path:
+        """Render a SHACL shape as JSON.
+
+        The full shape representation is documented in the docstring of
+        :meth:`_shape_to_dict`. NodeShapes and named PropertyShapes are
+        both rendered through this method; the ``kinds`` field carries
+        the discriminator.
+
+        Args:
+            shape_info: Shape to render.
+            entities: All extracted entities.
+
+        Returns:
+            Path to the rendered file.
+        """
+        data = self._shape_to_dict(shape_info)
+
+        from ..config import entity_to_path
+        rel_path = entity_to_path(shape_info.qname, "shape", self.config, extension=".json")
+        return self._write_json(self.config.output_dir / rel_path, data)
+
     def render_namespaces(self, entities: "ExtractedEntities") -> Path:
         """Render namespaces as JSON.
 
@@ -381,6 +515,11 @@ class JSONRenderer:
             "instances": [
                 self._instance_to_dict(i) for i in entities.instances
             ],
+            # Full shape representations. Breaking change from v0.4.x:
+            # shapes used to be lumped into 'instances' because the
+            # extractor didn't filter them out. They now have their
+            # own top-level array.
+            "shapes": [self._shape_to_dict(s) for s in entities.shapes],
         }
 
         return self._write_json(self._get_output_path("ontology.json"), data)

--- a/src/rdf_construct/docs/renderers/markdown.py
+++ b/src/rdf_construct/docs/renderers/markdown.py
@@ -7,7 +7,14 @@ from typing import TYPE_CHECKING, Any
 
 if TYPE_CHECKING:
     from ..config import DocsConfig
-    from ..extractors import ClassInfo, ExtractedEntities, InstanceInfo, PropertyInfo
+    from ..extractors import (
+        ClassInfo,
+        ExtractedEntities,
+        InstanceInfo,
+        PropertyInfo,
+        PropertyShapeInfo,
+        ShapeInfo,
+    )
 
 
 class MarkdownRenderer:
@@ -128,6 +135,8 @@ class MarkdownRenderer:
         lines.append(f"- **Object Properties:** {len(entities.object_properties)}")
         lines.append(f"- **Datatype Properties:** {len(entities.datatype_properties)}")
         lines.append(f"- **Annotation Properties:** {len(entities.annotation_properties)}")
+        if entities.shapes and self.config.include_shapes:
+            lines.append(f"- **Shapes:** {len(entities.shapes)}")
         if entities.instances:
             lines.append(f"- **Instances:** {len(entities.instances)}")
         lines.append("")
@@ -168,6 +177,24 @@ class MarkdownRenderer:
             for p in entities.datatype_properties:
                 link = self._entity_link(p.qname, "datatype_property", p.label or p.qname)
                 lines.append(f"- {link}")
+            lines.append("")
+
+        # Shapes section (#60). Listed before instances would be (when
+        # the existing renderer ever gets that section), reflecting the
+        # priority that shapes carry more semantic weight than plain
+        # individuals.
+        if entities.shapes and self.config.include_shapes:
+            lines.append("## Shapes")
+            lines.append("")
+            for s in entities.shapes:
+                link = self._entity_link(s.qname, "shape", s.label or s.qname)
+                kind_tags = " ".join(
+                    f"`{k}`" for k in s.kinds if k != "shape"
+                )
+                if kind_tags:
+                    lines.append(f"- {link} {kind_tags}")
+                else:
+                    lines.append(f"- {link}")
             lines.append("")
 
         content = "\n".join(lines)
@@ -344,6 +371,10 @@ class MarkdownRenderer:
     ) -> str:
         """Convert a URI to a display string, linking if possible.
 
+        Searches classes, properties, instances, and shapes (in that
+        order — most specific match wins). Falls back to the URI's
+        local name in code formatting when no entity matches.
+
         Args:
             uri: URI to convert.
             entities: All entities for lookups.
@@ -359,10 +390,21 @@ class MarkdownRenderer:
             if str(c.uri) == uri_str:
                 return self._entity_link(c.qname, "class", c.label or c.qname)
 
+        # Check if it's a known property
+        for p in entities.properties:
+            if str(p.uri) == uri_str:
+                entity_type = f"{p.property_type}_property"
+                return self._entity_link(p.qname, entity_type, p.label or p.qname)
+
         # Check if it's a known instance
         for i in entities.instances:
             if str(i.uri) == uri_str:
                 return self._entity_link(i.qname, "instance", i.label or i.qname)
+
+        # Check if it's a known shape
+        for s in entities.shapes:
+            if str(s.uri) == uri_str:
+                return self._entity_link(s.qname, "shape", s.label or s.qname)
 
         # Fall back to extracting local name
         if "#" in uri_str:
@@ -518,6 +560,213 @@ class MarkdownRenderer:
         rel_path = entity_to_path(instance_info.qname, "instance", self.config, extension=".md")
         return self._write_file(self.config.output_dir / rel_path, content)
 
+    def _render_property_shape_table(
+        self,
+        ps: "PropertyShapeInfo",
+        entities: "ExtractedEntities",
+    ) -> list[str]:
+        """Render a PropertyShape's constraints as a Markdown table.
+
+        Output is a GFM 2-column table (constraint -> value). Only
+        populated first-class fields are included; long-tail SHACL
+        predicates from ``other_constraints`` get a generic key-value
+        row each so they remain visible without per-predicate template
+        work.
+
+        Returns the lines of the table (no trailing blank line — caller
+        adds spacing).
+        """
+        rows: list[tuple[str, str]] = []
+
+        if ps.path is not None:
+            # Try to resolve to a known property for a clickable link.
+            display = self._uri_to_display(ps.path, entities)
+            rows.append(("Path", display))
+        if ps.name:
+            rows.append(("Name", ps.name))
+        if ps.description:
+            rows.append(("Description", ps.description))
+        if ps.datatype is not None:
+            rows.append(("Datatype", f"`{ps.datatype}`"))
+        if ps.class_ is not None:
+            rows.append(("Class", self._uri_to_display(ps.class_, entities)))
+        if ps.node_kind is not None:
+            rows.append(("Node Kind", f"`{ps.node_kind}`"))
+        if ps.min_count is not None:
+            rows.append(("Min Count", str(ps.min_count)))
+        if ps.max_count is not None:
+            rows.append(("Max Count", str(ps.max_count)))
+        if ps.min_length is not None:
+            rows.append(("Min Length", str(ps.min_length)))
+        if ps.max_length is not None:
+            rows.append(("Max Length", str(ps.max_length)))
+        if ps.min_inclusive is not None:
+            rows.append(("Min Inclusive", str(ps.min_inclusive)))
+        if ps.max_inclusive is not None:
+            rows.append(("Max Inclusive", str(ps.max_inclusive)))
+        if ps.pattern is not None:
+            rows.append(("Pattern", f"`{ps.pattern}`"))
+        if ps.has_value is not None:
+            rows.append(("Has Value", f"`{ps.has_value}`"))
+        if ps.in_values:
+            joined = ", ".join(f"`{v}`" for v in ps.in_values)
+            rows.append(("In", joined))
+
+        # Long-tail fallback
+        for pred, vals in ps.other_constraints.items():
+            joined = ", ".join(f"`{v}`" for v in vals)
+            rows.append((f"`{pred}`", joined))
+
+        if not rows:
+            return []
+
+        lines = ["| Constraint | Value |", "| --- | --- |"]
+        for k, v in rows:
+            # Pipe characters in cell values would break the table layout.
+            v_safe = v.replace("|", "\\|")
+            lines.append(f"| {k} | {v_safe} |")
+        return lines
+
+    def render_shape(
+        self,
+        shape_info: "ShapeInfo",
+        entities: "ExtractedEntities",
+    ) -> Path:
+        """Render a SHACL shape documentation page.
+
+        Renders both NodeShapes and named PropertyShapes from the same
+        method (the kind in the frontmatter and the section headings
+        differ).
+
+        Args:
+            shape_info: Shape to render.
+            entities: All extracted entities.
+
+        Returns:
+            Path to the rendered file.
+        """
+        lines = []
+
+        # Frontmatter — pick the most-specific kind for the type field
+        # so static-site generators can filter on it.
+        primary = "shape"
+        if "node_shape" in shape_info.kinds:
+            primary = "node_shape"
+        elif "property_shape" in shape_info.kinds:
+            primary = "property_shape"
+        lines.append(self._frontmatter(
+            title=shape_info.label or shape_info.qname,
+            type=primary,
+        ))
+
+        lines.append(f"# {shape_info.label or shape_info.qname}")
+        lines.append("")
+        # All kinds as a Markdown badge-style line, mirroring HTML output.
+        kind_labels = " ".join(
+            f"`{kind}`" for kind in shape_info.kinds if kind != "shape"
+        )
+        if kind_labels:
+            lines.append(f"**Kinds:** {kind_labels}")
+            lines.append("")
+        lines.append(f"**URI:** `{shape_info.uri}`")
+        lines.append("")
+
+        if shape_info.definition:
+            lines.append(shape_info.definition)
+            lines.append("")
+
+        # Targets
+        target_rows: list[tuple[str, list]] = []
+        if shape_info.target_classes:
+            target_rows.append(("Target class", shape_info.target_classes))
+        if shape_info.target_nodes:
+            target_rows.append(("Target node", shape_info.target_nodes))
+        if shape_info.target_subjects_of:
+            target_rows.append(("Target subjects of", shape_info.target_subjects_of))
+        if shape_info.target_objects_of:
+            target_rows.append(("Target objects of", shape_info.target_objects_of))
+        if target_rows:
+            lines.append("## Targets")
+            lines.append("")
+            for label, uris in target_rows:
+                joined = ", ".join(self._uri_to_display(u, entities) for u in uris)
+                lines.append(f"- **{label}:** {joined}")
+            lines.append("")
+
+        # NodeShape structural fields
+        if "node_shape" in shape_info.kinds:
+            structure_rows: list[str] = []
+            if shape_info.closed:
+                structure_rows.append("- **Closed:** true")
+            if shape_info.ignored_properties:
+                joined = ", ".join(f"`{u}`" for u in shape_info.ignored_properties)
+                structure_rows.append(f"- **Ignored properties:** {joined}")
+            if structure_rows:
+                lines.append("## Structure")
+                lines.append("")
+                lines.extend(structure_rows)
+                lines.append("")
+
+            # Property arcs
+            if shape_info.properties:
+                lines.append("## Property Constraints")
+                lines.append("")
+                for ps in shape_info.properties:
+                    if ps.is_blank:
+                        # Heading: the property path if available, else a placeholder.
+                        if ps.path is not None:
+                            heading = self._uri_to_display(ps.path, entities)
+                        else:
+                            heading = "_(blank-node constraint)_"
+                        lines.append(f"### {heading}")
+                    else:
+                        # Named PropertyShape — link to its standalone page.
+                        link = self._entity_link(
+                            ps.qname or "",
+                            "shape",
+                            ps.name or ps.qname or "",
+                        )
+                        lines.append(f"### {link} `property_shape`")
+                    lines.append("")
+                    table_lines = self._render_property_shape_table(ps, entities)
+                    if table_lines:
+                        lines.extend(table_lines)
+                    lines.append("")
+
+        # PropertyShape constraints (when the top-level shape is itself a PropertyShape)
+        if "property_shape" in shape_info.kinds and shape_info.property_shape is not None:
+            lines.append("## Constraints")
+            lines.append("")
+            table_lines = self._render_property_shape_table(shape_info.property_shape, entities)
+            if table_lines:
+                lines.extend(table_lines)
+            lines.append("")
+
+        # Long-tail SHACL predicates at the top level
+        if shape_info.other_constraints:
+            lines.append("## Other Constraints")
+            lines.append("")
+            lines.append("| Predicate | Value |")
+            lines.append("| --- | --- |")
+            for pred, vals in shape_info.other_constraints.items():
+                joined = ", ".join(f"`{v}`" for v in vals)
+                lines.append(f"| `{pred}` | {joined} |")
+            lines.append("")
+
+        # Annotations
+        if shape_info.annotations:
+            lines.append("## Annotations")
+            lines.append("")
+            for name, values in shape_info.annotations.items():
+                for value in values:
+                    lines.append(f"- **{name}:** {value}")
+            lines.append("")
+
+        content = "\n".join(lines)
+        from ..config import entity_to_path
+        rel_path = entity_to_path(shape_info.qname, "shape", self.config, extension=".md")
+        return self._write_file(self.config.output_dir / rel_path, content)
+
     def render_namespaces(self, entities: "ExtractedEntities") -> Path:
         """Render the namespace reference page.
 
@@ -572,6 +821,8 @@ class MarkdownRenderer:
         lines.append("- [Classes](#classes)")
         lines.append("- [Object Properties](#object-properties)")
         lines.append("- [Datatype Properties](#datatype-properties)")
+        if entities.shapes and self.config.include_shapes:
+            lines.append("- [Shapes](#shapes)")
         lines.append("- [Namespaces](#namespaces)")
         lines.append("")
 
@@ -609,6 +860,32 @@ class MarkdownRenderer:
             if p.definition:
                 lines.append(p.definition)
                 lines.append("")
+
+        # Shapes (#60)
+        if entities.shapes and self.config.include_shapes:
+            lines.append("## Shapes")
+            lines.append("")
+            for s in entities.shapes:
+                lines.append(f"### {s.label or s.qname}")
+                lines.append("")
+                kind_tags = " ".join(
+                    f"`{k}`" for k in s.kinds if k != "shape"
+                )
+                if kind_tags:
+                    lines.append(f"**Kinds:** {kind_tags}")
+                    lines.append("")
+                lines.append(f"**URI:** `{s.uri}`")
+                lines.append("")
+                if s.definition:
+                    lines.append(s.definition)
+                    lines.append("")
+                if s.target_classes:
+                    joined = ", ".join(self._uri_to_display(u, entities) for u in s.target_classes)
+                    lines.append(f"**Target classes:** {joined}")
+                    lines.append("")
+                if "node_shape" in s.kinds and s.properties:
+                    lines.append(f"**Property constraints:** {len(s.properties)}")
+                    lines.append("")
 
         # Namespaces
         lines.append("## Namespaces")

--- a/src/rdf_construct/docs/search.py
+++ b/src/rdf_construct/docs/search.py
@@ -4,25 +4,43 @@ from __future__ import annotations
 
 import json
 import re
-from dataclasses import asdict, dataclass
+from dataclasses import asdict, dataclass, field
 from pathlib import Path
 from typing import TYPE_CHECKING
 
 if TYPE_CHECKING:
     from rdf_construct.docs.config import DocsConfig
-    from rdf_construct.docs.extractors import ClassInfo, ExtractedEntities, InstanceInfo, PropertyInfo
+    from rdf_construct.docs.extractors import (
+        ClassInfo,
+        ExtractedEntities,
+        InstanceInfo,
+        PropertyInfo,
+        ShapeInfo,
+    )
 
 
 @dataclass
 class SearchEntry:
-    """A single entry in the search index."""
+    """A single entry in the search index.
+
+    The ``entity_type`` field is the primary discriminator (used by
+    the client-side search to choose a badge colour); ``kinds`` is the
+    full multi-kind list, mainly there so JSON consumers and future
+    smarter search UIs can distinguish, e.g., a NodeShape from a
+    named PropertyShape, both of which share ``entity_type='shape'``.
+
+    Adding ``kinds`` to the index is additive — the existing
+    ``assets/search.js`` ignores fields it doesn't know about, so
+    existing search behaviour is unchanged.
+    """
 
     uri: str
     qname: str
-    entity_type: str  # class, object_property, datatype_property, instance
+    entity_type: str  # class, object_property, datatype_property, instance, shape
     label: str
     keywords: list[str]
     url: str
+    kinds: list[str] = field(default_factory=list)
 
 
 def extract_keywords(text: str | None) -> list[str]:
@@ -105,6 +123,7 @@ def class_to_search_entry(
         label=class_info.label or class_info.qname,
         keywords=list(set(keywords)),
         url=entity_to_url(class_info.qname, "class", config),
+        kinds=[str(k) for k in class_info.kinds],
     )
 
 
@@ -157,6 +176,7 @@ def property_to_search_entry(
         label=prop_info.label or prop_info.qname,
         keywords=list(set(keywords)),
         url=entity_to_url(prop_info.qname, entity_type, config),
+        kinds=[str(k) for k in prop_info.kinds],
     )
 
 
@@ -207,6 +227,68 @@ def instance_to_search_entry(
         label=instance_info.label or instance_info.qname,
         keywords=list(set(keywords)),
         url=entity_to_url(instance_info.qname, "instance", config),
+        kinds=[str(k) for k in instance_info.kinds],
+    )
+
+
+def shape_to_search_entry(
+    shape_info: "ShapeInfo",
+    config: "DocsConfig",
+) -> SearchEntry:
+    """Convert a ShapeInfo to a SearchEntry.
+
+    Indexes target class names alongside the shape's own qname/label
+    so a search for the underlying class also surfaces the shape that
+    constrains it. The full ``kinds`` list is preserved so future
+    smarter search UIs can distinguish NodeShape from named
+    PropertyShape — currently both share ``entity_type='shape'``.
+
+    Args:
+        shape_info: Shape information.
+        config: Documentation configuration.
+
+    Returns:
+        SearchEntry for the shape.
+    """
+    keywords = []
+
+    # QName parts
+    if ":" in shape_info.qname:
+        prefix, local = shape_info.qname.split(":", 1)
+        keywords.extend(extract_keywords(local))
+        keywords.append(prefix.lower())
+
+    # Label and definition
+    if shape_info.label:
+        keywords.extend(extract_keywords(shape_info.label))
+    if shape_info.definition:
+        keywords.extend(extract_keywords(shape_info.definition))
+
+    # Each kind as a keyword so a literal search for "node_shape" works
+    for k in shape_info.kinds:
+        keywords.append(str(k))
+    # Also add the human-friendly form so searches for "shape" or
+    # "node shape" both match.
+    keywords.append("shape")
+
+    # Target class names as keywords — searching for the constrained
+    # class should surface its shape.
+    for uri in shape_info.target_classes:
+        uri_str = str(uri)
+        if "#" in uri_str:
+            keywords.extend(extract_keywords(uri_str.split("#")[-1]))
+        elif "/" in uri_str:
+            keywords.extend(extract_keywords(uri_str.split("/")[-1]))
+
+    from .config import entity_to_url
+    return SearchEntry(
+        uri=str(shape_info.uri),
+        qname=shape_info.qname,
+        entity_type="shape",
+        label=shape_info.label or shape_info.qname,
+        keywords=list(set(keywords)),
+        url=entity_to_url(shape_info.qname, "shape", config),
+        kinds=[str(k) for k in shape_info.kinds],
     )
 
 
@@ -247,6 +329,11 @@ def generate_search_index(
     if config.include_instances:
         for instance_info in entities.instances:
             entries.append(instance_to_search_entry(instance_info, config))
+
+    # Shapes (#60)
+    if config.include_shapes:
+        for shape_info in entities.shapes:
+            entries.append(shape_to_search_entry(shape_info, config))
 
     return entries
 

--- a/src/rdf_construct/docs/templates/html/index.html.jinja
+++ b/src/rdf_construct/docs/templates/html/index.html.jinja
@@ -12,6 +12,12 @@
         <div class="number">{{ total_properties }}</div>
         <div class="label">Properties</div>
     </div>
+    {% if shapes and config.include_shapes %}
+    <div class="stat-card">
+        <div class="number">{{ shapes | length }}</div>
+        <div class="label">Shapes</div>
+    </div>
+    {% endif %}
     {% if instances %}
     <div class="stat-card">
         <div class="number">{{ total_instances }}</div>
@@ -86,6 +92,29 @@
                 {{ prop.label or prop.qname }}
             </a>
             <span class="entity-type annotation">Annotation</span>
+        </li>
+        {% endfor %}
+    </ul>
+</section>
+{% endif %}
+
+{% if shapes and config.include_shapes %}
+<section class="section">
+    <h2>Shapes</h2>
+    <ul class="entity-list">
+        {% for shape in shapes %}
+        <li>
+            <a href="{{ shape.qname | entity_url('shape') }}">
+                {{ shape.label or shape.qname }}
+            </a>
+            {% for kind in shape.kinds %}
+            {% if kind != 'shape' %}
+            <span class="entity-type {{ kind }}">{{ kind | replace('_', ' ') }}</span>
+            {% endif %}
+            {% endfor %}
+            {% if shape.definition %}
+            <span class="definition">— {{ shape.definition[:80] }}{% if shape.definition|length > 80 %}...{% endif %}</span>
+            {% endif %}
         </li>
         {% endfor %}
     </ul>

--- a/src/rdf_construct/docs/templates/html/shape.html.jinja
+++ b/src/rdf_construct/docs/templates/html/shape.html.jinja
@@ -1,0 +1,206 @@
+{% extends "base.html.jinja" %}
+
+{% block title %}{{ shape_info.label or shape_info.qname }} - {{ ontology.title or "Documentation" }}{% endblock %}
+
+{# Render a constraint table for a single PropertyShape (inline blank-node
+   or top-level named). Shows only the first-class constraints that are
+   actually populated; falls back to a generic key-value table for any
+   long-tail SHACL predicates in `other_constraints`. #}
+{% macro render_property_shape(ps, classes, properties) %}
+<table class="property-shape-constraints">
+    <tbody>
+        {% if ps.path %}
+        <tr><th>Path</th><td>
+            {% set found = namespace(value=false) %}
+            {% for p in properties %}
+                {% if p.uri|string == ps.path|string %}
+                <a href="{{ p.qname | entity_url(p.property_type + '_property') }}">{{ p.label or p.qname }}</a>
+                {% set found.value = true %}
+                {% endif %}
+            {% endfor %}
+            {% if not found.value %}<code>{{ ps.path }}</code>{% endif %}
+        </td></tr>
+        {% endif %}
+        {% if ps.name %}<tr><th>Name</th><td>{{ ps.name }}</td></tr>{% endif %}
+        {% if ps.description %}<tr><th>Description</th><td>{{ ps.description }}</td></tr>{% endif %}
+        {% if ps.datatype %}
+        <tr><th>Datatype</th><td><code>{{ ps.datatype }}</code></td></tr>
+        {% endif %}
+        {% if ps.class_ %}
+        <tr><th>Class</th><td>
+            {% set found = namespace(value=false) %}
+            {% for c in classes %}
+                {% if c.uri|string == ps.class_|string %}
+                <a href="{{ c.qname | entity_url('class') }}">{{ c.label or c.qname }}</a>
+                {% set found.value = true %}
+                {% endif %}
+            {% endfor %}
+            {% if not found.value %}<code>{{ ps.class_ }}</code>{% endif %}
+        </td></tr>
+        {% endif %}
+        {% if ps.node_kind %}<tr><th>Node Kind</th><td><code>{{ ps.node_kind }}</code></td></tr>{% endif %}
+        {% if ps.min_count is not none %}<tr><th>Min Count</th><td>{{ ps.min_count }}</td></tr>{% endif %}
+        {% if ps.max_count is not none %}<tr><th>Max Count</th><td>{{ ps.max_count }}</td></tr>{% endif %}
+        {% if ps.min_length is not none %}<tr><th>Min Length</th><td>{{ ps.min_length }}</td></tr>{% endif %}
+        {% if ps.max_length is not none %}<tr><th>Max Length</th><td>{{ ps.max_length }}</td></tr>{% endif %}
+        {% if ps.min_inclusive is not none %}<tr><th>Min Inclusive</th><td>{{ ps.min_inclusive }}</td></tr>{% endif %}
+        {% if ps.max_inclusive is not none %}<tr><th>Max Inclusive</th><td>{{ ps.max_inclusive }}</td></tr>{% endif %}
+        {% if ps.pattern %}<tr><th>Pattern</th><td><code>{{ ps.pattern }}</code></td></tr>{% endif %}
+        {% if ps.has_value is not none %}
+        <tr><th>Has Value</th><td><code>{{ ps.has_value }}</code></td></tr>
+        {% endif %}
+        {% if ps.in_values %}
+        <tr><th>In</th><td>
+            {% for v in ps.in_values %}<code>{{ v }}</code>{% if not loop.last %}, {% endif %}{% endfor %}
+        </td></tr>
+        {% endif %}
+        {% for pred, vals in ps.other_constraints.items() %}
+        <tr><th><code>{{ pred }}</code></th><td>
+            {% for v in vals %}<code>{{ v }}</code>{% if not loop.last %}, {% endif %}{% endfor %}
+        </td></tr>
+        {% endfor %}
+    </tbody>
+</table>
+{% endmacro %}
+
+{% block content %}
+<article class="entity-card">
+    <h1>
+        {{ shape_info.label or shape_info.qname }}
+        {% for kind in shape_info.kinds %}
+        <span class="entity-type {{ kind }}">{{ kind | replace('_', ' ') }}</span>
+        {% endfor %}
+    </h1>
+    <p class="uri">{{ shape_info.uri }}</p>
+
+    {% if shape_info.definition %}
+    <p class="definition">{{ shape_info.definition }}</p>
+    {% endif %}
+
+    {# Targets: targetClass, targetNode, targetSubjectsOf, targetObjectsOf #}
+    {% if shape_info.target_classes or shape_info.target_nodes
+        or shape_info.target_subjects_of or shape_info.target_objects_of %}
+    <section class="section">
+        <h3>Targets</h3>
+        <table>
+            <tbody>
+                {% if shape_info.target_classes %}
+                <tr><th>Target Class</th><td>
+                    {% for uri in shape_info.target_classes %}
+                    {% set found = namespace(value=false) %}
+                    {% for c in classes %}
+                        {% if c.uri|string == uri|string %}
+                        <a href="{{ c.qname | entity_url('class') }}">{{ c.label or c.qname }}</a>
+                        {% set found.value = true %}
+                        {% endif %}
+                    {% endfor %}
+                    {% if not found.value %}<code>{{ uri }}</code>{% endif %}
+                    {% if not loop.last %}, {% endif %}
+                    {% endfor %}
+                </td></tr>
+                {% endif %}
+                {% if shape_info.target_nodes %}
+                <tr><th>Target Node</th><td>
+                    {% for uri in shape_info.target_nodes %}<code>{{ uri }}</code>{% if not loop.last %}, {% endif %}{% endfor %}
+                </td></tr>
+                {% endif %}
+                {% if shape_info.target_subjects_of %}
+                <tr><th>Target Subjects Of</th><td>
+                    {% for uri in shape_info.target_subjects_of %}<code>{{ uri }}</code>{% if not loop.last %}, {% endif %}{% endfor %}
+                </td></tr>
+                {% endif %}
+                {% if shape_info.target_objects_of %}
+                <tr><th>Target Objects Of</th><td>
+                    {% for uri in shape_info.target_objects_of %}<code>{{ uri }}</code>{% if not loop.last %}, {% endif %}{% endfor %}
+                </td></tr>
+                {% endif %}
+            </tbody>
+        </table>
+    </section>
+    {% endif %}
+
+    {# NodeShape structural fields #}
+    {% if 'node_shape' in shape_info.kinds %}
+        {% if shape_info.closed or shape_info.ignored_properties %}
+        <section class="section">
+            <h3>Structure</h3>
+            <table>
+                <tbody>
+                    {% if shape_info.closed %}
+                    <tr><th>Closed</th><td>true</td></tr>
+                    {% endif %}
+                    {% if shape_info.ignored_properties %}
+                    <tr><th>Ignored Properties</th><td>
+                        {% for uri in shape_info.ignored_properties %}<code>{{ uri }}</code>{% if not loop.last %}, {% endif %}{% endfor %}
+                    </td></tr>
+                    {% endif %}
+                </tbody>
+            </table>
+        </section>
+        {% endif %}
+
+        {% if shape_info.properties %}
+        <section class="section">
+            <h3>Property Constraints</h3>
+            {% for ps in shape_info.properties %}
+            <div class="property-shape">
+                <h4>
+                    {% if ps.is_blank %}
+                        {% if ps.path %}<code>{{ ps.path }}</code>{% else %}(blank-node constraint){% endif %}
+                    {% else %}
+                        <a href="{{ ps.qname | entity_url('shape') }}">{{ ps.name or ps.qname }}</a>
+                        <span class="entity-type property_shape">property shape</span>
+                    {% endif %}
+                </h4>
+                {{ render_property_shape(ps, classes, object_properties + datatype_properties + annotation_properties) }}
+            </div>
+            {% endfor %}
+        </section>
+        {% endif %}
+    {% endif %}
+
+    {# Top-level PropertyShape constraints (when this shape itself is a PropertyShape) #}
+    {% if 'property_shape' in shape_info.kinds and shape_info.property_shape %}
+    <section class="section">
+        <h3>Constraints</h3>
+        {{ render_property_shape(shape_info.property_shape, classes, object_properties + datatype_properties + annotation_properties) }}
+    </section>
+    {% endif %}
+
+    {# Generic fallback for any non-first-class SHACL predicates at the top level #}
+    {% if shape_info.other_constraints %}
+    <section class="section">
+        <h3>Other Constraints</h3>
+        <table>
+            <thead><tr><th>Predicate</th><th>Value</th></tr></thead>
+            <tbody>
+                {% for pred, vals in shape_info.other_constraints.items() %}
+                {% for v in vals %}
+                <tr><td><code>{{ pred }}</code></td><td><code>{{ v }}</code></td></tr>
+                {% endfor %}
+                {% endfor %}
+            </tbody>
+        </table>
+    </section>
+    {% endif %}
+
+    {% if shape_info.annotations %}
+    <section class="section">
+        <h3>Annotations</h3>
+        <table>
+            <thead><tr><th>Property</th><th>Value</th></tr></thead>
+            <tbody>
+                {% for name, values in shape_info.annotations.items() %}
+                {% for value in values %}
+                <tr>
+                    <td><code>{{ name }}</code></td>
+                    <td>{{ value }}</td>
+                </tr>
+                {% endfor %}
+                {% endfor %}
+            </tbody>
+        </table>
+    </section>
+    {% endif %}
+</article>
+{% endblock %}

--- a/src/rdf_construct/docs/templates/html/single_page.html.jinja
+++ b/src/rdf_construct/docs/templates/html/single_page.html.jinja
@@ -12,6 +12,9 @@
         {% if annotation_properties %}
         <li><a href="#annotation-properties">Annotation Properties</a></li>
         {% endif %}
+        {% if shapes and config.include_shapes %}
+        <li><a href="#shapes">Shapes</a></li>
+        {% endif %}
         {% if instances and config.include_instances %}
         <li><a href="#instances">Instances</a></li>
         {% endif %}
@@ -28,6 +31,12 @@
         <div class="number">{{ object_properties | length + datatype_properties | length }}</div>
         <div class="label">Properties</div>
     </div>
+    {% if shapes and config.include_shapes %}
+    <div class="stat-card">
+        <div class="number">{{ shapes | length }}</div>
+        <div class="label">Shapes</div>
+    </div>
+    {% endif %}
     {% if instances %}
     <div class="stat-card">
         <div class="number">{{ instances | length }}</div>
@@ -119,6 +128,36 @@
         <p class="uri">{{ prop.uri }}</p>
         {% if prop.definition %}
         <p class="definition">{{ prop.definition }}</p>
+        {% endif %}
+    </article>
+    {% endfor %}
+</section>
+{% endif %}
+
+{% if shapes and config.include_shapes %}
+<section id="shapes">
+    <h2>Shapes</h2>
+    {% for shape in shapes %}
+    <article class="entity-card" id="shape-{{ shape.qname | qname_local }}">
+        <h3>
+            {{ shape.label or shape.qname }}
+            {% for kind in shape.kinds %}
+            {% if kind != 'shape' %}
+            <span class="entity-type {{ kind }}">{{ kind | replace('_', ' ') }}</span>
+            {% endif %}
+            {% endfor %}
+        </h3>
+        <p class="uri">{{ shape.uri }}</p>
+        {% if shape.definition %}
+        <p class="definition">{{ shape.definition }}</p>
+        {% endif %}
+        {% if shape.target_classes %}
+        <p><strong>Target classes:</strong>
+        {% for uri in shape.target_classes %}<code>{{ uri }}</code>{% if not loop.last %}, {% endif %}{% endfor %}
+        </p>
+        {% endif %}
+        {% if 'node_shape' in shape.kinds and shape.properties %}
+        <p><strong>Property constraints:</strong> {{ shape.properties | length }}</p>
         {% endif %}
     </article>
     {% endfor %}

--- a/tests/test_docs.py
+++ b/tests/test_docs.py
@@ -4,15 +4,17 @@ import json
 from pathlib import Path
 
 import pytest
-from rdflib import Graph, Literal, Namespace, RDF, RDFS, URIRef
-from rdflib.namespace import OWL, XSD
+from rdflib import BNode, Graph, Literal, Namespace, RDF, RDFS, URIRef
+from rdflib.namespace import OWL, SH, XSD
 
 from rdf_construct.docs import (
     ClassInfo,
     DocsConfig,
     DocsGenerator,
+    EntityKind,
     ExtractedEntities,
     PropertyInfo,
+    ShapeInfo,
     extract_all,
     generate_docs,
 )
@@ -650,3 +652,590 @@ class TestPathResolution:
             # And no relative-prefix paths on layout assets
             assert 'href="./assets/style.css"' not in html
             assert 'href="../assets/style.css"' not in html
+
+
+# ---------------------------------------------------------------------------
+# SHACL shape support — issue #60 / milestone v0.5.0 stage 1
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture
+def shape_ontology() -> Graph:
+    """Create an ontology with SHACL shapes for testing.
+
+    Includes:
+    - A class (Person) and an instance (Alice) — for verifying that
+      shapes don't pollute the instance bucket and for cross-references.
+    - A datatype property (hasName) — referenced by sh:path.
+    - A NodeShape (PersonShape) with one blank-node PropertyShape
+      (constraints on hasName) and one named PropertyShape arc
+      (AgeConstraint).
+    - A named PropertyShape (AgeConstraint) with its own URI and
+      constraints — referenced from PersonShape.property and also
+      standing alone.
+    - A long-tail SHACL constraint (sh:severity) on the blank-node
+      PropertyShape — exercises the generic fallback rendering.
+    """
+    g = Graph()
+    g.bind("ex", EX)
+    g.bind("sh", SH)
+
+    g.add((EX.MyOnt, RDF.type, OWL.Ontology))
+    g.add((EX.MyOnt, RDFS.label, Literal("Shape Demo")))
+
+    # Class + property + instance for context
+    g.add((EX.Person, RDF.type, OWL.Class))
+    g.add((EX.Person, RDFS.label, Literal("Person")))
+    g.add((EX.hasName, RDF.type, OWL.DatatypeProperty))
+    g.add((EX.hasName, RDFS.domain, EX.Person))
+    g.add((EX.hasName, RDFS.range, XSD.string))
+    g.add((EX.hasName, RDFS.label, Literal("has name")))
+    g.add((EX.Alice, RDF.type, EX.Person))
+    g.add((EX.Alice, RDFS.label, Literal("Alice")))
+
+    # NodeShape with blank-node and named PropertyShape arcs
+    g.add((EX.PersonShape, RDF.type, SH.NodeShape))
+    g.add((EX.PersonShape, RDFS.label, Literal("Person Shape")))
+    g.add((EX.PersonShape, RDFS.comment, Literal("Constraints on Person.")))
+    g.add((EX.PersonShape, SH.targetClass, EX.Person))
+    g.add((EX.PersonShape, SH.closed, Literal(False)))
+
+    ps_name = BNode()
+    g.add((EX.PersonShape, SH.property, ps_name))
+    g.add((ps_name, SH.path, EX.hasName))
+    g.add((ps_name, SH.minCount, Literal(1)))
+    g.add((ps_name, SH.maxCount, Literal(1)))
+    g.add((ps_name, SH.datatype, XSD.string))
+    g.add((ps_name, SH.maxLength, Literal(100)))
+    # Long-tail SHACL constraint — exercises the generic fallback
+    g.add((ps_name, SH.severity, SH.Violation))
+
+    # Named PropertyShape, also referenced from PersonShape
+    g.add((EX.AgeConstraint, RDF.type, SH.PropertyShape))
+    g.add((EX.AgeConstraint, RDFS.label, Literal("Age Constraint")))
+    g.add((EX.AgeConstraint, SH.path, EX.hasAge))
+    g.add((EX.AgeConstraint, SH.datatype, XSD.integer))
+    g.add((EX.AgeConstraint, SH.minInclusive, Literal(0)))
+    g.add((EX.AgeConstraint, SH.maxInclusive, Literal(150)))
+    g.add((EX.PersonShape, SH.property, EX.AgeConstraint))
+
+    return g
+
+
+class TestShapeExtraction:
+    """Tests for ShapeInfo extraction (acceptance criteria 1 & 2 of #60)."""
+
+    def test_node_shape_extracted(self, shape_ontology: Graph):
+        """NodeShape is recognised as a shape with the right kinds."""
+        entities = extract_all(shape_ontology)
+        person_shape = next(
+            (s for s in entities.shapes if "PersonShape" in s.qname),
+            None,
+        )
+        assert person_shape is not None
+        assert EntityKind.SHAPE in person_shape.kinds
+        assert EntityKind.NODE_SHAPE in person_shape.kinds
+        assert EntityKind.PROPERTY_SHAPE not in person_shape.kinds
+
+    def test_named_property_shape_extracted(self, shape_ontology: Graph):
+        """Named PropertyShape gets its own ShapeInfo entry."""
+        entities = extract_all(shape_ontology)
+        age_constraint = next(
+            (s for s in entities.shapes if "AgeConstraint" in s.qname),
+            None,
+        )
+        assert age_constraint is not None
+        assert EntityKind.SHAPE in age_constraint.kinds
+        assert EntityKind.PROPERTY_SHAPE in age_constraint.kinds
+        assert EntityKind.NODE_SHAPE not in age_constraint.kinds
+
+    def test_node_shape_target_class(self, shape_ontology: Graph):
+        """NodeShape's sh:targetClass populates target_classes."""
+        entities = extract_all(shape_ontology)
+        person_shape = next(s for s in entities.shapes if "PersonShape" in s.qname)
+        assert len(person_shape.target_classes) == 1
+        assert str(person_shape.target_classes[0]) == str(EX.Person)
+
+    def test_blank_node_property_shape_inline_on_parent(self, shape_ontology: Graph):
+        """Blank-node PropertyShapes appear inline on their parent NodeShape.
+
+        They do NOT get their own standalone ShapeInfo entry — they're
+        only accessible via the parent's `properties` list.
+        """
+        entities = extract_all(shape_ontology)
+        person_shape = next(s for s in entities.shapes if "PersonShape" in s.qname)
+
+        # Should have 2 property arcs: one blank (hasName), one named (AgeConstraint)
+        assert len(person_shape.properties) == 2
+        blank_props = [p for p in person_shape.properties if p.is_blank]
+        named_props = [p for p in person_shape.properties if not p.is_blank]
+        assert len(blank_props) == 1
+        assert len(named_props) == 1
+
+        # The blank one constrains hasName
+        assert str(blank_props[0].path) == str(EX.hasName)
+
+        # And it has no standalone ShapeInfo entry
+        blank_node_shapes = [
+            s for s in entities.shapes
+            if s.uri is None or "hasName" in str(s.uri).lower()
+        ]
+        assert blank_node_shapes == [], "Blank-node PropertyShape leaked as standalone"
+
+    def test_named_property_shape_referenced_inline_too(self, shape_ontology: Graph):
+        """Named PropertyShape appears both standalone and inline on parent."""
+        entities = extract_all(shape_ontology)
+        person_shape = next(s for s in entities.shapes if "PersonShape" in s.qname)
+        # Inline reference on parent
+        named_inline = [p for p in person_shape.properties if not p.is_blank]
+        assert len(named_inline) == 1
+        assert "AgeConstraint" in (named_inline[0].qname or "")
+        # Standalone entry
+        age_constraint = next(s for s in entities.shapes if "AgeConstraint" in s.qname)
+        assert age_constraint is not None
+
+    def test_first_class_constraints_extracted(self, shape_ontology: Graph):
+        """All populated first-class constraints land in named fields."""
+        entities = extract_all(shape_ontology)
+        person_shape = next(s for s in entities.shapes if "PersonShape" in s.qname)
+        blank_ps = next(p for p in person_shape.properties if p.is_blank)
+
+        assert str(blank_ps.path) == str(EX.hasName)
+        assert blank_ps.min_count == 1
+        assert blank_ps.max_count == 1
+        assert str(blank_ps.datatype) == str(XSD.string)
+        assert blank_ps.max_length == 100
+
+    def test_long_tail_constraint_falls_back(self, shape_ontology: Graph):
+        """Unknown SHACL predicates land in other_constraints, not silently dropped."""
+        entities = extract_all(shape_ontology)
+        person_shape = next(s for s in entities.shapes if "PersonShape" in s.qname)
+        blank_ps = next(p for p in person_shape.properties if p.is_blank)
+
+        # sh:severity isn't first-class — should be in other_constraints
+        severity_pred = SH.severity
+        assert severity_pred in blank_ps.other_constraints
+        values = blank_ps.other_constraints[severity_pred]
+        assert len(values) == 1
+
+    def test_shapes_excluded_from_instances(self, shape_ontology: Graph):
+        """Shapes do not appear in the instances list (the central #60 bug)."""
+        entities = extract_all(shape_ontology)
+        instance_qnames = {i.qname for i in entities.instances}
+        # Alice should be there
+        assert "ex:Alice" in instance_qnames
+        # PersonShape and AgeConstraint should NOT
+        assert "ex:PersonShape" not in instance_qnames
+        assert "ex:AgeConstraint" not in instance_qnames
+
+    def test_node_shapes_property_filters_correctly(self, shape_ontology: Graph):
+        """ExtractedEntities.node_shapes returns only NodeShapes."""
+        entities = extract_all(shape_ontology)
+        ns = entities.node_shapes
+        assert len(ns) == 1
+        assert "PersonShape" in ns[0].qname
+
+    def test_property_shapes_property_filters_correctly(self, shape_ontology: Graph):
+        """ExtractedEntities.property_shapes returns only PropertyShapes."""
+        entities = extract_all(shape_ontology)
+        ps = entities.property_shapes
+        assert len(ps) == 1
+        assert "AgeConstraint" in ps[0].qname
+
+    def test_multi_kind_node_shape_also_named_individual(self):
+        """A NodeShape that's also owl:NamedIndividual still appears in shapes.
+
+        This is the canonical multi-kind case the panel review highlighted.
+        Should appear in shapes (priority order places shape ahead of
+        named_individual) — and must NOT also appear in instances.
+        """
+        g = Graph()
+        g.bind("ex", EX)
+        g.add((EX.MyShape, RDF.type, SH.NodeShape))
+        g.add((EX.MyShape, RDF.type, OWL.NamedIndividual))
+
+        entities = extract_all(g)
+        shape_qnames = {s.qname for s in entities.shapes}
+        instance_qnames = {i.qname for i in entities.instances}
+
+        assert "ex:MyShape" in shape_qnames
+        # And shouldn't double-up in instances
+        assert "ex:MyShape" not in instance_qnames
+
+    def test_sh_in_walks_rdf_list(self):
+        """sh:in is an rdf:List — its members should be walked into in_values."""
+        g = Graph()
+        g.bind("ex", EX)
+        g.add((EX.S, RDF.type, SH.PropertyShape))
+        g.add((EX.S, SH.path, EX.colour))
+
+        # rdf:List of three values: red, green, blue
+        list_head = BNode()
+        list_mid = BNode()
+        list_tail = BNode()
+        g.add((EX.S, SH["in"], list_head))
+        g.add((list_head, RDF.first, Literal("red")))
+        g.add((list_head, RDF.rest, list_mid))
+        g.add((list_mid, RDF.first, Literal("green")))
+        g.add((list_mid, RDF.rest, list_tail))
+        g.add((list_tail, RDF.first, Literal("blue")))
+        g.add((list_tail, RDF.rest, RDF.nil))
+
+        entities = extract_all(g)
+        shape = next(s for s in entities.shapes if "S" == s.qname.split(":")[-1])
+        assert shape.property_shape is not None
+        assert shape.property_shape.in_values == ["red", "green", "blue"]
+
+
+class TestShapeRendering:
+    """Tests for shape rendering across HTML, Markdown, and JSON formats.
+
+    Covers acceptance criteria 3, 4, 5, 6, 7 of #60: shape pages
+    appear with kind badges, blank-node and named PropertyShapes
+    render correctly, all 21 first-class constraints render, the
+    generic fallback works, and JSON output uses the new schema.
+    """
+
+    def test_html_renders_shape_pages(self, shape_ontology: Graph, output_dir: Path):
+        """HTML format produces shape pages under shapes/."""
+        config = DocsConfig(output_dir=output_dir, format="html")
+        result = DocsGenerator(config).generate(shape_ontology)
+
+        assert result.shapes_count == 2
+        assert (output_dir / "shapes" / "PersonShape.html").exists()
+        assert (output_dir / "shapes" / "AgeConstraint.html").exists()
+
+    def test_markdown_renders_shape_pages(self, shape_ontology: Graph, output_dir: Path):
+        """Markdown format produces shape pages under shapes/."""
+        config = DocsConfig(output_dir=output_dir, format="markdown")
+        result = DocsGenerator(config).generate(shape_ontology)
+
+        assert result.shapes_count == 2
+        assert (output_dir / "shapes" / "PersonShape.md").exists()
+        assert (output_dir / "shapes" / "AgeConstraint.md").exists()
+
+    def test_json_renders_shape_pages(self, shape_ontology: Graph, output_dir: Path):
+        """JSON format produces shape pages under shapes/."""
+        config = DocsConfig(output_dir=output_dir, format="json")
+        result = DocsGenerator(config).generate(shape_ontology)
+
+        assert result.shapes_count == 2
+        assert (output_dir / "shapes" / "PersonShape.json").exists()
+        assert (output_dir / "shapes" / "AgeConstraint.json").exists()
+
+    def test_html_kind_badges(self, shape_ontology: Graph, output_dir: Path):
+        """HTML shape pages include kind badges (node_shape / property_shape)."""
+        config = DocsConfig(output_dir=output_dir, format="html")
+        DocsGenerator(config).generate(shape_ontology)
+
+        ns_html = (output_dir / "shapes" / "PersonShape.html").read_text()
+        assert "node_shape" in ns_html
+        assert "node shape" in ns_html  # human-readable label
+
+        ps_html = (output_dir / "shapes" / "AgeConstraint.html").read_text()
+        assert "property_shape" in ps_html
+        assert "property shape" in ps_html
+
+    def test_html_blank_property_shape_inline(self, shape_ontology: Graph, output_dir: Path):
+        """Blank-node PropertyShape constraints render inline on parent NodeShape."""
+        config = DocsConfig(output_dir=output_dir, format="html")
+        DocsGenerator(config).generate(shape_ontology)
+
+        ns_html = (output_dir / "shapes" / "PersonShape.html").read_text()
+        # Constraint table values from the blank-node PropertyShape
+        assert "Min Count" in ns_html
+        assert "Max Length" in ns_html
+        assert "Datatype" in ns_html
+        # Path should resolve to a link (hasName is in the ontology)
+        assert 'href="' in ns_html and "hasName" in ns_html
+
+    def test_html_named_property_shape_linked_inline(self, shape_ontology: Graph, output_dir: Path):
+        """Named PropertyShape inline reference includes a link to its own page."""
+        config = DocsConfig(output_dir=output_dir, format="html")
+        DocsGenerator(config).generate(shape_ontology)
+
+        ns_html = (output_dir / "shapes" / "PersonShape.html").read_text()
+        # Should link to AgeConstraint.html somewhere in the page
+        assert "AgeConstraint.html" in ns_html
+
+    def test_html_long_tail_constraint_visible(self, shape_ontology: Graph, output_dir: Path):
+        """Long-tail SHACL predicates render in the generic fallback area, not silently dropped."""
+        config = DocsConfig(output_dir=output_dir, format="html")
+        DocsGenerator(config).generate(shape_ontology)
+
+        ns_html = (output_dir / "shapes" / "PersonShape.html").read_text()
+        # sh:severity is a long-tail constraint — should appear by URI
+        assert "shacl#severity" in ns_html
+
+    def test_html_target_class_cross_reference(self, shape_ontology: Graph, output_dir: Path):
+        """sh:targetClass links to the class's docs page when in the ontology."""
+        config = DocsConfig(output_dir=output_dir, format="html")
+        DocsGenerator(config).generate(shape_ontology)
+
+        ns_html = (output_dir / "shapes" / "PersonShape.html").read_text()
+        # The target class Person is in the ontology — should link
+        assert 'href="' in ns_html and "Person.html" in ns_html
+
+    def test_markdown_kind_in_frontmatter(self, shape_ontology: Graph, output_dir: Path):
+        """Markdown frontmatter type field carries the most-specific kind."""
+        config = DocsConfig(output_dir=output_dir, format="markdown")
+        DocsGenerator(config).generate(shape_ontology)
+
+        ns_md = (output_dir / "shapes" / "PersonShape.md").read_text()
+        assert "type: node_shape" in ns_md
+
+        ps_md = (output_dir / "shapes" / "AgeConstraint.md").read_text()
+        assert "type: property_shape" in ps_md
+
+    def test_markdown_constraint_table(self, shape_ontology: Graph, output_dir: Path):
+        """Markdown shape pages include a GFM constraint table."""
+        config = DocsConfig(output_dir=output_dir, format="markdown")
+        DocsGenerator(config).generate(shape_ontology)
+
+        ns_md = (output_dir / "shapes" / "PersonShape.md").read_text()
+        # GFM table header
+        assert "| Constraint | Value |" in ns_md
+        assert "| --- | --- |" in ns_md
+        # First-class constraint values
+        assert "Min Count" in ns_md
+        assert "Datatype" in ns_md
+
+    def test_json_breaking_change_shapes_not_in_instances(
+        self, shape_ontology: Graph, output_dir: Path
+    ):
+        """Breaking change: shapes are NOT in the instances array of index.json."""
+        config = DocsConfig(output_dir=output_dir, format="json")
+        DocsGenerator(config).generate(shape_ontology)
+
+        idx = json.loads((output_dir / "index.json").read_text())
+        instance_qnames = {i["qname"] for i in idx["instances"]}
+        assert "ex:PersonShape" not in instance_qnames
+        assert "ex:AgeConstraint" not in instance_qnames
+        # And ex:Alice (a real instance) IS there
+        assert "ex:Alice" in instance_qnames
+
+    def test_json_top_level_shapes_array(self, shape_ontology: Graph, output_dir: Path):
+        """index.json gains a top-level 'shapes' array with shape summaries."""
+        config = DocsConfig(output_dir=output_dir, format="json")
+        DocsGenerator(config).generate(shape_ontology)
+
+        idx = json.loads((output_dir / "index.json").read_text())
+        assert "shapes" in idx
+        shape_qnames = {s["qname"] for s in idx["shapes"]}
+        assert "ex:PersonShape" in shape_qnames
+        assert "ex:AgeConstraint" in shape_qnames
+        # Each summary entry includes kinds
+        for s in idx["shapes"]:
+            assert "kinds" in s
+            assert isinstance(s["kinds"], list)
+
+    def test_json_statistics_includes_shapes(self, shape_ontology: Graph, output_dir: Path):
+        """index.json statistics object includes a 'shapes' count."""
+        config = DocsConfig(output_dir=output_dir, format="json")
+        DocsGenerator(config).generate(shape_ontology)
+
+        idx = json.loads((output_dir / "index.json").read_text())
+        assert idx["statistics"]["shapes"] == 2
+
+    def test_json_full_shape_schema(self, shape_ontology: Graph, output_dir: Path):
+        """A full shape JSON file has the agreed schema keys."""
+        config = DocsConfig(output_dir=output_dir, format="json")
+        DocsGenerator(config).generate(shape_ontology)
+
+        ps_json = json.loads((output_dir / "shapes" / "PersonShape.json").read_text())
+        # Top-level keys
+        for key in [
+            "uri", "qname", "kinds", "label", "definition",
+            "target_classes", "target_nodes", "target_subjects_of", "target_objects_of",
+            "closed", "ignored_properties", "properties", "property_shape",
+            "annotations", "other_constraints",
+        ]:
+            assert key in ps_json, f"shape JSON missing key: {key}"
+
+        # Inline blank PropertyShape schema
+        prop = ps_json["properties"][0]
+        for key in [
+            "uri", "qname", "is_blank", "path", "name", "description",
+            "datatype", "class", "node_kind",
+            "min_count", "max_count", "min_length", "max_length",
+            "min_inclusive", "max_inclusive", "pattern", "has_value",
+            "in_values", "other_constraints",
+        ]:
+            assert key in prop, f"property shape JSON missing key: {key}"
+
+    def test_json_uses_class_not_class_underscore(
+        self, shape_ontology: Graph, output_dir: Path
+    ):
+        """JSON key is 'class' (matches SHACL spec), not 'class_'."""
+        # Add a sh:class constraint to verify
+        g = shape_ontology
+        ps_extra = BNode()
+        g.add((EX.PersonShape, SH.property, ps_extra))
+        g.add((ps_extra, SH.path, EX.knows))
+        g.add((ps_extra, SH["class"], EX.Person))
+
+        config = DocsConfig(output_dir=output_dir, format="json")
+        DocsGenerator(config).generate(g)
+
+        ps_json = json.loads((output_dir / "shapes" / "PersonShape.json").read_text())
+        # Find the property shape that has a class constraint
+        with_class = [p for p in ps_json["properties"] if p.get("class") is not None]
+        assert len(with_class) >= 1
+        assert "class_" not in with_class[0]
+
+
+class TestShapeIndexAndSinglePage:
+    """Tests for shapes appearing in index and single-page outputs."""
+
+    def test_html_index_has_shapes_section(
+        self, shape_ontology: Graph, output_dir: Path
+    ):
+        """HTML index.html includes a Shapes section."""
+        config = DocsConfig(output_dir=output_dir, format="html")
+        DocsGenerator(config).generate(shape_ontology)
+
+        idx = (output_dir / "index.html").read_text()
+        assert "<h2>Shapes</h2>" in idx
+        assert "PersonShape" in idx or "Person Shape" in idx
+
+    def test_markdown_index_has_shapes_section(
+        self, shape_ontology: Graph, output_dir: Path
+    ):
+        """Markdown index.md includes a Shapes section."""
+        config = DocsConfig(output_dir=output_dir, format="markdown")
+        DocsGenerator(config).generate(shape_ontology)
+
+        idx = (output_dir / "index.md").read_text()
+        assert "## Shapes" in idx
+
+    def test_html_single_page_has_shapes(
+        self, shape_ontology: Graph, output_dir: Path
+    ):
+        """HTML single-page output includes a Shapes section."""
+        config = DocsConfig(output_dir=output_dir, format="html", single_page=True)
+        DocsGenerator(config).generate(shape_ontology)
+
+        text = (output_dir / "index.html").read_text()
+        assert '<section id="shapes">' in text
+
+
+class TestShapeSearchIndex:
+    """Tests for shapes appearing in the search index."""
+
+    def test_shapes_appear_in_search_index(self, shape_ontology: Graph):
+        """Shapes appear with entity_type='shape' and the right kinds."""
+        entities = extract_all(shape_ontology)
+        config = DocsConfig()
+        index = generate_search_index(entities, config)
+
+        shape_entries = [e for e in index if e.entity_type == "shape"]
+        assert len(shape_entries) == 2
+        qnames = {e.qname for e in shape_entries}
+        assert "ex:PersonShape" in qnames
+        assert "ex:AgeConstraint" in qnames
+
+    def test_search_entry_kinds_field_populated(self, shape_ontology: Graph):
+        """SearchEntry.kinds carries the full multi-kind list."""
+        entities = extract_all(shape_ontology)
+        config = DocsConfig()
+        index = generate_search_index(entities, config)
+
+        ns_entry = next(e for e in index if e.qname == "ex:PersonShape")
+        assert "node_shape" in ns_entry.kinds
+        assert "shape" in ns_entry.kinds
+
+    def test_search_target_class_indexed(self, shape_ontology: Graph):
+        """Searching for the target class name surfaces the shape."""
+        entities = extract_all(shape_ontology)
+        config = DocsConfig()
+        index = generate_search_index(entities, config)
+
+        ns_entry = next(e for e in index if e.qname == "ex:PersonShape")
+        # 'person' (from Person target class) should be a keyword
+        assert "person" in ns_entry.keywords
+
+
+class TestIncludeShapesFlag:
+    """Tests for the --include-shapes / config.include_shapes toggle."""
+
+    def test_default_include_shapes_true(self):
+        """include_shapes defaults to True."""
+        assert DocsConfig().include_shapes is True
+
+    def test_include_shapes_from_dict(self):
+        """include_shapes is settable via from_dict (YAML config)."""
+        cfg = DocsConfig.from_dict({"include_shapes": False})
+        assert cfg.include_shapes is False
+
+    def test_include_shapes_false_excludes_pages(
+        self, shape_ontology: Graph, output_dir: Path
+    ):
+        """include_shapes=False produces no shape pages or shapes/ dir."""
+        config = DocsConfig(
+            output_dir=output_dir,
+            format="html",
+            include_shapes=False,
+        )
+        result = DocsGenerator(config).generate(shape_ontology)
+        assert result.shapes_count == 0
+        assert not (output_dir / "shapes").exists()
+
+    def test_include_shapes_false_excludes_from_search(self, shape_ontology: Graph):
+        """include_shapes=False excludes shapes from the search index."""
+        entities = extract_all(shape_ontology)
+        config = DocsConfig(include_shapes=False)
+        index = generate_search_index(entities, config)
+        shape_entries = [e for e in index if e.entity_type == "shape"]
+        assert shape_entries == []
+
+
+class TestShapeRouting:
+    """Tests for shape URL/path generation."""
+
+    def test_shape_path_under_shapes_directory(self):
+        """entity_to_path routes shapes under shapes/."""
+        config = DocsConfig(format="html")
+        path = entity_to_path("ex:PersonShape", "shape", config)
+        assert path == Path("shapes/PersonShape.html")
+
+    def test_shape_path_with_entity_kind_enum(self):
+        """entity_to_path accepts an EntityKind member directly (str-equivalent)."""
+        config = DocsConfig(format="html")
+        path = entity_to_path("ex:PersonShape", EntityKind.SHAPE, config)
+        assert path == Path("shapes/PersonShape.html")
+
+
+class TestEntityKindEnum:
+    """Tests for the EntityKind enum behaviour.
+
+    These verify the str-mixin contract that the rest of the docs
+    module relies on: enum members compare equal to their string
+    values, render as their values in templates and JSON, and survive
+    round-tripping through json.dumps as plain strings.
+    """
+
+    def test_enum_equals_string_value(self):
+        assert EntityKind.SHAPE == "shape"
+        assert "shape" == EntityKind.SHAPE
+        assert EntityKind.NODE_SHAPE == "node_shape"
+
+    def test_str_returns_value(self):
+        """str() returns the enum value (overrides 3.11+ default)."""
+        assert str(EntityKind.SHAPE) == "shape"
+        assert str(EntityKind.NODE_SHAPE) == "node_shape"
+
+    def test_fstring_renders_value(self):
+        """f-strings render the value, not 'EntityKind.SHAPE'."""
+        assert f"{EntityKind.SHAPE}" == "shape"
+
+    def test_json_serialises_as_plain_string(self):
+        """json.dumps emits the value as a plain string."""
+        assert json.dumps(EntityKind.SHAPE) == '"shape"'
+        assert json.dumps([EntityKind.SHAPE, EntityKind.NODE_SHAPE]) == '["shape", "node_shape"]'
+
+    def test_enum_in_string_list(self):
+        """String-based 'in' checks work both ways."""
+        kinds = [EntityKind.SHAPE, EntityKind.NODE_SHAPE]
+        assert "shape" in kinds
+        assert EntityKind.SHAPE in kinds
+        assert "instance" not in kinds

--- a/tests/test_docs.py
+++ b/tests/test_docs.py
@@ -653,6 +653,46 @@ class TestPathResolution:
             assert 'href="./assets/style.css"' not in html
             assert 'href="../assets/style.css"' not in html
 
+    def test_all_links_resolve_for_every_entity_kind(
+        self, shape_ontology: Graph, output_dir: Path
+    ):
+        """Every page of every entity kind must have resolvable links.
+
+        The sibling tests above run against ``simple_ontology``, which has
+        no SHACL shapes — so they cannot see a render method that skips
+        ``_render_page()`` and leaves its pages on the ``.`` fallback.
+        ``render_shape`` was added that way in #60 and every reference on a
+        ``shapes/`` page broke.
+
+        This runs the same walk over an ontology carrying a class, an
+        instance, a property and both shape kinds, so a new entity type
+        added without going through ``_render_page()`` fails here rather
+        than shipping.
+        """
+        import re
+
+        config = DocsConfig(output_dir=output_dir, format="html")
+        DocsGenerator(config).generate(shape_ontology)
+
+        # The point of the test is lost if the fixture stops producing
+        # pages at depth — assert the tree actually has them.
+        assert list(output_dir.glob("shapes/*.html")), "fixture generated no shape pages"
+
+        broken: list[tuple[Path, str, Path]] = []
+        ref_pat = re.compile(r'(?:href|src)="([^"#?]+)"')
+        for html_file in output_dir.rglob("*.html"):
+            for ref in ref_pat.findall(html_file.read_text()):
+                if ref.startswith(("http://", "https://", "mailto:", "#")):
+                    continue
+                target = (html_file.parent / ref).resolve()
+                if not target.exists():
+                    broken.append((html_file.relative_to(output_dir), ref, target))
+
+        assert not broken, (
+            "References did not resolve to existing files:\n"
+            + "\n".join(f"  {p}: {r!r} -> {t}" for p, r, t in broken)
+        )
+
 
 # ---------------------------------------------------------------------------
 # SHACL shape support — issue #60 / milestone v0.5.0 stage 1


### PR DESCRIPTION
## Summary

Adds first-class support for SHACL shapes (`sh:NodeShape` and named `sh:PropertyShape`) as a distinct entity type in the `docs` command, alongside Classes, Properties, and Instances. NodeShapes and named PropertyShapes get their own pages under `shapes/`; blank-node PropertyShapes attached via `sh:property` render inline on their parent NodeShape's page.

This is **stage 1** of milestone [v0.5.0 — Entity-type taxonomy in docs](https://github.com/aigora-de/rdf-construct/milestone/1). The multi-kind data model introduced here is the extension point for stages 2 (SKOS) and 3 (`owl:NamedIndividual` recognition).

## Related Issues

Closes #60

Resolves the central bug from the original report: subjects typed as `sh:NodeShape` or `sh:PropertyShape` no longer appear under the **Instances** section. They now have their own section, their own page template, distinct kind badges, and are excluded from the search index's `instance` entries.

## Changes

Nine logical commits, each scoped to one step:

| Step | Commit | Scope |
|---|---|---|
| 1 | `feat(docs): add multi-kind data model and SHACL shape extraction` | `EntityKind` enum, `ShapeInfo`/`PropertyShapeInfo` dataclasses, `extract_all_shapes()`, instance-bucket exclusion, `extractors.py` |
| 2 | `feat(docs): route shapes under shapes/ and add include_shapes flag` | `entity_to_path` routing, `DocsConfig.include_shapes` |
| 3 | `feat(docs): render SHACL shapes in HTML output` | `render_shape()`, new `shape.html.jinja`, index/single-page sections, accessible CSS badges |
| 4 | `feat(docs): render SHACL shapes in Markdown output` | Markdown shape pages with GFM constraint tables, frontmatter |
| 5 | `feat(docs): render SHACL shapes in JSON output` | Breaking-change JSON schema (top-level `shapes` array) |
| 6 | `feat(docs): include SHACL shapes in the search index` | `shape_to_search_entry`, `kinds` field on `SearchEntry`, target-class indexing |
| 7 | `feat(docs): wire shape rendering into DocsGenerator orchestrator` | Render loop, `GenerationResult.shapes_count` |
| 8 | `test(docs): add comprehensive tests for SHACL shape support` | 44 new tests across 7 classes; bug fix in `_walk_rdf_list` |
| 9 | `docs(docs-guide): document SHACL shape support and add --no-shapes CLI flag` | DOCS_GUIDE, CHANGELOG, `--no-shapes` CLI option |

### Multi-kind data model

Entities now carry a `kinds: list[EntityKind]` field. Defaults: `[CLASS]`, `[PROPERTY, <type>_PROPERTY]`, `[INSTANCE]`, `[SHAPE, NODE_SHAPE]` / `[SHAPE, PROPERTY_SHAPE]`. A NodeShape that's also typed `owl:NamedIndividual` carries both kinds and is placed in the Shapes section (priority order). `EntityKind` is a `str, Enum` mixin with an explicit `__str__` override — restores 3.10-era behaviour where `str(member)` returns the value, so f-strings and Jinja templates render `"shape"` rather than `"EntityKind.SHAPE"`.

### First-class SHACL constraint coverage

21 constraints get explicit per-format rendering: `sh:path`, `sh:minCount`, `sh:maxCount`, `sh:datatype`, `sh:class`, `sh:nodeKind`, `sh:in`, `sh:hasValue`, `sh:pattern`, `sh:minLength`, `sh:maxLength`, `sh:minInclusive`, `sh:maxInclusive`, `sh:targetClass`, `sh:targetNode`, `sh:targetSubjectsOf`, `sh:targetObjectsOf`, `sh:closed`, `sh:ignoredProperties`, `sh:name`, `sh:description`. Anything else (e.g. `sh:severity`, `sh:order`) renders in a generic visible-but-plain key-value fallback. Logical operators (`sh:and` / `sh:or` / `sh:xone`) and `sh:qualifiedValueShape` are explicitly deferred — they need their own design pass.

### Accessible badge palette

Shape badges use a single hue family with a brightness gradient signalling NodeShape/PropertyShape kinship:

| Class | Hex | Contrast (vs white text) |
|---|---|---|
| `.shape` | `#dc2626` | 4.83:1 (WCAG AA) |
| `.node_shape` | `#b91c1c` | 6.47:1 (WCAG AA) |
| `.property_shape` | `#e11d48` | 4.70:1 (WCAG AA) |

All three pass WCAG AA. Distinct from the existing purple/cyan/amber/green palette under deuteranopia, protanopia, and tritanopia (warm reds stay clearly red-saturated where amber/green converge to muddy yellow). Descriptive uppercase badge text labels (`"NODE SHAPE"`, `"PROPERTY SHAPE"`) carry the category meaning regardless of perceived colour, so colour is a redundant signal — not the sole differentiator.

The reporter's original suggestion (`#d7191c` red + `#ffffbf` yellow) was rejected after WCAG analysis: yellow on white fails contrast, and red+yellow is the worst possible CVD pair. Documented in the commit message for step 3.

## Bug found and fixed during testing

`_walk_rdf_list` and `extract_property_shape_info` silently truncated `rdf:List` members at the first cell when the list-rest pointer was a blank node (the rdflib default representation). In practice this meant `sh:in` constraints with multiple values lost everything except the first member during extraction. The test `test_sh_in_walks_rdf_list` caught it. Fix: both call sites now accept `(URIRef, BNode)` for list pointers. Folded into commit 8.

## Breaking Changes

**Yes** — to JSON output, called out in `CHANGELOG.md` under `Changed` and in `DOCS_GUIDE.md`.

In v0.4.x, SHACL shapes appeared in the `instances` array of `index.json` and `ontology.json` because the extractor didn't filter them out. v0.5.0 introduces a top-level `shapes` array. Shapes have been removed from `instances`. The `statistics` object also gains a `shapes` count.

JSON consumers updating from v0.4.x must read both arrays to see all entities. The migration is mechanical: where a consumer was iterating `instances` and looking for shape URIs by type, they now iterate `shapes` directly.

Additive (not breaking, but worth noting): all entity dicts in JSON output now include a `kinds` array. Existing fields are unchanged. Consumers that ignore unknown fields are unaffected.

## Testing

```
$ python -m pytest --no-cov
======================= 569 passed, 5 warnings in 4.41s ========================
```

525 baseline tests still pass. 44 new tests added across 7 classes:

| Class | Count | Coverage |
|---|---|---|
| `TestShapeExtraction` | 12 | Acceptance criteria 1, 2, 3, 4, 7, 8: shapes found, kinds correct, blank-vs-named, multi-kind entity, sh:in walking, exclusion from instances, target-class extraction |
| `TestShapeRendering` | 15 | Acceptance criteria 2, 3, 4, 5, 7, 9, 10: HTML/MD/JSON page generation, kind badges, inline blank-node rendering, named PropertyShape link-out, GFM constraint table, JSON schema, breaking-change verification, `class` (not `class_`) JSON key, target-class cross-reference |
| `TestShapeIndexAndSinglePage` | 3 | Acceptance criterion 6: Shapes section appears in index/single-page across all three formats |
| `TestShapeSearchIndex` | 3 | Acceptance criterion 11: shapes in search.json with `kinds` field, target classes indexed as keywords |
| `TestIncludeShapesFlag` | 4 | Acceptance criterion 12: default True, settable via from_dict, False excludes from output and search |
| `TestShapeRouting` | 2 | shape route under `shapes/`, EntityKind accepted by routing |
| `TestEntityKindEnum` | 5 | str-mixin contract: equality, `__str__` returns value, f-string, json.dumps, list membership |

The `test_sh_in_walks_rdf_list` test in `TestShapeExtraction` caught the genuine `_walk_rdf_list` BNode bug — without it, `sh:in` truncation would have shipped silently.

## Panel review

Convened before implementation — three personas (Sam, Alex, Dr. Semantic). Full design discussion captured as a comment on #60. Key locked-in decisions:

- **Multi-kind data model** (Dr. Semantic) — entities carry a list of kinds, not a single bucket. Extension point for SKOS and `owl:NamedIndividual` later.
- **PropertyShape inline-vs-linked** (Sam + Dr. Semantic) — blank-node PropertyShapes inline on parent; named ones get their own pages plus inline link.
- **21 first-class constraints** (Alex) — render the common 80% well, generic fallback for the long tail. Logical operators explicitly deferred.
- **Format parity** — HTML, Markdown, JSON all gain shape support in this PR. No deferred renderers.
- **Concrete `render_shape()` not generic dispatch** (Alex) — YAGNI on premature abstraction. We don't yet know what stage 2 looks like in detail.
- **Clean JSON break, no transition period** — documented as `Changed`, called out in DOCS_GUIDE.

## Acknowledgement

Thanks to @otellomaria for the original report (which also covered #59) and the initial CSS sketch for shape badges.

## Checklist

- [x] All existing tests pass (525/525 baseline)
- [x] New regression tests added (+44 tests, 569/569 total)
- [x] CHANGELOG updated under `[Unreleased]` with `Added`, `Changed`, and `Fixed` entries
- [x] DOCS_GUIDE updated with full SHACL Shapes section, JSON schema, and breaking-change call-out
- [x] CLI gains `--no-shapes` flag and `shapes` accepted in `--include` / `--exclude`
- [x] Manual verification across all three renderers
- [x] Issue #60 assigned to milestone 1; design decisions documented in the issue body and panel review comment
- [x] Branch state verified by clean clone + test run
- [ ] Owner approval (Dave)