### PR TITLE
fix: use relative paths for docs assets when base_url is empty

### DIFF
--- a/src/rdf_construct/docs/templates/html/base.html.jinja
+++ b/src/rdf_construct/docs/templates/html/base.html.jinja
@@ -4,7 +4,7 @@
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>{% block title %}{{ ontology.title or "Ontology Documentation" }}{% endblock %}</title>
-    <link rel="stylesheet" href="{{ config.base_url }}/assets/style.css">
+    <link rel="stylesheet" href="{{ ('%s/' % config.base_url) if config.base_url else '' }}assets/style.css">
     {% block head %}{% endblock %}
 </head>
 <body>
@@ -16,9 +16,9 @@
     </header>
 
     <nav class="nav">
-        <a href="{{ config.base_url }}/index.html">Index</a>
-        <a href="{{ config.base_url }}/hierarchy.html">Hierarchy</a>
-        <a href="{{ config.base_url }}/namespaces.html">Namespaces</a>
+        <a href="{{ ('%s/' % config.base_url) if config.base_url else '' }}index.html">Index</a>
+        <a href="{{ ('%s/' % config.base_url) if config.base_url else '' }}hierarchy.html">Hierarchy</a>
+        <a href="{{ ('%s/' % config.base_url) if config.base_url else '' }}namespaces.html">Namespaces</a>
     </nav>
 
     {% if config.include_search %}
@@ -37,7 +37,7 @@
     </footer>
 
     {% if config.include_search %}
-    <script src="{{ config.base_url }}/assets/search.js"></script>
+    <script src="{{ ('%s/' % config.base_url) if config.base_url else '' }}assets/search.js"></script>
     {% endif %}
     {% block scripts %}{% endblock %}
 </body>


### PR DESCRIPTION
Fixes #59 - Generated HTML docs used leading-slash paths (e.g., `/assets/style.css`) for CSS, nav links, and search assets when `base_url` was empty. This broke local file:// browsing. Now paths are properly relative when `base_url` is unset, and absolute with base_url when configured for deployment.