### PR TITLE
fix(diff): include CURIE representations in JSON diff output (fixes #59)

### DIFF
--- a/src/rdf_construct/diff/formatters/json.py
+++ b/src/rdf_construct/diff/formatters/json.py
@@ -80,12 +80,14 @@ def _format_entity_json(entity: EntityChange, graph: Graph | None = None) -> dic
     """Format a single entity for JSON output."""
     result = {
         "uri": str(entity.uri),
+        "uri_curie": _format_uri(entity.uri, graph),
         "label": entity.label,
         "type": entity.entity_type.value,
     }
 
     if entity.superclasses:
         result["superclasses"] = [str(sc) for sc in entity.superclasses]
+        result["superclasses_curie"] = [_format_uri(sc, graph) for sc in entity.superclasses]
 
     return result
 
@@ -99,6 +101,7 @@ def _format_modified_entities_json(
     for entity in entities:
         entity_dict = {
             "uri": str(entity.uri),
+            "uri_curie": _format_uri(entity.uri, graph),
             "label": entity.label,
             "type": entity.entity_type.value,
             "changes": [],

--- a/tests/test_diff.py
+++ b/tests/test_diff.py
@@ -395,6 +395,16 @@ class TestFormatters:
         assert data["summary"]["removed"] == 1
         assert data["summary"]["modified"] == 1
         assert "classes" in data["added"]
+        assert "uri_curie" in data["added"]["classes"][0]
+
+    def test_json_format_curies_with_graph(self, sample_diff):
+        """Test JSON output includes CURIE fields for entities when graph is provided."""
+        g = Graph()
+        output = format_json(sample_diff, graph=g)
+        data = json.loads(output)
+
+        assert "uri_curie" in data["added"]["classes"][0]
+        assert "uri_curie" in data["modified"][0]
 
     def test_identical_diff_output(self):
         """Test output for identical graphs."""


### PR DESCRIPTION
## Summary
Fixes #59.

## Changes
- Added  to entity dicts in  and .
- Added  to entity dicts when  are present in .
- Added unit tests in  to verify CURIE presence in JSON formatted diff output.