### PR TITLE
docs: Fix leading-slash asset paths when base_url is empty

### DIFF
--- a/src/rdf_construct/docs/templates/html/base.html.jinja
+++ b/src/rdf_construct/docs/templates/html/base.html.jinja
@@ -4,7 +4,7 @@
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>{% block title %}{{ ontology.title or "Ontology Documentation" }}{% endblock %}</title>
-    <link rel="stylesheet" href="{{ config.base_url }}/assets/style.css">
+    <link rel="stylesheet" href="{{ config.base_url }}{{ "/" if config.base_url else "" }}assets/style.css">
     {% block head %}{% endblock %}
 </head>
 <body>
@@ -16,9 +16,9 @@
     </header>
 
     <nav class="nav">
-        <a href="{{ config.base_url }}/index.html">Index</a>
-        <a href="{{ config.base_url }}/hierarchy.html">Hierarchy</a>
-        <a href="{{ config.base_url }}/namespaces.html">Namespaces</a>
+        <a href="{{ config.base_url }}{{ "/" if config.base_url else "" }}index.html">Index</a>
+        <a href="{{ config.base_url }}{{ "/" if config.base_url else "" }}hierarchy.html">Hierarchy</a>
+        <a href="{{ config.base_url }}{{ "/" if config.base_url else "" }}namespaces.html">Namespaces</a>
     </nav>
 
     {% if config.include_search %}

--- a/src/rdf_construct/docs/templates/html/base.html.jinja
+++ b/src/rdf_construct/docs/templates/html/base.html.jinja
@@ -37,7 +37,7 @@
     </footer>
 
     {% if config.include_search %}
-    <script src="{{ config.base_url }}/assets/search.js"></script>
+    <script src="{{ config.base_url }}{{ "/" if config.base_url else "" }}assets/search.js"></script>
     {% endif %}
     {% block scripts %}{% endblock %}
 </body>


### PR DESCRIPTION
## Fix: Strip leading slash from asset paths when base_url is empty

Issue: #59

**Problem:** The Jinja template uses `{{ config.base_url }}/assets/...` for asset paths. When `config.base_url` defaults to empty string `""`, this produces leading-slash paths like `/assets/style.css`, breaking docs when:
- Opened via `file://`
- Hosted under a sub-path
- Published via GitHub Pages from a sub-directory

**Fix:** Conditionally include the `/` separator only when `base_url` is non-empty:
```jinja
href="{{ config.base_url }}{{ "/" if config.base_url else "" }}assets/style.css"
```

This generates:
- `base_url=""` → `href="assets/style.css"` ✓
- `base_url="/docs"` → `href="/docs/assets/style.css"` ✓

Closes #59
