### PR TITLE
fix: use relative paths for CSS, nav, and search assets in generated docs

### DIFF
--- a/src/rdf_construct/docs/config.py
+++ b/src/rdf_construct/docs/config.py
@@ -89,6 +89,8 @@ class DocsConfig:
             config.language = data["language"]
         if "base_url" in data:
             config.base_url = data["base_url"].rstrip("/")
+            if config.base_url:
+                config.base_url += "/"
         if "logo_path" in data:
             config.logo_path = Path(data["logo_path"])
         if "css_path" in data:
@@ -234,5 +236,5 @@ def entity_to_url(
     url = str(path).replace("\\", "/")  # Ensure forward slashes
 
     if config.base_url:
-        return f"{config.base_url}/{url}"
+        return f"{config.base_url}{url}"
     return url

--- a/src/rdf_construct/docs/templates/html/base.html.jinja
+++ b/src/rdf_construct/docs/templates/html/base.html.jinja
@@ -4,7 +4,7 @@
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>{% block title %}{{ ontology.title or "Ontology Documentation" }}{% endblock %}</title>
-    <link rel="stylesheet" href="{{ config.base_url }}/assets/style.css">
+    <link rel="stylesheet" href="{{ config.base_url }}assets/style.css">
     {% block head %}{% endblock %}
 </head>
 <body>
@@ -16,9 +16,9 @@
     </header>
 
     <nav class="nav">
-        <a href="{{ config.base_url }}/index.html">Index</a>
-        <a href="{{ config.base_url }}/hierarchy.html">Hierarchy</a>
-        <a href="{{ config.base_url }}/namespaces.html">Namespaces</a>
+        <a href="{{ config.base_url }}index.html">Index</a>
+        <a href="{{ config.base_url }}hierarchy.html">Hierarchy</a>
+        <a href="{{ config.base_url }}namespaces.html">Namespaces</a>
     </nav>
 
     {% if config.include_search %}
@@ -37,7 +37,7 @@
     </footer>
 
     {% if config.include_search %}
-    <script src="{{ config.base_url }}/assets/search.js"></script>
+    <script src="{{ config.base_url }}assets/search.js"></script>
     {% endif %}
     {% block scripts %}{% endblock %}
 </body>


### PR DESCRIPTION
Fixes #59 - Generated HTML docs used leading-slash paths for CSS, navigation, and search assets. When base_url was empty (default), paths like `/assets/style.css` broke when opening docs via file:// or hosting under a sub-path.

Changes:
- Normalize base_url to always end with '/' when non-empty
- Removed extra '/' from template href/src attributes
- Updated entity_to_url to not double-slash
- Paths are now relative when base_url is empty, absolute-with-base when set