### PR TITLE
docs(readme): update the stated version to v0.5.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -387,7 +387,7 @@ properties:
 
 ## Project Status
 
-**Current**: v0.4.1 - Feature complete for core ontology workflows
+**Current**: v0.5.0 - Feature complete for core ontology workflows
 **License**: MIT
 
 ### Implemented
@@ -399,6 +399,7 @@ properties:
 ✅ Configurable styling and layouts
 ✅ Semantic diff (compare ontology versions)
 ✅ Documentation generation (HTML, Markdown, JSON)
+✅ SHACL shapes documented as a first-class entity type
 ✅ SHACL shape generation
 ✅ Ontology linting (11 rules)
 ✅ Competency question testing
@@ -474,6 +475,6 @@ MIT License - see [LICENSE](LICENSE) file for details.
 
 ---
 
-**Status**: v0.4.1
+**Status**: v0.5.0
 **Python**: 3.10+ required
 **Maintainer**: See [CONTRIBUTING.md](CONTRIBUTING.md)


### PR DESCRIPTION
`README.md` claimed **v0.4.1** in two places — the Project Status heading and
the footer. That was already four releases stale before v0.5.0, so this is a
pre-existing defect the release surfaced rather than one it caused. Both now
read v0.5.0.

Also adds the release's headline feature to the implemented list. The existing
"SHACL shape generation" entry refers to `shacl-gen`; `docs` rendering shapes as
a first-class entity type is a different capability, so it gets its own line
rather than an edit to that one.

## Checked and deliberately left alone

- **"Ontology linting (11 rules)"** — verified against `lint --list-rules`:
  4 best-practice, 2 documentation, 5 structural. Correct.
- No other version string in `README.md`, `docs/index.md` or `CONTRIBUTING.md`
  is stale.

Docs only; no code paths touched.
