### PR TITLE
fix(order): stop dropping subjects no profile section claims

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,30 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+- `order` profiles accept an `unclaimed` policy, in `defaults:` or on an individual
+  profile, controlling what happens to subjects no section of the profile claims:
+  `warn` (default) reports the loss on stderr and exits 0, `emit` appends them in a
+  trailing section so nothing is lost, and `ignore` is silent — for a profile such as
+  `test_profile.yml`'s `compact` that filters on purpose. The warning names the terms
+  and the `select:` key that would have claimed them (#84)
+
 ### Fixed
+- `order` no longer emits an empty `[ ]` in place of a blank node that no section
+  claimed. `build_section_graph()` copies triples by subject, so an `owl:Restriction`
+  or an `owl:unionOf` list lost its own triples while the reference to it survived —
+  producing not a partial ontology but a different one, asserting an anonymous class
+  with no axioms. Blank nodes reachable from the selected subjects are now pulled in
+  transitively, whatever the `unclaimed` policy says: a blank node carries no identity
+  a profile could select it *by*, so it belongs to the description of whatever
+  references it (#84)
+- `order` no longer silently drops subjects that no profile section claims. Copying the
+  shipped `examples/order/sample_profile.yml` was enough to hit it: its `doc_order` and
+  `props_by_domain` profiles had no `annotation_properties` section, so
+  `animals:scientificName` and its three triples were absent from the output with no
+  warning and exit code 0. Both those profiles — and the matching pair in
+  `ies_profile.yml` — now have the missing section, and the default policy reports any
+  remaining gap (#84)
 - `order` no longer drops terms declared only as `rdf:Property`. They were excluded from the
   `individuals` selector while no other selector claimed them, so their triples were silently
   absent from the ordered output — 10 triples in, 8 out, with no warning

--- a/examples/order/ies_profile.yml
+++ b/examples/order/ies_profile.yml
@@ -92,6 +92,9 @@ profiles:
           group_order: explicit_then_alpha
           explicit_group_sequence: *domain_priority
           sort: qname_alpha
+      - annotation_properties:
+          select: ann_props
+          sort: qname_alpha
       - individuals:
           select: individuals
           sort: qname_alpha
@@ -116,6 +119,9 @@ profiles:
           after_anchors: topological_then_alpha
       - data_properties:
           select: data_props
+          sort: alpha
+      - annotation_properties:
+          select: ann_props
           sort: alpha
       - individuals:
           select: individuals

--- a/examples/order/sample_profile.yml
+++ b/examples/order/sample_profile.yml
@@ -4,6 +4,9 @@ defaults:
   comment_blocks: true         # allow emitting # section dividers
   preserve_prefix_order: true  # enforce a declared prefix sequence
   bnode_strategy: skolem       # or "stable"
+  unclaimed: warn              # subjects no section claims: warn | emit | ignore.
+                               # Override per profile — set "ignore" on one that
+                               # filters deliberately, "emit" to never lose a triple.
 
 prefix_order:
   - rdf
@@ -133,6 +136,9 @@ profiles:
           group_order: explicit_then_alpha
           explicit_group_sequence: *domain_priority
           sort: qname_alpha
+      - annotation_properties:
+          select: ann_props
+          sort: qname_alpha
       - individuals:
           select: individuals
           sort: qname_alpha
@@ -157,6 +163,9 @@ profiles:
           after_anchors: topological_then_alpha
       - data_properties:
           select: data_props
+          sort: alpha
+      - annotation_properties:
+          select: ann_props
           sort: alpha
       - individuals:
           select: individuals

--- a/examples/order/test_profile.yml
+++ b/examples/order/test_profile.yml
@@ -159,6 +159,7 @@ profiles:
   # ============================================
   compact:
     description: "Just header and classes - useful for quick inspection"
+    unclaimed: ignore              # this profile filters on purpose; do not warn
     sections:
       - header: {}
       - classes:

--- a/src/rdf_construct/cli.py
+++ b/src/rdf_construct/cli.py
@@ -4,11 +4,13 @@ import sys
 from pathlib import Path
 
 import click
-from rdflib import Graph, RDF, URIRef
+from rdflib import BNode, Graph, RDF, URIRef
 from rdflib.namespace import OWL
+from rdflib.term import Node
 
 from rdf_construct.core import (
     OrderingConfig,
+    bnode_closure,
     build_section_graph,
     extract_prefix_map,
     rebind_prefixes,
@@ -273,6 +275,137 @@ def cast(
         raise SystemExit(2)
 
 
+# Selector keys understood by select_subjects(), most specific first, used to tell a
+# user which section they are missing. Keys defined in the config are appended to
+# these, so a profile with custom selector names still gets a usable suggestion.
+_SELECTOR_KEYS = (
+    "classes",
+    "obj_props",
+    "data_props",
+    "ann_props",
+    "other_props",
+    "individuals",
+)
+
+# How many unclaimed subjects to name before summarising the rest.
+_UNCLAIMED_SHOWN = 3
+
+
+def _term_label(graph: Graph, term: Node) -> str:
+    """Render a term as a QName using only the bindings the graph already has.
+
+    ``namespace_manager.qname()`` invents and binds prefixes for unknown
+    namespaces, which would alter the prefixes of the file being ordered.
+    This is read-only: it falls back to the full URI in angle brackets.
+
+    Args:
+        graph: RDF graph whose namespace bindings to use
+        term: RDF term to render
+
+    Returns:
+        QName string, or the bracketed URI when no prefix matches
+    """
+    if isinstance(term, URIRef):
+        best_prefix, best_uri = "", ""
+        for prefix, uri in graph.namespace_manager.namespaces():
+            if prefix and str(term).startswith(str(uri)) and len(str(uri)) > len(best_uri):
+                best_prefix, best_uri = prefix, str(uri)
+        if best_prefix:
+            return f"{best_prefix}:{str(term)[len(best_uri):]}"
+    return f"<{term}>"
+
+
+def _selector_hints(
+    graph: Graph, unclaimed: list[Node], selectors: dict[str, str]
+) -> dict[Node, str]:
+    """Map each unclaimed subject to the selector key that would have claimed it.
+
+    Args:
+        graph: RDF graph being ordered
+        unclaimed: Subjects no section of the profile claimed
+        selectors: Selector definitions from the ordering config
+
+    Returns:
+        Dictionary of subject to selector key, omitting subjects no selector claims
+    """
+    keys = list(_SELECTOR_KEYS) + [k for k in selectors if k not in _SELECTOR_KEYS]
+    remaining = set(unclaimed)
+    hints: dict[Node, str] = {}
+
+    for key in keys:
+        if not remaining:
+            break
+        claimed = select_subjects(graph, key, selectors)
+        for subject in list(remaining):
+            if subject in claimed:
+                hints[subject] = key
+                remaining.discard(subject)
+
+    return hints
+
+
+def _warn_unclaimed(
+    graph: Graph, unclaimed: list[Node], prof_name: str, selectors: dict[str, str]
+) -> None:
+    """Report subjects that no section of a profile claimed.
+
+    Names the terms and the section that would have claimed them: a bare count
+    tells the user something is wrong but not what to do about it.
+
+    Args:
+        graph: RDF graph being ordered
+        unclaimed: Subjects no section claimed, in output order
+        prof_name: Profile the loss occurred in
+        selectors: Selector definitions from the ordering config
+    """
+    named = [s for s in unclaimed if not isinstance(s, BNode)]
+    anonymous = len(unclaimed) - len(named)
+    dropped = sum(1 for s, _, _ in graph if s in set(unclaimed))
+
+    subject_word = "subject" if len(unclaimed) == 1 else "subjects"
+    triple_word = "triple" if dropped == 1 else "triples"
+    click.secho(
+        f"  ⚠ profile '{prof_name}': {len(unclaimed)} {subject_word} claimed by no "
+        f"section — {dropped} {triple_word} dropped.",
+        fg="yellow",
+        err=True,
+    )
+
+    hints = _selector_hints(graph, named, selectors)
+    for subject in named[:_UNCLAIMED_SHOWN]:
+        types = sorted(_term_label(graph, t) for t in graph.objects(subject, RDF.type))
+        type_str = f"  ({', '.join(types)})" if types else ""
+        click.secho(f"      {_term_label(graph, subject)}{type_str}", fg="yellow", err=True)
+
+    if len(named) > _UNCLAIMED_SHOWN:
+        click.secho(f"      … and {len(named) - _UNCLAIMED_SHOWN} more", fg="yellow", err=True)
+    if anonymous:
+        node_word = "node" if anonymous == 1 else "nodes"
+        click.secho(
+            f"      + {anonymous} anonymous {node_word} reachable from nothing claimed",
+            fg="yellow",
+            err=True,
+        )
+
+    wanted = sorted(set(hints.values()))
+    if wanted:
+        selects = ", ".join(f"`select: {key}`" for key in wanted)
+        click.secho(f"    add a section with {selects},", fg="yellow", err=True)
+        click.secho(
+            "    or set `unclaimed: emit` to keep them, or `unclaimed: ignore` if this "
+            "profile filters deliberately.",
+            fg="yellow",
+            err=True,
+        )
+    else:
+        click.secho(
+            "    set `unclaimed: emit` to keep them, or `unclaimed: ignore` if this "
+            "profile filters deliberately.",
+            fg="yellow",
+            err=True,
+        )
+
+
 @cli.command()
 @click.argument("source", type=click.Path(exists=True, path_type=Path))
 @click.argument("config", type=click.Path(exists=True, path_type=Path))
@@ -325,6 +458,17 @@ def order(source: Path, config: Path, profile: tuple[str, ...], outdir: Path):
             click.echo(f"Available profiles: {available}", err=True)
             raise click.Abort()
 
+    # Resolve the unclaimed-subject policies before writing anything: a typo in one
+    # profile should not surface only after the earlier profiles have been written.
+    try:
+        unclaimed_policies = {
+            prof_name: ordering_config.get_unclaimed_policy(prof_name)
+            for prof_name in profiles_to_gen
+        }
+    except ValueError as exc:
+        click.secho(f"Error: {exc}", fg="red", err=True)
+        raise click.Abort() from exc
+
     # Create output directory
     outdir.mkdir(parents=True, exist_ok=True)
 
@@ -375,6 +519,30 @@ def order(source: Path, config: Path, profile: tuple[str, ...], outdir: Path):
                 if s not in seen:
                     ordered_subjects.append(s)
                     seen.add(s)
+
+        # Blank nodes carry no identity a section could select them by — they belong
+        # to the description of whatever references them. Pull in the ones reachable
+        # from the selected subjects whatever the policy says, so a restriction cannot
+        # collapse to an empty "[ ]" and assert something the source never did.
+        for s in bnode_closure(graph, ordered_subjects):
+            ordered_subjects.append(s)
+            seen.add(s)
+
+        # Handle the named subjects no section claimed
+        unclaimed = [s for s in {s for (s, _, _) in graph} if s not in seen]
+        if unclaimed:
+            policy = unclaimed_policies[prof_name]
+            if policy == "emit":
+                for s in sort_subjects(graph, set(unclaimed), "qname_alpha"):
+                    ordered_subjects.append(s)
+                    seen.add(s)
+            elif policy == "warn":
+                _warn_unclaimed(
+                    graph,
+                    sort_subjects(graph, set(unclaimed), "qname_alpha"),
+                    prof_name,
+                    ordering_config.selectors,
+                )
 
         # Build output graph
         out_graph = build_section_graph(graph, ordered_subjects)

--- a/src/rdf_construct/core/__init__.py
+++ b/src/rdf_construct/core/__init__.py
@@ -1,7 +1,13 @@
 """Core RDF ordering and serialization functionality."""
 
 from .ordering import sort_subjects, topo_sort_subset, sort_with_roots
-from .profile import OrderingConfig, OrderingProfile, load_yaml
+from .profile import (
+    DEFAULT_UNCLAIMED_POLICY,
+    UNCLAIMED_POLICIES,
+    OrderingConfig,
+    OrderingProfile,
+    load_yaml,
+)
 from .selector import select_subjects
 from .vocab import (
     ALL_PROPERTY_TYPES,
@@ -12,7 +18,12 @@ from .vocab import (
     KIND_SPECIFIC_PROPERTY_TYPES,
     OBJECT_PROPERTY_TYPES,
 )
-from .serialiser import collect_used_namespaces, serialise_turtle, build_section_graph
+from .serialiser import (
+    bnode_closure,
+    collect_used_namespaces,
+    serialise_turtle,
+    build_section_graph,
+)
 from .utils import (
     expand_curie,
     extract_prefix_map,
@@ -40,6 +51,8 @@ __all__ = [
     "OrderingConfig",
     "OrderingProfile",
     "load_yaml",
+    "UNCLAIMED_POLICIES",
+    "DEFAULT_UNCLAIMED_POLICY",
     # Selector
     "select_subjects",
     # Vocabulary
@@ -51,6 +64,7 @@ __all__ = [
     "KIND_SPECIFIC_PROPERTY_TYPES",
     "OBJECT_PROPERTY_TYPES",
     # Serialiser
+    "bnode_closure",
     "collect_used_namespaces",
     "serialise_turtle",
     "build_section_graph",

--- a/src/rdf_construct/core/profile.py
+++ b/src/rdf_construct/core/profile.py
@@ -7,6 +7,16 @@ import yaml
 
 from .predicate_order import PredicateOrderConfig
 
+#: Policies for subjects that no section of a profile claims.
+#:
+#: - ``warn``   — emit only what the sections claimed, and report the loss (default)
+#: - ``emit``   — append the unclaimed subjects in a trailing section, losing nothing
+#: - ``ignore`` — emit only what the sections claimed, silently; for a profile that
+#:   filters deliberately
+UNCLAIMED_POLICIES = ("warn", "emit", "ignore")
+
+DEFAULT_UNCLAIMED_POLICY = "warn"
+
 
 class OrderingProfile:
     """Represents an ordering profile from a YAML configuration.
@@ -20,6 +30,8 @@ class OrderingProfile:
         description: Human-readable description
         sections: List of section configurations
         predicate_order: Optional predicate ordering configuration
+        unclaimed: Policy for subjects no section claims, or None to inherit
+            the config-level default
     """
 
     def __init__(self, name: str, config: dict[str, Any]):
@@ -32,6 +44,7 @@ class OrderingProfile:
         self.name = name
         self.description = config.get("description", "")
         self.sections = config.get("sections", [])
+        self.unclaimed = config.get("unclaimed")
         self.predicate_order = PredicateOrderConfig.from_dict(
             config.get("predicate_order")
         )
@@ -131,6 +144,36 @@ class OrderingConfig:
             return self.predicate_order
 
         return None
+
+    def get_unclaimed_policy(self, profile_name: str) -> str:
+        """Get the effective policy for subjects no section of a profile claims.
+
+        Profile-level ``unclaimed`` takes precedence over ``defaults.unclaimed``,
+        which in turn takes precedence over the built-in default (``warn``).
+
+        Args:
+            profile_name: Profile identifier
+
+        Returns:
+            One of :data:`UNCLAIMED_POLICIES`
+
+        Raises:
+            KeyError: If profile name not found
+            ValueError: If the configured policy is not a recognised value
+        """
+        profile = self.get_profile(profile_name)
+
+        policy = profile.unclaimed
+        if policy is None:
+            policy = self.defaults.get("unclaimed", DEFAULT_UNCLAIMED_POLICY)
+
+        if policy not in UNCLAIMED_POLICIES:
+            raise ValueError(
+                f"Unknown 'unclaimed' policy {policy!r} in profile '{profile_name}'. "
+                f"Expected one of: {', '.join(UNCLAIMED_POLICIES)}"
+            )
+
+        return str(policy)
 
     def list_profiles(self) -> list[str]:
         """Get list of available profile names.

--- a/src/rdf_construct/core/serialiser.py
+++ b/src/rdf_construct/core/serialiser.py
@@ -9,6 +9,7 @@ from pathlib import Path
 
 from rdflib import BNode, Graph, URIRef, Literal, RDF
 from rdflib.namespace import RDFS, OWL, XSD
+from rdflib.term import Node
 
 try:
     from .predicate_order import (
@@ -402,6 +403,43 @@ def _order_subject_predicates(
         sorted_preds.append((pred, pred_dict[pred]))
 
     return sorted_preds
+
+
+def bnode_closure(base: Graph, subjects: list[Node]) -> list[Node]:
+    """Collect the blank nodes reachable as objects from a set of subjects.
+
+    ``build_section_graph()`` copies triples by subject, so a blank node that
+    no section selected loses its own triples while the reference to it
+    survives in the selected subject — the description collapses to an empty
+    ``[ ]``, which is not a partial ontology but a different one (an anonymous
+    class with no axioms, an ``owl:unionOf`` pointing at a non-list).
+
+    A blank node has no identity a profile could select it *by*: it belongs to
+    the description of whatever references it. This walks object positions
+    transitively — blank nodes nest, both through ``rdf:rest`` chains and
+    through structures such as a quantity inside a measurement — and returns
+    the ones not already present.
+
+    Args:
+        base: Source RDF graph to walk.
+        subjects: Subjects already selected for output.
+
+    Returns:
+        Reachable blank nodes not already in *subjects*, in discovery order.
+    """
+    known: set[Node] = set(subjects)
+    discovered: list[Node] = []
+    queue: list[Node] = list(subjects)
+
+    while queue:
+        subject = queue.pop(0)
+        for obj in base.objects(subject, None):
+            if isinstance(obj, BNode) and obj not in known:
+                known.add(obj)
+                discovered.append(obj)
+                queue.append(obj)
+
+    return discovered
 
 
 def build_section_graph(base: Graph, subjects_ordered: list) -> Graph:

--- a/tests/test_unclaimed_subjects.py
+++ b/tests/test_unclaimed_subjects.py
@@ -1,0 +1,583 @@
+"""Tests for subjects that no section of an ordering profile claims.
+
+`order` built its output graph from the subjects the profile's sections
+selected, so anything no section claimed was discarded with no warning and
+exit code 0 — reachable through the shipped example configs. Two distinct
+failures live here:
+
+- Blank nodes lost their triples while the reference to them survived, so an
+  ``owl:Restriction`` collapsed to an empty ``[ ]`` — not a partial ontology
+  but a different one. That is repaired unconditionally.
+- Named subjects are governed by the ``unclaimed`` policy: ``warn`` (default),
+  ``emit`` or ``ignore``.
+
+Relates to: #84
+"""
+
+from pathlib import Path
+from textwrap import dedent
+
+import pytest
+from click.testing import CliRunner
+from rdflib import RDF, BNode, Graph, Literal, Namespace
+from rdflib.namespace import OWL, RDFS
+
+from rdf_construct.cli import cli
+from rdf_construct.core import OrderingConfig, bnode_closure
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+EXAMPLES = REPO_ROOT / "examples"
+
+EX = Namespace("http://example.org/")
+
+
+# -- Fixtures --
+
+
+@pytest.fixture
+def restriction_ontology(tmp_path: Path) -> Path:
+    """Ontology whose classes carry blank-node axioms.
+
+    Covers both bnode shapes that matter: a single ``owl:Restriction`` hanging
+    off ``rdfs:subClassOf``, and an ``owl:unionOf`` collection, which rdflib
+    represents as a chain of blank nodes and so exercises transitivity.
+    """
+    content = dedent(
+        """
+        @prefix owl: <http://www.w3.org/2002/07/owl#> .
+        @prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
+        @prefix ex: <http://example.org/> .
+
+        <http://example.org/> a owl:Ontology .
+
+        ex:Dog a owl:Class ;
+            rdfs:label "Dog" ;
+            rdfs:subClassOf ex:Animal ,
+                [ a owl:Restriction ;
+                  owl:onProperty ex:hasOwner ;
+                  owl:someValuesFrom ex:Person ] .
+
+        ex:Animal a owl:Class .
+        ex:Person a owl:Class .
+
+        ex:Union a owl:Class ;
+            owl:unionOf ( ex:Dog ex:Person ) .
+
+        ex:hasOwner a owl:ObjectProperty .
+
+        ex:note a owl:AnnotationProperty ;
+            rdfs:label "note" .
+        """
+    ).strip()
+
+    path = tmp_path / "restrictions.ttl"
+    path.write_text(content, encoding="utf-8")
+    return path
+
+
+@pytest.fixture
+def classes_only_config(tmp_path: Path) -> Path:
+    """Config whose single profile claims classes and nothing else."""
+    content = dedent(
+        """
+        selectors:
+          classes: "rdf:type owl:Class"
+        profiles:
+          classes_only:
+            description: "Classes and nothing else"
+            sections:
+              - header: {}
+              - classes:
+                  select: classes
+                  sort: alpha
+        """
+    ).strip()
+
+    path = tmp_path / "classes_only.yml"
+    path.write_text(content, encoding="utf-8")
+    return path
+
+
+@pytest.fixture
+def policy_config(tmp_path: Path) -> Path:
+    """Config exercising each ``unclaimed`` policy and its inheritance."""
+    content = dedent(
+        """
+        defaults:
+          unclaimed: emit
+        selectors:
+          classes: "rdf:type owl:Class"
+        profiles:
+          inherits_emit:
+            sections:
+              - header: {}
+              - classes: {select: classes, sort: alpha}
+          overrides_ignore:
+            unclaimed: ignore
+            sections:
+              - header: {}
+              - classes: {select: classes, sort: alpha}
+          overrides_warn:
+            unclaimed: warn
+            sections:
+              - header: {}
+              - classes: {select: classes, sort: alpha}
+        """
+    ).strip()
+
+    path = tmp_path / "policies.yml"
+    path.write_text(content, encoding="utf-8")
+    return path
+
+
+def _order(source: Path, config: Path, outdir: Path, *args: str):
+    """Run the order command through Click's test runner."""
+    runner = CliRunner()
+    return runner.invoke(cli, ["order", str(source), str(config), "-o", str(outdir), *args])
+
+
+# -- The shipped examples must not demonstrate the bug --
+
+
+class TestShippedExamplesRoundTrip:
+    """The bug was reachable by copying a shipped config; it must not be.
+
+    A new user is invited to copy `examples/order/sample_profile.yml`, and its
+    `doc_order` and `props_by_domain` profiles had no `annotation_properties`
+    section — so `animals:scientificName` and its three triples vanished.
+    """
+
+    @pytest.mark.parametrize("config_name", ["sample_profile.yml", "ies_profile.yml"])
+    @pytest.mark.parametrize("source_name", ["animal_ontology.ttl", "organisation_ontology.ttl"])
+    def test_every_profile_preserves_every_triple(
+        self, tmp_path: Path, config_name: str, source_name: str
+    ) -> None:
+        source = EXAMPLES / source_name
+        config = EXAMPLES / "order" / config_name
+        assert source.exists() and config.exists()
+
+        result = _order(source, config, tmp_path)
+        assert result.exit_code == 0
+
+        base = Graph()
+        base.parse(source)
+
+        profiles = OrderingConfig(config).list_profiles()
+        assert profiles
+
+        for profile in profiles:
+            out = tmp_path / f"{source.stem}-{profile}.ttl"
+            ordered = Graph()
+            ordered.parse(out)
+            assert ordered.isomorphic(base), (
+                f"{config_name} profile '{profile}' lost "
+                f"{len(base) - len(ordered)} triple(s) of {source_name}"
+            )
+
+    def test_shipped_configs_emit_no_warning(self, tmp_path: Path) -> None:
+        """A config that warns on its own example ontology is documentation of a bug."""
+        result = _order(
+            EXAMPLES / "animal_ontology.ttl",
+            EXAMPLES / "order" / "sample_profile.yml",
+            tmp_path,
+        )
+        assert result.exit_code == 0
+        assert "claimed by no section" not in result.output
+
+    def test_compact_filters_deliberately_and_silently(self, tmp_path: Path) -> None:
+        """`compact` is header-and-classes by design and declares `unclaimed: ignore`."""
+        source = EXAMPLES / "animal_ontology.ttl"
+        result = _order(source, EXAMPLES / "order" / "test_profile.yml", tmp_path, "-p", "compact")
+        assert result.exit_code == 0
+        assert "claimed by no section" not in result.output
+
+        base = Graph()
+        base.parse(source)
+        ordered = Graph()
+        ordered.parse(tmp_path / f"{source.stem}-compact.ttl")
+        assert len(ordered) < len(base)
+
+
+# -- Blank-node closure --
+
+
+class TestBnodeClosure:
+    """Tests for the bnode_closure helper."""
+
+    def test_finds_directly_referenced_bnode(self) -> None:
+        g = Graph()
+        node = BNode()
+        g.add((EX.Dog, RDFS.subClassOf, node))
+        g.add((node, RDF.type, OWL.Restriction))
+
+        assert bnode_closure(g, [EX.Dog]) == [node]
+
+    def test_walks_nested_bnodes_transitively(self) -> None:
+        g = Graph()
+        outer, inner = BNode(), BNode()
+        g.add((EX.Thing, EX.hasQuantity, outer))
+        g.add((outer, EX.hasValue, inner))
+        g.add((inner, RDF.value, Literal(3)))
+
+        assert set(bnode_closure(g, [EX.Thing])) == {outer, inner}
+
+    def test_ignores_bnodes_already_present(self) -> None:
+        g = Graph()
+        node = BNode()
+        g.add((EX.Dog, RDFS.subClassOf, node))
+        g.add((node, RDF.type, OWL.Restriction))
+
+        assert bnode_closure(g, [EX.Dog, node]) == []
+
+    def test_ignores_unreachable_bnodes(self) -> None:
+        g = Graph()
+        orphan = BNode()
+        g.add((EX.Dog, RDF.type, OWL.Class))
+        g.add((orphan, RDF.type, OWL.Restriction))
+
+        assert bnode_closure(g, [EX.Dog]) == []
+
+    def test_terminates_on_a_bnode_cycle(self) -> None:
+        g = Graph()
+        first, second = BNode(), BNode()
+        g.add((EX.Thing, EX.points, first))
+        g.add((first, EX.points, second))
+        g.add((second, EX.points, first))
+
+        assert set(bnode_closure(g, [EX.Thing])) == {first, second}
+
+    def test_does_not_follow_named_subjects(self) -> None:
+        """Closure repairs anonymous descriptions; it does not pull in whole graphs."""
+        g = Graph()
+        node = BNode()
+        g.add((EX.Dog, RDFS.subClassOf, EX.Animal))
+        g.add((EX.Animal, RDFS.subClassOf, node))
+        g.add((node, RDF.type, OWL.Restriction))
+
+        assert bnode_closure(g, [EX.Dog]) == []
+
+
+class TestBnodesSurviveUnclaimed:
+    """A blank node no section claimed must not collapse to an empty `[ ]`."""
+
+    def test_restriction_is_emitted_in_full(
+        self, restriction_ontology: Path, classes_only_config: Path, tmp_path: Path
+    ) -> None:
+        outdir = tmp_path / "out"
+        result = _order(restriction_ontology, classes_only_config, outdir)
+        assert result.exit_code == 0
+
+        ordered = Graph()
+        ordered.parse(outdir / "restrictions-classes_only.ttl")
+
+        restrictions = list(ordered.subjects(RDF.type, OWL.Restriction))
+        assert len(restrictions) == 1
+        assert (restrictions[0], OWL.onProperty, EX.hasOwner) in ordered
+        assert (restrictions[0], OWL.someValuesFrom, EX.Person) in ordered
+
+    def test_collection_members_survive(
+        self, restriction_ontology: Path, classes_only_config: Path, tmp_path: Path
+    ) -> None:
+        outdir = tmp_path / "out"
+        assert _order(restriction_ontology, classes_only_config, outdir).exit_code == 0
+
+        ordered = Graph()
+        ordered.parse(outdir / "restrictions-classes_only.ttl")
+
+        union = next(ordered.objects(EX.Union, OWL.unionOf))
+        members = list(ordered.items(union))
+        assert members == [EX.Dog, EX.Person]
+
+    def test_no_empty_brackets_in_output(
+        self, restriction_ontology: Path, classes_only_config: Path, tmp_path: Path
+    ) -> None:
+        """The visible symptom: `rdfs:subClassOf [ ]` and `owl:unionOf [ ]`."""
+        outdir = tmp_path / "out"
+        assert _order(restriction_ontology, classes_only_config, outdir).exit_code == 0
+
+        text = (outdir / "restrictions-classes_only.ttl").read_text(encoding="utf-8")
+        assert "[\n        ]" not in text
+        assert "[\n    ]" not in text
+
+    def test_bnodes_are_not_reported_as_unclaimed(
+        self, restriction_ontology: Path, classes_only_config: Path, tmp_path: Path
+    ) -> None:
+        """Only named subjects are counted: a bnode identifier tells the user nothing."""
+        result = _order(restriction_ontology, classes_only_config, tmp_path / "out")
+        assert result.exit_code == 0
+        # ex:hasOwner and ex:note are unclaimed; the three blank nodes are not.
+        assert "2 subjects claimed by no section" in result.output
+
+
+# -- The unclaimed policy --
+
+
+class TestUnclaimedPolicyResolution:
+    """Tests for OrderingConfig.get_unclaimed_policy."""
+
+    def test_defaults_to_warn(self, classes_only_config: Path) -> None:
+        config = OrderingConfig(classes_only_config)
+        assert config.get_unclaimed_policy("classes_only") == "warn"
+
+    def test_inherits_config_level_default(self, policy_config: Path) -> None:
+        config = OrderingConfig(policy_config)
+        assert config.get_unclaimed_policy("inherits_emit") == "emit"
+
+    def test_profile_overrides_config_level(self, policy_config: Path) -> None:
+        config = OrderingConfig(policy_config)
+        assert config.get_unclaimed_policy("overrides_ignore") == "ignore"
+        assert config.get_unclaimed_policy("overrides_warn") == "warn"
+
+    def test_rejects_an_unknown_policy(self, tmp_path: Path) -> None:
+        path = tmp_path / "bad.yml"
+        path.write_text(
+            dedent(
+                """
+                profiles:
+                  bogus:
+                    unclaimed: yes-please
+                    sections:
+                      - header: {}
+                """
+            ).strip(),
+            encoding="utf-8",
+        )
+
+        with pytest.raises(ValueError, match="warn, emit, ignore"):
+            OrderingConfig(path).get_unclaimed_policy("bogus")
+
+
+class TestUnclaimedPolicyBehaviour:
+    """End-to-end behaviour of each policy through the CLI."""
+
+    def test_warn_names_the_term_and_the_missing_section(
+        self, restriction_ontology: Path, classes_only_config: Path, tmp_path: Path
+    ) -> None:
+        """A bare count tells the user something is wrong but not what to do."""
+        result = _order(restriction_ontology, classes_only_config, tmp_path / "out")
+
+        assert result.exit_code == 0
+        assert "profile 'classes_only'" in result.output
+        assert "3 triples dropped" in result.output
+        assert "ex:note" in result.output
+        assert "owl:AnnotationProperty" in result.output
+        assert "`select: ann_props`" in result.output
+        assert "`select: obj_props`" in result.output
+
+    def test_warn_does_not_change_the_output(
+        self, restriction_ontology: Path, classes_only_config: Path, tmp_path: Path
+    ) -> None:
+        outdir = tmp_path / "out"
+        assert _order(restriction_ontology, classes_only_config, outdir).exit_code == 0
+
+        ordered = Graph()
+        ordered.parse(outdir / "restrictions-classes_only.ttl")
+        assert (EX.note, RDF.type, OWL.AnnotationProperty) not in ordered
+
+    def test_emit_loses_nothing(
+        self, restriction_ontology: Path, policy_config: Path, tmp_path: Path
+    ) -> None:
+        outdir = tmp_path / "out"
+        result = _order(restriction_ontology, policy_config, outdir, "-p", "inherits_emit")
+        assert result.exit_code == 0
+
+        base = Graph()
+        base.parse(restriction_ontology)
+        ordered = Graph()
+        ordered.parse(outdir / "restrictions-inherits_emit.ttl")
+        assert ordered.isomorphic(base)
+
+    def test_ignore_is_silent(
+        self, restriction_ontology: Path, policy_config: Path, tmp_path: Path
+    ) -> None:
+        result = _order(
+            restriction_ontology, policy_config, tmp_path / "out", "-p", "overrides_ignore"
+        )
+        assert result.exit_code == 0
+        assert "claimed by no section" not in result.output
+
+    def test_warn_exits_zero(
+        self, restriction_ontology: Path, policy_config: Path, tmp_path: Path
+    ) -> None:
+        """Warnings that change the exit code break the scripts that call this."""
+        result = _order(
+            restriction_ontology, policy_config, tmp_path / "out", "-p", "overrides_warn"
+        )
+        assert result.exit_code == 0
+        assert "claimed by no section" in result.output
+
+    def test_unknown_policy_aborts_before_writing_anything(
+        self, restriction_ontology: Path, tmp_path: Path
+    ) -> None:
+        """A typo in the last profile must not surface after the first is written."""
+        config = tmp_path / "mixed.yml"
+        config.write_text(
+            dedent(
+                """
+                selectors:
+                  classes: "rdf:type owl:Class"
+                profiles:
+                  good:
+                    sections:
+                      - header: {}
+                      - classes: {select: classes, sort: alpha}
+                  bad:
+                    unclaimed: sure
+                    sections:
+                      - header: {}
+                """
+            ).strip(),
+            encoding="utf-8",
+        )
+
+        outdir = tmp_path / "out"
+        result = _order(restriction_ontology, config, outdir)
+
+        assert result.exit_code != 0
+        assert "Unknown 'unclaimed' policy" in result.output
+        assert list(outdir.glob("*.ttl")) == []
+
+
+class TestUnclaimedReporting:
+    """The message has to be actionable, and it has to scale."""
+
+    def test_lists_at_most_three_then_summarises(self, tmp_path: Path) -> None:
+        lines = [
+            "@prefix owl: <http://www.w3.org/2002/07/owl#> .",
+            "@prefix ex: <http://example.org/> .",
+            "",
+            "ex:Kept a owl:Class .",
+        ]
+        lines += [f"ex:prop{i} a owl:AnnotationProperty ." for i in range(5)]
+        source = tmp_path / "many.ttl"
+        source.write_text("\n".join(lines), encoding="utf-8")
+
+        config = tmp_path / "classes.yml"
+        config.write_text(
+            dedent(
+                """
+                selectors:
+                  classes: "rdf:type owl:Class"
+                profiles:
+                  classes_only:
+                    sections:
+                      - classes: {select: classes, sort: alpha}
+                """
+            ).strip(),
+            encoding="utf-8",
+        )
+
+        result = _order(source, config, tmp_path / "out")
+
+        assert result.exit_code == 0
+        assert "5 subjects claimed by no section" in result.output
+        assert "… and 2 more" in result.output
+
+    def test_uses_singular_wording_for_one_subject(self, tmp_path: Path) -> None:
+        source = tmp_path / "one.ttl"
+        source.write_text(
+            dedent(
+                """
+                @prefix owl: <http://www.w3.org/2002/07/owl#> .
+                @prefix ex: <http://example.org/> .
+
+                ex:Kept a owl:Class .
+                ex:lost a owl:AnnotationProperty .
+                """
+            ).strip(),
+            encoding="utf-8",
+        )
+
+        config = tmp_path / "classes.yml"
+        config.write_text(
+            dedent(
+                """
+                selectors:
+                  classes: "rdf:type owl:Class"
+                profiles:
+                  classes_only:
+                    sections:
+                      - classes: {select: classes, sort: alpha}
+                """
+            ).strip(),
+            encoding="utf-8",
+        )
+
+        result = _order(source, config, tmp_path / "out")
+
+        assert result.exit_code == 0
+        assert "1 subject claimed by no section" in result.output
+        assert "1 triple dropped" in result.output
+
+    def test_reports_a_term_with_no_matching_selector(self, tmp_path: Path) -> None:
+        """An unclaimed term nothing can claim still gets the policy advice."""
+        source = tmp_path / "odd.ttl"
+        source.write_text(
+            dedent(
+                """
+                @prefix owl: <http://www.w3.org/2002/07/owl#> .
+                @prefix ex: <http://example.org/> .
+
+                ex:Kept a owl:Class .
+                ex:thing a ex:Widget .
+                """
+            ).strip(),
+            encoding="utf-8",
+        )
+
+        config = tmp_path / "no_individuals.yml"
+        config.write_text(
+            dedent(
+                """
+                selectors:
+                  classes: "rdf:type owl:Class"
+                profiles:
+                  classes_only:
+                    sections:
+                      - classes: {select: classes, sort: alpha}
+                """
+            ).strip(),
+            encoding="utf-8",
+        )
+
+        result = _order(source, config, tmp_path / "out")
+
+        assert result.exit_code == 0
+        assert "ex:thing" in result.output
+        assert "`unclaimed: ignore`" in result.output
+
+    def test_unprefixed_uri_is_reported_in_full(self, tmp_path: Path) -> None:
+        """No prefix is invented for the report — that would alter the output file."""
+        source = tmp_path / "nopfx.ttl"
+        source.write_text(
+            dedent(
+                """
+                @prefix owl: <http://www.w3.org/2002/07/owl#> .
+                @prefix ex: <http://example.org/> .
+
+                ex:Kept a owl:Class .
+                <http://elsewhere.invalid/lost> a owl:AnnotationProperty .
+                """
+            ).strip(),
+            encoding="utf-8",
+        )
+
+        config = tmp_path / "classes.yml"
+        config.write_text(
+            dedent(
+                """
+                selectors:
+                  classes: "rdf:type owl:Class"
+                profiles:
+                  classes_only:
+                    sections:
+                      - classes: {select: classes, sort: alpha}
+                """
+            ).strip(),
+            encoding="utf-8",
+        )
+
+        result = _order(source, config, tmp_path / "out")
+
+        assert result.exit_code == 0
+        assert "<http://elsewhere.invalid/lost>" in result.output


### PR DESCRIPTION
## What this fixes

`order` built its output graph from only the subjects a section selected. Anything no
section claimed was discarded — no warning, no diagnostic, exit code 0 — and it was
reachable by copying a shipped example config:

```
$ rdf-construct order examples/animal_ontology.ttl examples/order/sample_profile.yml -o out/

animal_ontology-alpha.ttl            68 in -> 68 out   isomorphic
animal_ontology-logical_topo.ttl     68 in -> 68 out   isomorphic
animal_ontology-doc_order.ttl        68 in -> 65 out   DIFFERS
animal_ontology-props_by_domain.ttl  68 in -> 65 out   DIFFERS
```

Investigating it turned up a second, more severe failure at the same call site, and the
two are fixed differently.

## 1. Blank nodes were eviscerated, not dropped (unconditional fix)

`build_section_graph()` copies triples by subject, so an unclaimed blank node lost its
own triples while the *reference* to it survived in a claimed subject — and still
rendered inline. Real output from the shipped `compact` profile on a class carrying an
`owl:Restriction`:

```turtle
ex:Dog
    a owl:Class ;
    rdfs:subClassOf
        [
        ] ,
        ex:Animal .

ex:Union
    a owl:Class ;
    owl:unionOf [
    ] .
```

That is not a partial ontology, it is a different and invalid one: an anonymous class
with no axioms, and `owl:unionOf` pointing at a non-list. A reasoner will accept it.

A blank node carries no identity a profile could select it *by* — it belongs to the
description of whatever references it, so this is an integrity question rather than a
selection one. `bnode_closure()` (new, additive, in `core/serialiser.py`) walks object
positions transitively from the selected subjects, and `order` applies it whatever the
policy says. Blank nodes re-nest at their point of use, so nothing else in the output
moves.

## 2. Named subjects get a declared policy

`examples/order/test_profile.yml`'s `compact` profile — "just header and classes,
useful for quick inspection" — is a legitimate filter, and it drops 772 of 3,305
triples of a real file on purpose. So the fix cannot be "always emit everything", and a
warning it could not silence would be a defect on day one.

Profiles now take an `unclaimed` policy, in `defaults:` or on an individual profile:

| value | behaviour |
|---|---|
| `warn` (default) | emit what the sections claimed, report the loss on stderr, exit 0 |
| `emit` | append the unclaimed subjects in a trailing section — lose nothing |
| `ignore` | emit what the sections claimed, silently — for a deliberate filter |

An unrecognised value aborts before any file is written, so a typo in the last profile
does not surface after the earlier ones have been generated.

The message names the term, its type, and the section that would have claimed it:

```
  ⚠ profile 'doc_order': 1 subject claimed by no section — 3 triples dropped.
      ex:scientificName  (owl:AnnotationProperty)
    add a section with `select: ann_props`,
    or set `unclaimed: emit` to keep them, or `unclaimed: ignore` if this profile filters deliberately.
```

Blank nodes are never counted in it: after closure they cannot be unclaimed, and a
blank-node identifier tells a user nothing. Orphan blank nodes reachable from nothing
claimed are reported as a bare count.

## 3. The shipped examples no longer demonstrate the bug

- `sample_profile.yml`: `doc_order` and `props_by_domain` gain the missing
  `annotation_properties` section; `defaults:` documents the `unclaimed` key.
- `ies_profile.yml`: the same pair had the identical gap — fixed too. It is shipped
  documentation with the same defect, and leaving it would have shipped the bug.
- `test_profile.yml`: `compact` declares `unclaimed: ignore`.

## Scope notes

- `build_section_graph()` is unchanged. It is a pure filter doing exactly what it is
  told, in `core/`, which every command imports; the caller is what had the missing
  knowledge. `bnode_closure()` is purely additive, and `order` is the only caller of
  either.
- Not a regression from #75. `2208da3^` reproduces identically: #75 fixed the
  selector-level instance of this shape, #84 is the profile-level one.
- No reformatting outside the change — #77's sweep is queued. The touched files are
  clean for the lines added: black and ruff clean, and `mypy src/rdf_construct` reports
  the same 297 errors before and after.

## Tests

`tests/test_unclaimed_subjects.py`, 30 tests. Suite is 591 → 621, green in ~2.5s;
`scripts/ci-local.sh` gate green (black/ruff/mypy advisory debt unchanged).

The one that matters most: every profile of `sample_profile.yml` and `ies_profile.yml`
round-trips every triple of `animal_ontology.ttl` and `organisation_ontology.ttl`,
asserted with `Graph.isomorphic()`. Both halves of the fix were verified to fail
without their code — reverting the closure fails 5 tests, reverting the YAML fixes
fails 5 more.

Also covered: closure transitivity, cycles, orphan and already-present blank nodes,
collection members surviving, no empty `[ ]` in output, policy resolution and
inheritance, an unknown policy aborting before writing, singular/plural wording, the
"… and N more" summary, terms no selector claims, and an unprefixed URI reported in
full (the report must not invent a prefix — that would alter the file being ordered).

Closes #84
