### PR TITLE
chore(release): prepare v0.5.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -108,6 +108,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   consumers that ignore unknown fields are unaffected (#60)
 
 ### Fixed
+- `rdf-construct --version` reports the version in the source rather than the one recorded
+  in the installed distribution metadata. `@click.version_option()` with no argument
+  resolves through `importlib.metadata`, so an editable install whose metadata predated a
+  version bump reported the stale number — v0.4.0 for a v0.4.7 checkout — until someone
+  re-ran `poetry install`. The same call also named the group function rather than the
+  tool, printing `cli, version …`; it now prints `rdf-construct, version …` (#66)
 - `order` no longer emits an empty `[ ]` in place of a blank node that no section
   claimed. `build_section_graph()` copies triples by subject, so an `owl:Restriction`
   or an `owl:unionOf` list lost its own triples while the reference to it survived —

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,13 +7,105 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.5.0] - 2026-08-22
+
 ### Added
+- **First-class SHACL shape support in the `docs` command** (#60). NodeShapes
+  (`sh:NodeShape`) and named PropertyShapes (`sh:PropertyShape` with their own
+  URI) are now rendered as a distinct entity type alongside Classes, Properties,
+  and Instances, in HTML, Markdown, and JSON output:
+  - Each shape gets its own page under `shapes/`, with kind badges
+    (`shape`, `node_shape`, `property_shape`) distinguishing NodeShapes from
+    named PropertyShapes
+  - The 21 most-used SHACL constraints (`sh:path`, `sh:minCount`, `sh:maxCount`,
+    `sh:datatype`, `sh:class`, `sh:nodeKind`, `sh:in`, `sh:hasValue`,
+    `sh:pattern`, `sh:minLength`, `sh:maxLength`, `sh:minInclusive`,
+    `sh:maxInclusive`, `sh:targetClass`, `sh:targetNode`, `sh:targetSubjectsOf`,
+    `sh:targetObjectsOf`, `sh:closed`, `sh:ignoredProperties`, `sh:name`,
+    `sh:description`) get explicit per-format rendering; everything else
+    (including `sh:severity`, `sh:order`, `sh:qualifiedValueShape`, etc.) falls
+    back to a generic visible-but-plain key-value display rather than being
+    silently dropped
+  - Blank-node PropertyShapes attached to a NodeShape via `sh:property` render
+    inline on the parent shape's page as a constraint table; named
+    PropertyShapes get their own pages plus an inline reference + link from any
+    NodeShape that uses them
+  - `sh:targetClass`, `sh:path`, and references to named PropertyShapes resolve
+    to clickable cross-references when the target is in the ontology, falling
+    back to plain code-formatted URIs otherwise
+  - Logical operators (`sh:and`, `sh:or`, `sh:xone`) and `sh:qualifiedValueShape`
+    are deferred — they need their own design pass and will be handled in a
+    future release
+- **Multi-kind data model.** Entities now carry a `kinds` list of
+  `EntityKind` enum members. Default values: `[CLASS]` for classes,
+  `[PROPERTY, <type>_PROPERTY]` for properties, `[INSTANCE]` for instances,
+  and `[SHAPE, NODE_SHAPE]` / `[SHAPE, PROPERTY_SHAPE]` for shapes. A NodeShape
+  that is also typed `owl:NamedIndividual` is placed in the Shapes section
+  rather than Instances, so it is documented once rather than twice. It does
+  not yet carry a named-individual kind — there is no `NAMED_INDIVIDUAL` member
+  in the enum, and recognising that type is stage 2/3 work. The `kinds` list is
+  the extension point for it, and for SKOS support
+- New `other_props` selector for properties whose kind is not implied by their declaration —
+  `rdf:Property`, `owl:FunctionalProperty`, `owl:DeprecatedProperty`. These remain visible to
+  the `individuals` selector, so existing profiles keep emitting them; adding an `other_props`
+  section before `individuals` groups them instead
+- New `rdf_construct.core.vocab` module holding the class and property type sets in one place,
+  so consumers no longer reproduce (and shorten) the list
+- New `EntityKind` enum (str-mixin) exported from `rdf_construct.docs`,
+  centralising kind values. Members: `CLASS`, `PROPERTY`, `OBJECT_PROPERTY`,
+  `DATATYPE_PROPERTY`, `ANNOTATION_PROPERTY`, `RDF_PROPERTY`, `INSTANCE`,
+  `SHAPE`, `NODE_SHAPE`, `PROPERTY_SHAPE`. Compares equal to its string
+  values and serialises to JSON as plain strings
+- New `ShapeInfo` and `PropertyShapeInfo` dataclasses, exported from
+  `rdf_construct.docs`. `ShapeInfo` covers NodeShapes and named PropertyShapes;
+  `PropertyShapeInfo` covers individual property constraint blocks (whether
+  blank-node arcs of a NodeShape or top-level constraint sets of a named
+  PropertyShape)
+- New `extract_all_shapes()` extractor and `extract_shape_info()` /
+  `extract_property_shape_info()` helpers
+- New `ExtractedEntities.shapes`, `node_shapes`, and `property_shapes` fields
+  / computed properties
+- New `DocsConfig.include_shapes` flag (default `True`) parallels
+  `include_instances`. When `False`, shapes are excluded from the output
+  pages and from the search index
+- New `--no-shapes` CLI flag and `shapes` accepted in the `--include` /
+  `--exclude` filter values
+- New `shape.html.jinja` template; `shape` entity type added to
+  `entity_to_path` / `entity_to_url` routing under `shapes/`
+- CSS for shape badges in HTML output: `.entity-type.shape` (`#dc2626`,
+  4.83:1 contrast), `.entity-type.node_shape` (`#b91c1c`, 6.47:1),
+  `.entity-type.property_shape` (`#e11d48`, 4.70:1) — all WCAG AA against
+  the badge's white text. Single hue family (red-rose) signals
+  NodeShape/PropertyShape kinship; brightness gradient reads as
+  parent-child. Distinct from the existing purple/cyan/amber/green
+  badges under common colour-vision deficiencies; descriptive uppercase
+  badge text labels (`"NODE SHAPE"`, `"PROPERTY SHAPE"`) carry the
+  category meaning regardless of perceived colour
+- `BaseRenderer.render_shape()` abstract method, implemented in all three
+  renderers (HTML / Markdown / JSON)
+- Comprehensive test coverage: 44 new tests in 7 classes covering shape
+  extraction, multi-kind handling, all three renderers, JSON schema, search
+  index integration, the `include_shapes` toggle, routing, and the
+  `EntityKind` enum contract
 - `order` profiles accept an `unclaimed` policy, in `defaults:` or on an individual
   profile, controlling what happens to subjects no section of the profile claims:
   `warn` (default) reports the loss on stderr and exits 0, `emit` appends them in a
   trailing section so nothing is lost, and `ignore` is silent — for a profile such as
   `test_profile.yml`'s `compact` that filters on purpose. The warning names the terms
   and the `select:` key that would have claimed them (#84)
+
+### Changed
+- **Breaking change to JSON output**: SHACL shapes used to appear in the
+  `instances` array of `index.json` and `ontology.json` because the extractor
+  didn't filter them out. They now have their own top-level `shapes` array,
+  and shapes have been removed from `instances`. JSON consumers updating from
+  v0.4.x must read both arrays to see all entities. The new top-level
+  `shapes` array contains complete `ShapeInfo` JSON for each shape (single-page
+  mode) or summary entries (index mode) — see `docs/user_guides/DOCS_GUIDE.md`
+  for the full schema. The `statistics` object also gains a `shapes` count (#60)
+- All entity entries in JSON output now include a `kinds` array carrying the
+  full multi-kind list. Existing fields are unchanged. This is additive —
+  consumers that ignore unknown fields are unaffected (#60)
 
 ### Fixed
 - `order` no longer emits an empty `[ ]` in place of a blank node that no section
@@ -62,111 +154,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   during extraction. Both call sites now accept blank-node list pointers.
   Found while writing tests for #60
 
-### Added
-- New `other_props` selector for properties whose kind is not implied by their declaration —
-  `rdf:Property`, `owl:FunctionalProperty`, `owl:DeprecatedProperty`. These remain visible to
-  the `individuals` selector, so existing profiles keep emitting them; adding an `other_props`
-  section before `individuals` groups them instead
-- New `rdf_construct.core.vocab` module holding the class and property type sets in one place,
-  so consumers no longer reproduce (and shorten) the list
-- **First-class SHACL shape support in the `docs` command** (#60). NodeShapes
-  (`sh:NodeShape`) and named PropertyShapes (`sh:PropertyShape` with their own
-  URI) are now rendered as a distinct entity type alongside Classes, Properties,
-  and Instances, in HTML, Markdown, and JSON output:
-  - Each shape gets its own page under `shapes/`, with kind badges
-    (`shape`, `node_shape`, `property_shape`) distinguishing NodeShapes from
-    named PropertyShapes
-  - The 21 most-used SHACL constraints (`sh:path`, `sh:minCount`, `sh:maxCount`,
-    `sh:datatype`, `sh:class`, `sh:nodeKind`, `sh:in`, `sh:hasValue`,
-    `sh:pattern`, `sh:minLength`, `sh:maxLength`, `sh:minInclusive`,
-    `sh:maxInclusive`, `sh:targetClass`, `sh:targetNode`, `sh:targetSubjectsOf`,
-    `sh:targetObjectsOf`, `sh:closed`, `sh:ignoredProperties`, `sh:name`,
-    `sh:description`) get explicit per-format rendering; everything else
-    (including `sh:severity`, `sh:order`, `sh:qualifiedValueShape`, etc.) falls
-    back to a generic visible-but-plain key-value display rather than being
-    silently dropped
-  - Blank-node PropertyShapes attached to a NodeShape via `sh:property` render
-    inline on the parent shape's page as a constraint table; named
-    PropertyShapes get their own pages plus an inline reference + link from any
-    NodeShape that uses them
-  - `sh:targetClass`, `sh:path`, and references to named PropertyShapes resolve
-    to clickable cross-references when the target is in the ontology, falling
-    back to plain code-formatted URIs otherwise
-  - Logical operators (`sh:and`, `sh:or`, `sh:xone`) and `sh:qualifiedValueShape`
-    are deferred — they need their own design pass and will be handled in a
-    future release
-- **Multi-kind data model.** Entities now carry a `kinds` list of
-  `EntityKind` enum members. Default values: `[CLASS]` for classes,
-  `[PROPERTY, <type>_PROPERTY]` for properties, `[INSTANCE]` for instances,
-  and `[SHAPE, NODE_SHAPE]` / `[SHAPE, PROPERTY_SHAPE]` for shapes. A NodeShape
-  that is also typed `owl:NamedIndividual` is placed in the Shapes section
-  rather than Instances, so it is documented once rather than twice. It does
-  not yet carry a named-individual kind — there is no `NAMED_INDIVIDUAL` member
-  in the enum, and recognising that type is stage 2/3 work. The `kinds` list is
-  the extension point for it, and for SKOS support
-- New `EntityKind` enum (str-mixin) exported from `rdf_construct.docs`,
-  centralising kind values. Members: `CLASS`, `PROPERTY`, `OBJECT_PROPERTY`,
-  `DATATYPE_PROPERTY`, `ANNOTATION_PROPERTY`, `RDF_PROPERTY`, `INSTANCE`,
-  `SHAPE`, `NODE_SHAPE`, `PROPERTY_SHAPE`. Compares equal to its string
-  values and serialises to JSON as plain strings
-- New `ShapeInfo` and `PropertyShapeInfo` dataclasses, exported from
-  `rdf_construct.docs`. `ShapeInfo` covers NodeShapes and named PropertyShapes;
-  `PropertyShapeInfo` covers individual property constraint blocks (whether
-  blank-node arcs of a NodeShape or top-level constraint sets of a named
-  PropertyShape)
-- New `extract_all_shapes()` extractor and `extract_shape_info()` /
-  `extract_property_shape_info()` helpers
-- New `ExtractedEntities.shapes`, `node_shapes`, and `property_shapes` fields
-  / computed properties
-- New `DocsConfig.include_shapes` flag (default `True`) parallels
-  `include_instances`. When `False`, shapes are excluded from the output
-  pages and from the search index
-- New `--no-shapes` CLI flag and `shapes` accepted in the `--include` /
-  `--exclude` filter values
-- New `shape.html.jinja` template; `shape` entity type added to
-  `entity_to_path` / `entity_to_url` routing under `shapes/`
-- CSS for shape badges in HTML output: `.entity-type.shape` (`#dc2626`,
-  4.83:1 contrast), `.entity-type.node_shape` (`#b91c1c`, 6.47:1),
-  `.entity-type.property_shape` (`#e11d48`, 4.70:1) — all WCAG AA against
-  the badge's white text. Single hue family (red-rose) signals
-  NodeShape/PropertyShape kinship; brightness gradient reads as
-  parent-child. Distinct from the existing purple/cyan/amber/green
-  badges under common colour-vision deficiencies; descriptive uppercase
-  badge text labels (`"NODE SHAPE"`, `"PROPERTY SHAPE"`) carry the
-  category meaning regardless of perceived colour
-- `BaseRenderer.render_shape()` abstract method, implemented in all three
-  renderers (HTML / Markdown / JSON)
-- Comprehensive test coverage: 44 new tests in 7 classes covering shape
-  extraction, multi-kind handling, all three renderers, JSON schema, search
-  index integration, the `include_shapes` toggle, routing, and the
-  `EntityKind` enum contract
-
-### Changed
-- **Breaking change to JSON output**: SHACL shapes used to appear in the
-  `instances` array of `index.json` and `ontology.json` because the extractor
-  didn't filter them out. They now have their own top-level `shapes` array,
-  and shapes have been removed from `instances`. JSON consumers updating from
-  v0.4.x must read both arrays to see all entities. The new top-level
-  `shapes` array contains complete `ShapeInfo` JSON for each shape (single-page
-  mode) or summary entries (index mode) — see `docs/user_guides/DOCS_GUIDE.md`
-  for the full schema. The `statistics` object also gains a `shapes` count (#60)
-- All entity entries in JSON output now include a `kinds` array carrying the
-  full multi-kind list. Existing fields are unchanged. This is additive —
-  consumers that ignore unknown fields are unaffected (#60)
-
 ### Contributors
 - Thanks to @otellomaria for reporting #59 with a clean reproducer
 - Thanks to @algojogacor, @hyldmh and @mayank-dev-15, who each independently diagnosed the same
   root cause and proposed a fix for it in #67, #68, #70 and #71
 
-**Note:** the equivalent gap in the `docs` command's entity extraction is not addressed here, to
-avoid conflicting with the in-flight entity-taxonomy work in #62.
+**Note:** `docs` entity extraction has the same gap that `order`'s selectors had — a property
+declared only by an OWL characteristic is missed. It is not addressed here and is tracked as #76.
 
-**Note:** the #59 fix covers the generated HTML only. Two related defects with the same root
-cause remain: `assets/search.js` fetches `search.json` page-relatively and stores root-relative
-result URLs, so the search overlay is inert on any sub-folder page; and the Markdown renderer
-emits the same root-relative entity links, so `classes/Dog.md` → `classes/Mammal.md` resolves as
-`classes/classes/Mammal.md`. Both predate this change.
+**Note:** the #59 fix covers the generated HTML only. Two related defects with the same root cause
+remain, both raised out of it: the search overlay is inert on any sub-folder page (#86), and the
+Markdown renderer emits root-relative entity links (#87).
 
 ## [0.4.7] - 2026-05-07
 
@@ -629,6 +627,7 @@ Initial public release.
 | [0.1.0] | 2025-11-30 | Initial release: ordering, UML generation, styling                                                  |
 
 [Unreleased]: https://github.com/aigora-de/rdf-construct/compare/v0.4.7...HEAD
+[0.5.0]: https://github.com/aigora-de/rdf-construct/releases/tag/v0.5.0
 [0.4.7]: https://github.com/aigora-de/rdf-construct/releases/tag/v0.4.7
 [0.4.6]: https://github.com/aigora-de/rdf-construct/releases/tag/v0.4.6
 [0.4.5]: https://github.com/aigora-de/rdf-construct/releases/tag/v0.4.5

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -16,9 +16,9 @@ context.
 **rdf-construct** is a Python CLI toolkit for semantic RDF operations, named after the Dixie
 Flatline ROM construct in Gibson's *Neuromancer*. Its founding feature: serialising RDF/Turtle in
 **semantic order** — respecting class and property hierarchies — instead of the alphabetical order
-every rdflib serialiser imposes. Public, MIT, published to PyPI; v0.4.7.
+every rdflib serialiser imposes. Public, MIT, published to PyPI; v0.5.0.
 
-Around 18 commands across 15 subpackages under `src/rdf_construct/`: `order`, `cast`, `uml`,
+17 commands across 14 subpackages under `src/rdf_construct/`: `order`, `cast`, `uml`,
 `lint`, `diff`, `docs`, `shacl-gen`, `puml2rdf`, `cq-test`, `stats`, `describe`, `merge`, `split`,
 `refactor rename|deprecate`, `localise extract|merge|report`, plus `profiles` and `contexts`.
 Built on rdflib 7, Click, Rich, Jinja2 and PyYAML.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "poetry.core.masonry.api"
 
 [project]
 name = "rdf-construct"
-version = "0.4.7"
+version = "0.5.0"
 description = "Semantic RDF manipulation toolkit - order, serialize, and diff RDF ontologies"
 license = "MIT"
 readme = "README.md"

--- a/src/rdf_construct/__init__.py
+++ b/src/rdf_construct/__init__.py
@@ -4,7 +4,7 @@ Named after the ROM construct from William Gibson's Neuromancer -
 preserved, structured knowledge that can be queried and transformed.
 """
 
-__version__ = "0.4.7"
+__version__ = "0.5.0"
 
 from . import core, uml
 from .cli import cli

--- a/src/rdf_construct/cli.py
+++ b/src/rdf_construct/cli.py
@@ -8,6 +8,11 @@ from rdflib import BNode, Graph, RDF, URIRef
 from rdflib.namespace import OWL
 from rdflib.term import Node
 
+# Safe despite rdf_construct/__init__.py importing this module: __version__ is
+# assigned there before the `from .cli import cli` line, so it is bound by the
+# time this import runs. Keep it that way — moving __version__ below those
+# imports would make this circular (#66).
+from rdf_construct import __version__
 from rdf_construct.core import (
     OrderingConfig,
     bnode_closure,
@@ -129,7 +134,7 @@ RENDERING_MODES = ["default", "odm"]
 
 
 @click.group()
-@click.version_option()
+@click.version_option(__version__, prog_name="rdf-construct")
 def cli():
     """rdf-construct: Semantic RDF manipulation toolkit.
 

--- a/tests/test_version.py
+++ b/tests/test_version.py
@@ -1,0 +1,76 @@
+"""Tests for `rdf-construct --version` and the version strings behind it (#66)."""
+
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+from click.testing import CliRunner
+
+import rdf_construct
+from rdf_construct.cli import cli
+
+PYPROJECT = Path(__file__).resolve().parent.parent / "pyproject.toml"
+
+
+class TestVersionOption:
+    """`--version` must report the source version, not installed metadata."""
+
+    def test_reports_source_version(self) -> None:
+        """The reported version is `rdf_construct.__version__`.
+
+        Regression test for #66: `@click.version_option()` with no argument
+        resolves through `importlib.metadata`, so an editable install whose
+        metadata predates a version bump reported the stale number.
+        """
+        result = CliRunner().invoke(cli, ["--version"])
+
+        assert result.exit_code == 0
+        assert rdf_construct.__version__ in result.output
+
+    def test_uses_the_tool_name_not_the_group_name(self) -> None:
+        """Output names the tool, rather than the `cli` group function."""
+        result = CliRunner().invoke(cli, ["--version"])
+
+        assert result.output.startswith("rdf-construct, version ")
+
+    def test_does_not_consult_installed_metadata(self) -> None:
+        """A stale or absent distribution must not change what is reported.
+
+        `importlib.metadata.version()` raising is the strongest evidence the
+        option no longer depends on it, so patch it to blow up and confirm
+        `--version` is unaffected.
+        """
+        import importlib.metadata
+
+        def explode(_name: str) -> str:
+            raise importlib.metadata.PackageNotFoundError("rdf-construct")
+
+        original = importlib.metadata.version
+        importlib.metadata.version = explode  # type: ignore[assignment]
+        try:
+            result = CliRunner().invoke(cli, ["--version"])
+        finally:
+            importlib.metadata.version = original  # type: ignore[assignment]
+
+        assert result.exit_code == 0
+        assert rdf_construct.__version__ in result.output
+
+
+class TestVersionStringsAgree:
+    """The two hand-maintained version strings must not drift apart."""
+
+    def test_pyproject_matches_dunder_version(self) -> None:
+        """`pyproject.toml` and `__init__.py` carry the same version.
+
+        `scripts/ci-local.sh` gates on this too, but that gate is a shell
+        script nobody runs from an IDE; the suite should catch it as well.
+
+        Read with a regex rather than a TOML parser: `tomllib` is 3.11+ and
+        this project supports 3.10, and pulling in `tomli` for one assertion
+        is not worth a dependency. This matches the `sed` the gate uses.
+        """
+        match = re.search(r'^version = "(.*)"', PYPROJECT.read_text(encoding="utf-8"), re.MULTILINE)
+
+        assert match is not None, "no version line found in pyproject.toml"
+        assert match.group(1) == rdf_construct.__version__


### PR DESCRIPTION
Prepares v0.5.0. **This does not tag or publish** — both remain yours to do
after this merges.

## Why 0.5.0 now, rather than waiting for the milestone

The v0.5.0 milestone still has #63 and #64 open, so the strict reading of the
release policy says hold. Two reasons not to.

**#84 is a silent data-loss fix that users do not have.** `order` drops subjects
no profile section claims and reduces unclaimed blank nodes to `[ ]` — wrong
output, exit code 0, no warning, reproducible with a *shipped* example profile.
Anyone on PyPI 0.4.7 using this project's flagship command is losing triples
today. That is the policy's second trigger, and it should not queue behind two
docs enhancements.

**The milestone is a theme, not a feature.** #60 (SHACL shapes), #63 (SKOS) and
#64 (`owl:NamedIndividual`) are three independent entity types sharing a bucket.
"Partial features are not released" guards against shipping half a feature; #60
is whole — extractors, dataclasses, templates, CLI flags, JSON, 44 tests.

Suggest moving #63 and #64 to a new **v0.6.0** milestone.

0.5.0 rather than 0.4.8 because the JSON output change is breaking and the
release adds public API (`EntityKind`, `ShapeInfo`, `core.vocab`).

## What is in this PR

**CHANGELOG consolidated** into a dated `## [0.5.0] - 2026-08-22`. The block had
two separate `### Added` sections from successive merges, which is malformed for
a release entry — merged into one, reordered into Keep a Changelog's Added /
Changed / Fixed order, and led with the headline feature rather than the
order-selector work that happened to be written first. Bullet text moved
verbatim; the file's top-level bullet count is unchanged at 161, so nothing was
lost. Comparison link added.

The two trailing notes were rewritten, being the only stale prose: one deferred
a `docs` extraction gap to avoid conflicting with "the in-flight
entity-taxonomy work in #62", which has since merged leaving the gap tracked as
#76; the other described the #59 follow-ups before they had numbers (#86, #87).

**Both version strings bumped** to 0.5.0 — `pyproject.toml` and
`src/rdf_construct/__init__.py`, which `ci-local.sh` gates on agreeing.

**CLAUDE.md facts refreshed**, the release being exactly when they drift and the
size guard measuring bytes rather than truth: v0.4.7 → v0.5.0, "around 18
commands" → 17, "15 subpackages" → 14. The command list itself was already
correct; the 15th directory is `__pycache__`.

## Verified

- `scripts/ci-local.sh` **gate green** — 621 tests, black clean, and the version
  gate reporting `version 0.5.0 (pyproject.toml and __init__.py agree)`
- `poetry check` passes; `poetry build` produces both artefacts

## Before you publish — one trap

**`rm -rf dist/` first.** `dist/` is gitignored and never cleaned; it now holds
24 files spanning 0.2.0 → 0.5.0. `poetry publish` uploads everything it finds
there, so it will try to re-upload every historical release and PyPI will reject
the duplicates. Build the release into an empty `dist/`.

Also still open and worth a thought before tagging: **#66** — `--version`
reports the installed metadata version rather than the source `__version__`, so
the confusion lands precisely when you verify the fresh release. Not fixed here;
it is a code change, not release prep.
