### PR TITLE
chore: gitignore local scratch and session-prompt files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -208,3 +208,10 @@ cython_debug/
 marimo/_static/
 marimo/_lsp/
 __marimo__/
+
+# Local working files — never project content (#81)
+# Session handover prompts: written for a future session, deleted when that work completes.
+PROMPT-*.md
+# Local scratch script for generating the project tree, and its output.
+project_tree.py
+project-structure*.txt


### PR DESCRIPTION
## Summary

Adds three patterns to `.gitignore` so local working files cannot be committed by accident.

## Related Issues

Closes #81.

## Changes

One hunk at the end of `.gitignore`:

```
# Local working files — never project content (#81)
# Session handover prompts: written for a future session, deleted when that work completes.
PROMPT-*.md
# Local scratch script for generating the project tree, and its output.
project_tree.py
project-structure*.txt
```

Untracked is not the same as safe: a bare `git add .` stages all three, and the `PROMPT-*.md` case is the likeliest to be caught in a hurry, since those files appear and disappear during ordinary work.

**Deliberately not ignored:** `docs/assets/`, `src/ontology/` and the IES working files under `examples/`. Those are undecided rather than local — some may belong in the repo — and ignoring them would bury the decision instead of settling it. They stay visible in `git status`.

## Testing

- `git check-ignore -v` confirms all three patterns match the files currently in the tree.
- `git status` no longer lists any of them.
- `scripts/ci-local.sh` — gate green (pytest 532, version consistency, memory guard); the three known advisory failures unchanged.

## Breaking Changes

None.
