### PR TITLE
docs: correct the CONTRIBUTING gate table after #77, and add .git-blame-ignore-revs

### DIFF
--- a/.git-blame-ignore-revs
+++ b/.git-blame-ignore-revs
@@ -1,0 +1,29 @@
+# Revisions that changed formatting only, and which `git blame` should skip.
+#
+# GitHub honours this file automatically in its blame view. Locally it does
+# nothing until you point git at it, once per clone:
+#
+#     git config blame.ignoreRevsFile .git-blame-ignore-revs
+#
+# Only list a commit that changed no behaviour whatsoever — a formatter sweep, a
+# whitespace pass, a reindentation. A commit mixing formatting with a real
+# change must never be listed: blame would skip the real change too. Use full
+# 40-character SHAs; git rejects abbreviated ones.
+#
+# KNOWN LIMITATION, measured rather than assumed. Ignoring a revision only
+# helps where the line still exists in a recognisable earlier form, so blame has
+# somewhere to reassign it. It does NOT help where the sweep *created* the line
+# — black joining a wrapped call onto one line produces content that never
+# existed before, and blame keeps those on the sweep because there is no earlier
+# version to fall back to. For 04a02b1 below that is the whole of the effect:
+# 145 lines across the 92 reformatted files stay attributed to it either way.
+# The entry is kept for correctness and for future sweeps (a reindentation or a
+# style-year bump, where the mechanism does work). Do not assume listing a
+# commit here makes its churn disappear — check before relying on it.
+
+# chore: repo-wide black and whitespace sweep, and gate on black (#91)
+# 92 files reformatted by black at line length 100, plus trailing-whitespace and
+# end-of-file-fixer across 39 more. Verified inert: every reformatted file parses
+# to a byte-identical AST, and 129 of 130 generated output files were identical
+# either side (#77).
+04a02b109a2f63f39395232378716dd1ffb456e0

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -158,6 +158,10 @@ feat!: rename --output to --out (breaking change)
 git clone https://github.com/aigora-de/rdf-construct.git
 cd rdf-construct
 poetry install --with dev
+pre-commit install
+
+# Let `git blame` skip the repo-wide formatting sweep (once per clone)
+git config blame.ignoreRevsFile .git-blame-ignore-revs
 
 # Make changes
 git checkout -b dev/my-feature
@@ -179,24 +183,29 @@ the gate. It runs every check, reports them all, and fails only if a *gate* step
 | Step | Severity |
 |---|---|
 | test suite (`pytest`) | **gate** |
+| version consistency (`pyproject.toml` vs `__init__.py`) | **gate** |
 | instruction/memory size guard | **gate** |
-| `black --check` | advisory |
+| `black --check` | **gate** |
 | `ruff check` | advisory |
 | `mypy --strict` | advisory |
 
-The three advisory steps carry substantial pre-existing debt across the repository — see
-[#77](https://github.com/aigora-de/rdf-construct/issues/77),
+The two advisory steps carry substantial pre-existing debt across the repository — see
 [#78](https://github.com/aigora-de/rdf-construct/issues/78) and
 [#79](https://github.com/aigora-de/rdf-construct/issues/79). **Keep the files your change touches
-clean; you are not expected to fix the rest.** Each becomes a gate as its debt reaches zero.
+clean; you are not expected to fix the rest.** Each becomes a gate as its debt reaches zero, as
+black did in [#77](https://github.com/aigora-de/rdf-construct/issues/77).
 
 Useful variants: `--tests-only` (the fast gate alone), `--lint-only` (everything else), and
 `CI_LOCAL_PYRUN=""` if you are already inside an activated virtualenv.
 
-The pre-commit hooks (`pre-commit install`) are a lighter, separate thing: whitespace and file
-hygiene only. `black`, `ruff` and `mypy` are deliberately **not** commit hooks, because against the
-current debt they rewrote files far beyond the change being committed — or, for mypy, refused the
-commit outright.
+The pre-commit hooks (`pre-commit install`) are a lighter, separate thing: file hygiene plus
+`black`. Because the repository is black-clean, the hook only ever reformats the file you are
+already editing. `ruff` and `mypy` are deliberately **not** commit hooks — against their current
+debt the first rewrote files far beyond the change being committed, and mypy refused the commit
+outright.
+
+If the black gate fails, `poetry run black .` fixes it; the usual cause is not having run
+`pre-commit install`.
 
 ## Pull Request Process
 


### PR DESCRIPTION
Two pieces of follow-up from #77 (PR #91), both small.

## CONTRIBUTING.md was left saying things that are no longer true

The gate table listed `black --check` as advisory, omitted the
version-consistency gate entirely, and the prose said black is "deliberately
**not**" a commit hook. #91 changed all three. `CLAUDE.md` makes
`CONTRIBUTING.md` authoritative for contributors, so this is a documentation
defect introduced by that merge rather than an improvement.

Also adds the recovery command for a failed black gate, since the script itself
does not print it (#92 will fix that at source).

## .git-blame-ignore-revs — and an honest measurement of what it does

A 92-file reformat pollutes `git blame`. The standard remedy is this file, which
GitHub honours automatically in its blame view.

**It does not work for this commit, and the file says so.** I measured rather
than assumed. Ignoring a revision only helps where the line survives in a
recognisable earlier form, so blame has an earlier version to reassign it to.
Black's dominant change here was joining wrapped calls onto a single line, which
produces content that never previously existed — blame has nowhere to send it,
so those lines stay attributed to the sweep. Across all 92 reformatted files:

| | Lines attributed to the sweep |
|---|---|
| ignore file off | 145 |
| ignore file on | 145 |

Explicit `--ignore-rev` behaves identically, so this is the mechanism working as
designed, not a misconfiguration.

**So why land it at all?** The honest answer is that it does nothing today and
is kept for the convention: the next sweep may well be reindentation or a black
style-year bump, where the mechanism does work, and GitHub picks the file up
with no further action. That reasoning — and the caveat — is written into the
file's header so nobody trusts it blindly. **If you would rather not carry a
mechanism that is currently inert, dropping the blame file and keeping the
CONTRIBUTING fix is a perfectly good outcome**; the two are independent.

The 145 lines are also less pollution than I expected when I suggested this —
out of 1262 insertions, blame already reattributed most of the sweep by itself.

`pre-commit run --all-files` passes; `scripts/ci-local.sh` unaffected.

Refs #77
