### PR TITLE
chore: add scripts/ci-local.sh and reconcile the pre-commit hooks

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,37 +1,29 @@
 # See https://pre-commit.com for more information
-# Install: pip install pre-commit
-# Setup: pre-commit install
+# Install: pip install pre-commit  (or: poetry install --with dev)
+# Setup:   pre-commit install
+#
+# This config holds only hooks that a contributor can actually live with today.
+# black, ruff and mypy are NOT here: each carries repo-wide pre-existing debt
+# (#77, #78, #79), so as commit hooks they either rewrote files well beyond the
+# change being committed or, in mypy's case, refused the commit outright. They
+# run as advisory steps in scripts/ci-local.sh instead — run that before opening
+# a PR. Each is restored here as its debt reaches zero. See #74.
 
 repos:
   - repo: https://github.com/pre-commit/pre-commit-hooks
     rev: v4.5.0
     hooks:
+      # These two rewrite the staged file. Repo-wide they would touch 21 and 34
+      # files respectively (#77), but scoped to what you are already editing the
+      # churn is small and it stops new debt accruing.
       - id: trailing-whitespace
       - id: end-of-file-fixer
+      # Read-only checks; all pass repo-wide as at 2026-08-22.
       - id: check-yaml
       - id: check-added-large-files
       - id: check-merge-conflict
       - id: check-toml
       - id: debug-statements
-
-  - repo: https://github.com/psf/black
-    rev: 24.1.1
-    hooks:
-      - id: black
-        language_version: python3.10
-
-  - repo: https://github.com/astral-sh/ruff-pre-commit
-    rev: v0.1.14
-    hooks:
-      - id: ruff
-        args: [--fix, --exit-non-zero-on-fix]
-
-  - repo: https://github.com/pre-commit/mirrors-mypy
-    rev: v1.8.0
-    hooks:
-      - id: mypy
-        additional_dependencies: [types-PyYAML]
-        args: [--strict]
 
   # Size guard for the instruction/memory surface (#73). Runs only when the
   # tracked half changes; the memory store itself is local, so the script warns

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   properties rather than classified as individuals. Each is a subclass of `owl:ObjectProperty`
   in OWL 2, and declaring one alone is legal and common in older ontologies
 - `owl:DeprecatedClass` is now recognised by the `classes` selector
+- Quoted the CURIEs in the `together:` flow sequences of `examples/uml/uml_layouts.yml`. Unquoted
+  `building:Building` inside `[ … ]` is rejected by stricter YAML parsers than the one this project
+  uses, so the example failed to load for anyone whose toolchain is spec-conformant. The parsed
+  data is unchanged
 
 ### Added
 - New `other_props` selector for properties whose kind is not implied by their declaration —

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -37,7 +37,7 @@ required before that release is ready.
 3. **Install dependencies**: `poetry install --with dev`
 4. **Make your changes** following the code standards below
 5. **Add tests** for new functionality
-6. **Run the test suite**: `poetry run pytest`
+6. **Run the checks**: `scripts/ci-local.sh` — see [the pre-PR ritual](#scriptsci-localsh--the-pre-pr-ritual)
 7. **Format your code**: `poetry run black src/ tests/`
 8. **Lint**: `poetry run ruff check src/ tests/`
 9. **Commit** with clear, descriptive messages — see [Commits](#commits)
@@ -162,16 +162,8 @@ poetry install --with dev
 # Make changes
 git checkout -b dev/my-feature
 
-# Test
-poetry run pytest
-poetry run pytest --cov=rdf_construct --cov-report=html  # with coverage
-
-# Format
-poetry run black src/ tests/
-poetry run ruff check --fix src/ tests/
-
-# Type check
-poetry run mypy src/
+# Check everything before opening a PR — this is the one command that matters
+scripts/ci-local.sh
 
 # Commit and push
 git add .
@@ -179,15 +171,36 @@ git commit -m "feat(core): clear description of changes"
 git push origin dev/my-feature
 ```
 
-**A note on the current state of the checks:** the test suite is green, but `black`, `ruff` and
-`mypy --strict` all carry substantial pre-existing debt across the repository. Keep *your* changed
-files clean; you are not expected to fix the rest. See
-[#74](https://github.com/aigora-de/rdf-construct/issues/74), which tracks a local CI runner and the
-debt behind each check.
+### `scripts/ci-local.sh` — the pre-PR ritual
+
+**There is no hosted CI.** Nothing runs on push or on a pull request, so `scripts/ci-local.sh` is
+the gate. It runs every check, reports them all, and fails only if a *gate* step failed:
+
+| Step | Severity |
+|---|---|
+| test suite (`pytest`) | **gate** |
+| instruction/memory size guard | **gate** |
+| `black --check` | advisory |
+| `ruff check` | advisory |
+| `mypy --strict` | advisory |
+
+The three advisory steps carry substantial pre-existing debt across the repository — see
+[#77](https://github.com/aigora-de/rdf-construct/issues/77),
+[#78](https://github.com/aigora-de/rdf-construct/issues/78) and
+[#79](https://github.com/aigora-de/rdf-construct/issues/79). **Keep the files your change touches
+clean; you are not expected to fix the rest.** Each becomes a gate as its debt reaches zero.
+
+Useful variants: `--tests-only` (the fast gate alone), `--lint-only` (everything else), and
+`CI_LOCAL_PYRUN=""` if you are already inside an activated virtualenv.
+
+The pre-commit hooks (`pre-commit install`) are a lighter, separate thing: whitespace and file
+hygiene only. `black`, `ruff` and `mypy` are deliberately **not** commit hooks, because against the
+current debt they rewrote files far beyond the change being committed — or, for mypy, refused the
+commit outright.
 
 ## Pull Request Process
 
-1. Ensure all tests pass
+1. Run `scripts/ci-local.sh` and ensure the gate is green
 2. Update documentation as needed
 3. Add entry to CHANGELOG.md under "Unreleased"
 4. Reference related issues in the PR description

--- a/examples/uml/uml_layouts.yml
+++ b/examples/uml/uml_layouts.yml
@@ -175,11 +175,11 @@ layouts:
     # Group related classes together
     together:
       # Core building concepts should be adjacent
-      - [building:Building, building:BuildingUnit, building:Envelope]
+      - ["building:Building", "building:BuildingUnit", "building:Envelope"]
       # Metaclasses grouped
-      - [building:ClassOfBuilding, building:ClassOfBuildingUnit, building:ClassOfEnvelope]
+      - ["building:ClassOfBuilding", "building:ClassOfBuildingUnit", "building:ClassOfEnvelope"]
       # Space types grouped
-      - [building:EnclosedSpace, building:OpenSpace, building:PartiallyEnclosedSpace]
+      - ["building:EnclosedSpace", "building:OpenSpace", "building:PartiallyEnclosedSpace"]
 
     # Hidden links to influence positioning
     layout_hints:

--- a/scripts/ci-local.sh
+++ b/scripts/ci-local.sh
@@ -1,0 +1,116 @@
+#!/usr/bin/env bash
+#
+# ci-local.sh — the pre-PR check runner for rdf-construct.
+#
+# Copyright (c) 2026 Dave Dyke / Agilit Ltd. MIT licence.
+#
+# There is no hosted CI: .github/workflows/ contains only .gitkeep, so nothing runs on
+# push, on a PR, or on a tag, and `gh pr checks` reports nothing. This script is the
+# gate. Run it before opening or merging a PR (#74).
+#
+# GATE vs ADVISORY
+#
+#   GATE     — the test suite and the instruction/memory size guard. A gate step's
+#              failure IS this script's exit code.
+#   ADVISORY — black, ruff and mypy. They run and report but do NOT fail the script,
+#              because each carries substantial pre-existing debt measured across the
+#              whole repository (see the tracking issues below). Gating on them today
+#              would mean the script failed on every run from day one, and a check that
+#              always fails is a check nobody reads.
+#
+# Keep the files YOUR change touches clean; you are not expected to fix the rest.
+# When a debt lands at zero, flip its step from `advisory` to `gate` below — a
+# one-word change — and, for black, restore its pre-commit hook.
+#
+#   black debt   — #77   ruff debt — #78   mypy --strict debt — #79
+#
+# Runs every selected check even if an earlier one fails, then prints a summary and
+# exits non-zero iff a GATE step failed. Override the Python runner with CI_LOCAL_PYRUN
+# (default "poetry run"; set to "" inside an already-active venv).
+#
+# Usage:
+#   scripts/ci-local.sh              # gates (pytest + memory guard) + advisory (black, ruff, mypy)
+#   scripts/ci-local.sh --tests-only # the pytest gate alone (fast)
+#   scripts/ci-local.sh --lint-only  # the non-pytest checks (black, ruff, mypy, memory guard)
+#   scripts/ci-local.sh -h|--help
+
+set -uo pipefail
+
+cd "$(git rev-parse --show-toplevel)" || { echo "not in a git repo" >&2; exit 2; }
+
+PYRUN="${CI_LOCAL_PYRUN-poetry run}"
+RUN_TESTS=1
+RUN_OTHER=1
+case "${1-}" in
+  --tests-only) RUN_OTHER=0 ;;
+  --lint-only)  RUN_TESTS=0 ;;
+  -h|--help)    sed -n '2,37p' "$0" | sed 's/^# \{0,1\}//'; exit 0 ;;
+  "")           ;;
+  *)            echo "unknown option: $1 (try --help)" >&2; exit 2 ;;
+esac
+
+GATE_FAILED=()
+ADVISORY_FAILED=()
+
+# step <gate|advisory> "Name" cmd...
+step() {
+  local mode="$1"; local name="$2"; shift 2
+  printf '\n\033[1m──▶ %s\033[0m' "$name"
+  [[ "$mode" == advisory ]] && printf ' \033[2m(advisory)\033[0m'
+  printf '\n'
+  if "$@"; then
+    printf '   \033[32m✓ %s\033[0m\n' "$name"
+  else
+    if [[ "$mode" == gate ]]; then
+      printf '   \033[31m✗ %s (GATE)\033[0m\n' "$name"
+      GATE_FAILED+=("$name")
+    else
+      printf '   \033[33m✗ %s (advisory — not a gate yet)\033[0m\n' "$name"
+      ADVISORY_FAILED+=("$name")
+    fi
+  fi
+}
+
+# --- the checks -------------------------------------------------------------
+
+# GATE: the full suite. Fast (~4s) and hermetic — no network, no config, no fixtures
+# beyond tests/fixtures/. Coverage is on by default via addopts in pyproject.toml.
+s_pytest() { $PYRUN pytest -q; }
+
+# GATE (#73): the instruction/memory surface size guard. Hard-fails only on MEMORY.md at
+# the harness truncation limit or CLAUDE.md over its ceiling; soft budgets warn. Warns
+# rather than fails when the memory dir is absent, so a fresh clone is never blocked.
+s_memory() { ./scripts/check-memory-budget.sh; }
+
+# ADVISORY (#77): 93 of 142 files would be reformatted as at 2026-08-22.
+s_black() { $PYRUN black --check .; }
+
+# ADVISORY (#78): 597 errors as at 2026-08-22.
+s_ruff() { $PYRUN ruff check .; }
+
+# ADVISORY (#79): 293 errors in 50 files as at 2026-08-22.
+s_mypy() { $PYRUN mypy src/rdf_construct; }
+
+# --- run --------------------------------------------------------------------
+
+if [[ $RUN_TESTS -eq 1 ]]; then
+  step gate "test suite (pytest)" s_pytest
+fi
+if [[ $RUN_OTHER -eq 1 ]]; then
+  step gate     "memory-budget guard"  s_memory
+  step advisory "black formatting"     s_black
+  step advisory "ruff lint"            s_ruff
+  step advisory "mypy type-check"      s_mypy
+fi
+
+# --- summary ----------------------------------------------------------------
+
+printf '\n\033[1m── summary ─────────────────────────────\033[0m\n'
+if (( ${#ADVISORY_FAILED[@]} )); then
+  printf '  advisory issues (not gating): %s\n' "${ADVISORY_FAILED[*]}"
+fi
+if (( ${#GATE_FAILED[@]} )); then
+  printf '  \033[31mGATE FAILED: %s\033[0m\n' "${GATE_FAILED[*]}"
+  exit 1
+fi
+printf '  \033[32mgate green\033[0m%s\n' "$( (( ${#ADVISORY_FAILED[@]} )) && echo ' (with advisory warnings above)')"

--- a/scripts/ci-local.sh
+++ b/scripts/ci-local.sh
@@ -10,8 +10,8 @@
 #
 # GATE vs ADVISORY
 #
-#   GATE     — the test suite and the instruction/memory size guard. A gate step's
-#              failure IS this script's exit code.
+#   GATE     — the test suite, the version-consistency check and the instruction/memory
+#              size guard. A gate step's failure IS this script's exit code.
 #   ADVISORY — black, ruff and mypy. They run and report but do NOT fail the script,
 #              because each carries substantial pre-existing debt measured across the
 #              whole repository (see the tracking issues below). Gating on them today
@@ -49,6 +49,17 @@ case "${1-}" in
   *)            echo "unknown option: $1 (try --help)" >&2; exit 2 ;;
 esac
 
+# Preflight: fail once, clearly, if the Python runner is missing — rather than five
+# times with "command not found" as each step trips over it in turn.
+runner="${PYRUN%% *}"
+if [[ -n "$runner" ]] && ! command -v "$runner" >/dev/null 2>&1; then
+  echo "error: '$runner' is not on PATH." >&2
+  echo "       Install it (https://python-poetry.org/docs/#installation) and run" >&2
+  echo "       'poetry install --with dev', or set CI_LOCAL_PYRUN=\"\" if you are" >&2
+  echo "       already inside an activated virtualenv." >&2
+  exit 2
+fi
+
 GATE_FAILED=()
 ADVISORY_FAILED=()
 
@@ -82,6 +93,25 @@ s_pytest() { $PYRUN pytest -q; }
 # rather than fails when the memory dir is absent, so a fresh clone is never blocked.
 s_memory() { ./scripts/check-memory-budget.sh; }
 
+# GATE: the version string lives in two places and they must agree. A mismatch is not
+# caught by any test, and #66 records that `--version` reports the installed metadata
+# version rather than the source __version__ — so the symptom is a confusing --version
+# output at release time, not an error. Pure shell, so it works even without the runner.
+s_version() {
+  local pyproject init
+  pyproject="$(sed -n 's/^version = "\(.*\)"/\1/p' pyproject.toml | head -1)"
+  init="$(sed -n 's/^__version__ = "\(.*\)"/\1/p' src/rdf_construct/__init__.py | head -1)"
+  if [[ -z "$pyproject" || -z "$init" ]]; then
+    echo "could not read a version string (pyproject.toml='$pyproject' __init__.py='$init')"
+    return 1
+  fi
+  if [[ "$pyproject" != "$init" ]]; then
+    echo "version mismatch: pyproject.toml=$pyproject but __init__.py=$init"
+    return 1
+  fi
+  echo "version $pyproject (pyproject.toml and __init__.py agree)"
+}
+
 # ADVISORY (#77): 93 of 142 files would be reformatted as at 2026-08-22.
 s_black() { $PYRUN black --check .; }
 
@@ -97,6 +127,7 @@ if [[ $RUN_TESTS -eq 1 ]]; then
   step gate "test suite (pytest)" s_pytest
 fi
 if [[ $RUN_OTHER -eq 1 ]]; then
+  step gate     "version consistency"  s_version
   step gate     "memory-budget guard"  s_memory
   step advisory "black formatting"     s_black
   step advisory "ruff lint"            s_ruff


### PR DESCRIPTION
## Summary

Adds `scripts/ci-local.sh` — the pre-PR gate this project has been missing — and reconciles `.pre-commit-config.yaml` with what the tree can actually pass.

There is no hosted CI: `.github/workflows/` holds only `.gitkeep`, so nothing runs on push, on a PR, or on a tag, and `gh pr checks` reports nothing. For a package published to PyPI, "full test suite passes" in the release checklist had nothing behind it.

## Related Issues

Closes #74. Files #77, #78, #79 for the debt behind each advisory step.

## Changes

**`scripts/ci-local.sh`** — runs every check, reports them all, exits non-zero only if a *gate* step failed:

| Step | Severity | Measured on `main`, 2026-08-22 |
|---|---|---|
| `pytest` | **gate** | 532 passed, ~4 s, 61% coverage |
| memory-budget guard | **gate** | green |
| `black --check .` | advisory | 93 of 142 files would be reformatted (#77) |
| `ruff check .` | advisory | 597 errors (#78) |
| `mypy src/rdf_construct` | advisory | 293 errors in 50 files (#79) |

Gating on all five would fail on every run from day one, and a check that always fails is a check nobody reads. Each advisory step becomes a gate with a one-word change as its debt clears. Flags: `--tests-only`, `--lint-only`, `--help`, plus `CI_LOCAL_PYRUN` for use inside an activated venv.

**`.pre-commit-config.yaml`** — `black`, `ruff` and `mypy` removed:

- `black` and `ruff --fix` rewrote the whole of any file being committed, well beyond the change itself — a direct contradiction of the code-change discipline in `CLAUDE.md`.
- `mypy --strict` was worse than noisy: it *refused the commit* on any of the 50 files carrying pre-existing errors, so `pre-commit install` made much of the codebase uncommittable. The hooks were evidently not in use, which is why nobody had hit this.

What remains is hygiene that passes today. Verified across the whole tree: `check-yaml`, `check-toml`, `check-merge-conflict`, `check-added-large-files`, `debug-statements` and the memory guard all pass; `trailing-whitespace` and `end-of-file-fixer` rewrite only the file being committed (21 and 34 files of repo-wide debt, tracked in #77).

**`examples/uml/uml_layouts.yml`** — quoted the CURIEs in the three `together:` flow sequences. `check-yaml` failed on line 178: unquoted `building:Building` inside `[ … ]` is rejected by stricter YAML parsers than the one this project uses, so the example would not load for anyone with a spec-conformant toolchain. Parsed data verified byte-identical before and after.

**`CONTRIBUTING.md`** — `scripts/ci-local.sh` is now the single pre-PR ritual, with the gate/advisory table and an explicit "keep the files your change touches clean; you are not expected to fix the rest".

## Not in this PR, deliberately

**The repo-wide formatting sweep.** #74 recommended clearing the black debt in one mechanical commit and keeping the hook. Six PRs are currently open — #61, #62, #67, #68, #70, #71, four from outside contributors — and reformatting 93 files conflicts with every one of them, with #62 rewriting `docs/` heavily. Tracked in #77 for when the queue clears; it is a single command whenever that is.

## Testing

- `scripts/ci-local.sh` — gate green, three advisory failures reported as expected.
- `--tests-only`, `--lint-only`, `--help` and an unknown flag (exit 2) all exercised.
- Gate-failure path verified: `CI_LOCAL_PYRUN="false" scripts/ci-local.sh --tests-only` exits 1 and names the failing gate.
- `pre-commit run --all-files` with the new config: all read-only hooks pass; the tree-wide fixes the two rewriting hooks proposed were reverted, since they belong to #77.
- 532 tests pass.

## Breaking Changes

None. No `src/` code changes.
