### PR TITLE
chore: add scripts/release.sh and guard the facts a release drifts

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -231,17 +231,41 @@ Not every merged PR triggers a release. Cut one when a milestone is complete, wh
 bug fix needs to reach users, when smaller improvements have accumulated, or immediately for a
 security fix. Partial features are not released.
 
-1. Ensure `main` is stable and the test suite passes
-2. Update version in `pyproject.toml` **and** `src/rdf_construct/__init__.py` — they must match
-3. Update CHANGELOG.md with the release notes and date, following
+**`scripts/release.sh` runs the release**, as `scripts/ci-local.sh` runs the pre-PR checks.
+
+Prepare the release by hand — these are judgement calls, so the script checks them rather than
+making them:
+
+1. Bump the version in `pyproject.toml` **and** `src/rdf_construct/__init__.py`, following
    [SemVer](https://semver.org/): MAJOR for breaking changes, MINOR for backward-compatible
    features, PATCH for backward-compatible fixes
-4. Create an annotated git tag: `git tag -a v0.5.0 -m "Release v0.5.0"`
-5. Push the tag: `git push origin v0.5.0`
-6. Build and publish: `poetry build && poetry publish`
+2. Date the CHANGELOG entry, empty `[Unreleased]`, add the version's `compare/…` link to the
+   footer, and move the `[Unreleased]` link on to the new version
+3. Update the version where prose states it — `README.md` and `CLAUDE.md`
 
-There is **no release automation** — `.github/workflows/` is empty, so nothing runs on push or on
-tag. Publishing is a manual step today.
+Then:
+
+```bash
+scripts/release.sh --check   # changes nothing; tells you what is not ready
+scripts/release.sh           # tag, push, clean build, verify the wheel, dry run
+poetry publish               # yours to run — see below
+scripts/release.sh --post    # GitHub release from the CHANGELOG, close the milestone
+```
+
+The script refuses rather than assists: every check names what to fix and it never edits a file
+to make itself pass. It also stops short of publishing. **A version can never be replaced on
+PyPI once uploaded**, so that one command stays deliberate and human.
+
+`--check` verifies: `main`, clean, in sync; the `ci-local.sh` gate; that the version agrees across
+`pyproject.toml`, `__init__.py`, `CHANGELOG.md`, `README.md` and `CLAUDE.md`; that the CHANGELOG's
+top entry is dated and `[Unreleased]` is empty; and that the tag does not already exist. After
+building it installs the wheel into a throwaway virtualenv and asks it for `--version`, because a
+non-editable install is where a version read from package metadata goes wrong ([#66]).
+
+There is **no hosted release automation** — `.github/workflows/` is empty, so nothing runs on push
+or on tag. The script is local, like every other gate here.
+
+[#66]: https://github.com/aigora-de/rdf-construct/issues/66
 
 ## Ownership, Licensing, and AI Tools
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -247,7 +247,7 @@ Then:
 
 ```bash
 scripts/release.sh --check   # changes nothing; tells you what is not ready
-scripts/release.sh           # tag, push, clean build, verify the wheel, dry run
+scripts/release.sh           # clean build, verify the wheel, tag, push, dry run
 poetry publish               # yours to run — see below
 scripts/release.sh --post    # GitHub release from the CHANGELOG, close the milestone
 ```
@@ -255,6 +255,10 @@ scripts/release.sh --post    # GitHub release from the CHANGELOG, close the mile
 The script refuses rather than assists: every check names what to fix and it never edits a file
 to make itself pass. It also stops short of publishing. **A version can never be replaced on
 PyPI once uploaded**, so that one command stays deliberate and human.
+
+It builds *before* it tags, and tags the exact commit it built. A pushed tag cannot be quietly
+retracted once anyone has fetched it, so nothing reaches origin until the artefact exists and has
+been proven to work.
 
 `--check` verifies: `main`, clean, in sync; the `ci-local.sh` gate; that the version agrees across
 `pyproject.toml`, `__init__.py`, `CHANGELOG.md`, `README.md` and `CLAUDE.md`; that the CHANGELOG's

--- a/scripts/release.sh
+++ b/scripts/release.sh
@@ -19,9 +19,13 @@
 #
 # Usage:
 #   scripts/release.sh -n | --check   # checks only; changes nothing, anywhere
-#   scripts/release.sh                # check, tag, push, build, verify, dry-run
+#   scripts/release.sh                # check, build, verify, tag, push, dry-run
 #   scripts/release.sh --post         # after publishing: GitHub release, milestone
 #   scripts/release.sh -h | --help
+#
+# The build comes before the tag deliberately. A tag that has been pushed cannot
+# be quietly retracted once anyone has fetched it, so nothing is published to
+# origin until the artefact exists and has been proven to work.
 #
 # Override the Python runner with CI_LOCAL_PYRUN (default "poetry run"), as for
 # ci-local.sh.
@@ -37,12 +41,16 @@ release.sh — the release runner for rdf-construct.
 Companion to ci-local.sh: that one gates a PR, this one gates a release.
 
   scripts/release.sh -n | --check   checks only; changes nothing, anywhere
-  scripts/release.sh                check, tag, push, build, verify, dry-run
+  scripts/release.sh                check, build, verify, tag, push, dry-run
   scripts/release.sh --post         after publishing: GitHub release, milestone
   scripts/release.sh -h | --help
 
 The default run stops before uploading to PyPI and prints the command for you
 to run. A published version can never be replaced, so that step stays human.
+
+The build happens before the tag: a pushed tag cannot be quietly retracted once
+anyone has fetched it, so nothing reaches origin until the artefact exists and
+has been proven to work.
 
 Checks performed:
 
@@ -53,8 +61,9 @@ Checks performed:
              and the footer carries this version's compare link
   tag        does not already exist, locally or on origin
 
-Then: annotated tag, pushed; a clean dist/; a build; the wheel installed into a
-throwaway venv and asked its own --version; and poetry publish --dry-run.
+Then: a clean dist/; a build; the wheel installed into a throwaway venv and
+asked its own --version; an annotated tag on the exact commit that was built,
+pushed; and poetry publish --dry-run.
 USAGE
 }
 
@@ -71,6 +80,9 @@ cd "$(git rev-parse --show-toplevel)" || { echo "not in a git repo" >&2; exit 2;
 
 PYRUN="${CI_LOCAL_PYRUN-poetry run}"
 FAILED=()
+# Set by do_build, read by do_tag. Initialised here so `set -u` gives a clear
+# failure rather than an unbound-variable crash if the order is ever changed.
+RELEASE_SHA=""
 
 say()  { printf '\n\033[1m──▶ %s\033[0m\n' "$1"; }
 ok()   { printf '   \033[32m✓ %s\033[0m\n' "$1"; }
@@ -201,14 +213,24 @@ check_tag() {
 
 # --- actions ------------------------------------------------------------------
 
+# Tags the commit that was actually built, captured before the build, rather
+# than whatever HEAD happens to be by now. Belt and braces — the checks refuse a
+# dirty tree, so these are the same commit — but it makes the tag a statement
+# about the artefact rather than about the clock.
 do_tag() {
   say "tagging $TAG"
-  git tag -a "$TAG" -m "Release $TAG" && ok "annotated tag created"
+  if [[ "$(git rev-parse HEAD)" != "$RELEASE_SHA" ]]; then
+    bad "HEAD moved during the run — refusing to tag"
+    note "built ${RELEASE_SHA:0:8}, HEAD is now $(git rev-parse --short HEAD)"
+    return
+  fi
+  git tag -a "$TAG" "$RELEASE_SHA" -m "Release $TAG" && ok "annotated tag on ${RELEASE_SHA:0:8}"
   git push origin "$TAG" >/dev/null 2>&1 && ok "pushed to origin" || bad "could not push $TAG"
 }
 
 do_build() {
-  say "building into a clean dist/"
+  RELEASE_SHA="$(git rev-parse HEAD)"
+  say "building into a clean dist/ (from ${RELEASE_SHA:0:8})"
   # Poetry only uploads artefacts matching the current version, so an old 0.4.x
   # in dist/ is harmless. A STALE 0.5.0 is not: it would publish an earlier tree
   # under the right filename. Clearing the directory makes that impossible.
@@ -321,9 +343,13 @@ case "$MODE" in
     printf '  run \033[1mscripts/release.sh\033[0m to tag, build and verify.\n'
     ;;
   run)
-    do_tag
+    # Build and prove the artefact before anything reaches origin. A failed
+    # build here leaves no public trace; the other order leaves a pushed tag to
+    # retract, which is the recovery this script exists to spare you.
     do_build
     do_verify
+    summary
+    do_tag
     summary
     do_dry_run
     printf '\n\033[1m── ready ───────────────────────────────\033[0m\n'

--- a/scripts/release.sh
+++ b/scripts/release.sh
@@ -1,0 +1,342 @@
+#!/usr/bin/env bash
+#
+# release.sh — the release runner for rdf-construct.
+#
+# Copyright (c) 2026 Dave Dyke / Agilit Ltd. MIT licence.
+#
+# Companion to ci-local.sh, which gates a PR. This gates a release (#98).
+#
+# It exists because the manual sequence was skipped, repeatedly and silently:
+# four published versions (0.4.1, 0.4.4, 0.4.5, 0.4.6) were never tagged at all,
+# twelve of thirteen never got a GitHub release, and README sat four versions
+# stale. None of that was caught, because nothing was checking.
+#
+# The design rule is REFUSE, DON'T ASSIST. Every check below fails the run and
+# tells you what to fix; the script never edits a file to make itself pass. The
+# one irreversible step — uploading to PyPI, which can never be undone for a
+# given version — it deliberately does NOT perform. It prepares and verifies
+# everything, then hands you one command.
+#
+# Usage:
+#   scripts/release.sh -n | --check   # checks only; changes nothing, anywhere
+#   scripts/release.sh                # check, tag, push, build, verify, dry-run
+#   scripts/release.sh --post         # after publishing: GitHub release, milestone
+#   scripts/release.sh -h | --help
+#
+# Override the Python runner with CI_LOCAL_PYRUN (default "poetry run"), as for
+# ci-local.sh.
+
+set -uo pipefail
+
+usage() {
+  # A heredoc, not a line-range slice of this file's own comments. ci-local.sh
+  # does the latter and it silently drifted (#93); no point repeating that here.
+  cat <<'USAGE'
+release.sh — the release runner for rdf-construct.
+
+Companion to ci-local.sh: that one gates a PR, this one gates a release.
+
+  scripts/release.sh -n | --check   checks only; changes nothing, anywhere
+  scripts/release.sh                check, tag, push, build, verify, dry-run
+  scripts/release.sh --post         after publishing: GitHub release, milestone
+  scripts/release.sh -h | --help
+
+The default run stops before uploading to PyPI and prints the command for you
+to run. A published version can never be replaced, so that step stays human.
+
+Checks performed:
+
+  git        on main, tracked tree clean, in sync with origin
+  gate       scripts/ci-local.sh passes
+  versions   pyproject.toml = __init__.py = CHANGELOG = README.md = CLAUDE.md
+  changelog  top entry is dated, matches the version, [Unreleased] is empty,
+             and the footer carries this version's compare link
+  tag        does not already exist, locally or on origin
+
+Then: annotated tag, pushed; a clean dist/; a build; the wheel installed into a
+throwaway venv and asked its own --version; and poetry publish --dry-run.
+USAGE
+}
+
+MODE=run
+case "${1-}" in
+  -n|--check)  MODE=check ;;
+  --post)      MODE=post ;;
+  -h|--help)   usage; exit 0 ;;
+  "")          ;;
+  *)           echo "unknown option: $1 (try --help)" >&2; exit 2 ;;
+esac
+
+cd "$(git rev-parse --show-toplevel)" || { echo "not in a git repo" >&2; exit 2; }
+
+PYRUN="${CI_LOCAL_PYRUN-poetry run}"
+FAILED=()
+
+say()  { printf '\n\033[1m──▶ %s\033[0m\n' "$1"; }
+ok()   { printf '   \033[32m✓ %s\033[0m\n' "$1"; }
+bad()  { printf '   \033[31m✗ %s\033[0m\n' "$1"; FAILED+=("$1"); }
+note() { printf '     \033[2m%s\033[0m\n' "$1"; }
+
+# --- the version under release ------------------------------------------------
+
+VERSION="$(sed -n 's/^version = "\(.*\)"/\1/p' pyproject.toml | head -1)"
+if [[ -z "$VERSION" ]]; then
+  echo "could not read a version from pyproject.toml" >&2
+  exit 2
+fi
+TAG="v$VERSION"
+
+printf '\033[1mrdf-construct release %s\033[0m\n' "$TAG"
+[[ "$MODE" == check ]] && printf '\033[2mcheck only — nothing will be changed\033[0m\n'
+
+# --- checks -------------------------------------------------------------------
+
+check_git() {
+  say "git state"
+  local branch; branch="$(git rev-parse --abbrev-ref HEAD)"
+  [[ "$branch" == main ]] && ok "on main" || bad "on '$branch', not main"
+
+  if [[ -n "$(git status --porcelain --untracked-files=no)" ]]; then
+    bad "tracked files are modified — commit or revert first"
+  else
+    ok "tracked tree clean"
+  fi
+
+  git fetch --quiet origin 2>/dev/null
+  local ahead behind
+  ahead="$(git rev-list --count origin/main..HEAD 2>/dev/null || echo 0)"
+  behind="$(git rev-list --count HEAD..origin/main 2>/dev/null || echo 0)"
+  if [[ "$ahead" == 0 && "$behind" == 0 ]]; then
+    ok "in sync with origin/main"
+  else
+    bad "out of sync with origin/main ($ahead ahead, $behind behind)"
+  fi
+}
+
+check_gate() {
+  say "pre-release gate (ci-local.sh)"
+  if ./scripts/ci-local.sh >/tmp/release-gate.$$ 2>&1; then
+    ok "gate green"
+  else
+    bad "ci-local.sh gate failed"
+    note "full output: /tmp/release-gate.$$"
+    tail -5 "/tmp/release-gate.$$" | sed 's/^/     /'
+    return
+  fi
+  rm -f "/tmp/release-gate.$$"
+}
+
+# Every place the version is written by hand. ci-local.sh gates the first two;
+# README and CLAUDE.md are the ones that actually drifted, so they are here.
+check_versions() {
+  say "version strings agree ($VERSION)"
+
+  local init; init="$(sed -n 's/^__version__ = "\(.*\)"/\1/p' src/rdf_construct/__init__.py | head -1)"
+  [[ "$init" == "$VERSION" ]] && ok "src/rdf_construct/__init__.py" \
+    || bad "__init__.py says '$init', pyproject.toml says '$VERSION'"
+
+  local readme_bad=0
+  while IFS= read -r found; do
+    [[ "$found" == "$VERSION" ]] || readme_bad=1
+  done < <(grep -oE 'v[0-9]+\.[0-9]+\.[0-9]+' README.md | sed 's/^v//')
+  if [[ "$readme_bad" == 0 ]]; then
+    ok "README.md"
+  else
+    bad "README.md names a version other than $VERSION"
+    note "$(grep -nE 'v[0-9]+\.[0-9]+\.[0-9]+' README.md | head -3 | tr '\n' ' ')"
+  fi
+
+  if grep -q "v$VERSION" CLAUDE.md; then
+    ok "CLAUDE.md"
+  else
+    bad "CLAUDE.md does not name v$VERSION"
+    note "it also states a command and subpackage count — check those while you are there"
+  fi
+}
+
+check_changelog() {
+  say "CHANGELOG"
+
+  local top; top="$(grep -m1 -E '^## \[[0-9]' CHANGELOG.md)"
+  if [[ "$top" =~ ^\#\#\ \[$VERSION\]\ -\ ([0-9]{4}-[0-9]{2}-[0-9]{2})$ ]]; then
+    ok "top entry is [$VERSION], dated ${BASH_REMATCH[1]}"
+  else
+    bad "top dated entry is not '## [$VERSION] - YYYY-MM-DD'"
+    note "found: $top"
+  fi
+
+  # Content still sitting under [Unreleased] should have been part of this
+  # release, or should not be claimed by it.
+  local unreleased
+  unreleased="$(awk '/^## \[Unreleased\]/{f=1;next} /^## \[/{f=0} f' CHANGELOG.md | grep -cE '^\s*-' || true)"
+  if [[ "$unreleased" == 0 ]]; then
+    ok "[Unreleased] is empty"
+  else
+    local s; [[ "$unreleased" == 1 ]] && s="entry" || s="entries"
+    bad "[Unreleased] still has $unreleased $s — fold them in or move them out"
+  fi
+
+  grep -q "^\[$VERSION\]: .*compare/.*\.\.\.v$VERSION$" CHANGELOG.md \
+    && ok "footer has the compare link for $VERSION" \
+    || bad "footer has no 'compare/…...v$VERSION' link for this version"
+
+  grep -q "^\[Unreleased\]: .*compare/v$VERSION\.\.\.HEAD$" CHANGELOG.md \
+    && ok "[Unreleased] link is based on v$VERSION" \
+    || bad "[Unreleased] link does not read 'compare/v$VERSION...HEAD'"
+}
+
+check_tag() {
+  say "tag $TAG is free"
+  if git rev-parse -q --verify "refs/tags/$TAG" >/dev/null; then
+    bad "$TAG already exists locally"
+  else
+    ok "no local tag"
+  fi
+  if [[ -n "$(git ls-remote --tags origin "$TAG" 2>/dev/null)" ]]; then
+    bad "$TAG already exists on origin"
+  else
+    ok "no remote tag"
+  fi
+}
+
+# --- actions ------------------------------------------------------------------
+
+do_tag() {
+  say "tagging $TAG"
+  git tag -a "$TAG" -m "Release $TAG" && ok "annotated tag created"
+  git push origin "$TAG" >/dev/null 2>&1 && ok "pushed to origin" || bad "could not push $TAG"
+}
+
+do_build() {
+  say "building into a clean dist/"
+  # Poetry only uploads artefacts matching the current version, so an old 0.4.x
+  # in dist/ is harmless. A STALE 0.5.0 is not: it would publish an earlier tree
+  # under the right filename. Clearing the directory makes that impossible.
+  rm -rf dist/
+  if $PYRUN poetry build >/tmp/release-build.$$ 2>&1 || poetry build >/tmp/release-build.$$ 2>&1; then
+    ok "built $(ls dist/ | tr '\n' ' ')"
+    rm -f "/tmp/release-build.$$"
+  else
+    bad "poetry build failed"
+    tail -5 "/tmp/release-build.$$" | sed 's/^/     /'
+  fi
+}
+
+# Install the artefact somewhere clean and ask it what it is. A non-editable
+# install is exactly where a version read from package metadata would go wrong,
+# which is how #66 hid for as long as it did.
+do_verify() {
+  say "verifying the built wheel"
+  local wheel venv reported
+  wheel="$(ls dist/*.whl 2>/dev/null | head -1)"
+  if [[ -z "$wheel" ]]; then bad "no wheel in dist/"; return; fi
+
+  venv="$(mktemp -d)"
+  python3 -m venv "$venv" >/dev/null 2>&1
+  if ! "$venv/bin/pip" install --quiet "$wheel" >/dev/null 2>&1; then
+    bad "the wheel does not install"
+    rm -rf "$venv"; return
+  fi
+  reported="$("$venv/bin/rdf-construct" --version 2>&1)"
+  rm -rf "$venv"
+
+  if [[ "$reported" == "rdf-construct, version $VERSION" ]]; then
+    ok "installs clean and reports: $reported"
+  else
+    bad "installed wheel reports '$reported', expected 'rdf-construct, version $VERSION'"
+  fi
+}
+
+do_dry_run() {
+  say "publish dry run"
+  poetry publish --dry-run 2>&1 | sed 's/^/     /'
+}
+
+# --- after you have published --------------------------------------------------
+
+do_post() {
+  say "GitHub release for $TAG"
+  if gh release view "$TAG" >/dev/null 2>&1; then
+    ok "release already exists"
+  else
+    local notes; notes="$(mktemp)"
+    {
+      echo "PyPI: https://pypi.org/project/rdf-construct/$VERSION/"
+      echo
+      echo '```'
+      echo "pip install rdf-construct==$VERSION"
+      echo '```'
+      echo
+      echo "---"
+      echo
+      awk -v v="$VERSION" '$0 ~ "^## \\["v"\\]"{f=1;next} /^## \[/{f=0} f' CHANGELOG.md
+    } > "$notes"
+    if gh release create "$TAG" --title "$TAG" --notes-file "$notes" --verify-tag >/dev/null 2>&1; then
+      ok "created, notes taken from the CHANGELOG entry"
+    else
+      bad "gh release create failed"
+    fi
+    rm -f "$notes"
+  fi
+
+  say "milestone"
+  local num open
+  num="$(gh api repos/:owner/:repo/milestones --jq ".[] | select(.title | startswith(\"$TAG\")) | .number" 2>/dev/null | head -1)"
+  if [[ -z "$num" ]]; then
+    ok "no milestone named $TAG — nothing to close"
+  else
+    open="$(gh api "repos/:owner/:repo/milestones/$num" --jq .open_issues 2>/dev/null)"
+    if [[ "$open" != 0 ]]; then
+      bad "milestone $TAG still has $open open issues — move or close them first"
+    elif gh api "repos/:owner/:repo/milestones/$num" -X PATCH -f state=closed >/dev/null 2>&1; then
+      ok "milestone $TAG closed"
+    else
+      bad "could not close milestone $TAG"
+    fi
+  fi
+}
+
+# --- run ----------------------------------------------------------------------
+
+check_git
+check_gate
+check_versions
+check_changelog
+[[ "$MODE" == post ]] || check_tag
+
+summary() {
+  printf '\n\033[1m── summary ─────────────────────────────\033[0m\n'
+  if (( ${#FAILED[@]} )); then
+    printf '  \033[31mFAILED: %s\033[0m\n' "${FAILED[*]}"
+    printf '  nothing was published.\n'
+    exit 1
+  fi
+}
+
+if (( ${#FAILED[@]} )); then summary; fi
+
+case "$MODE" in
+  check)
+    printf '\n\033[32m  all checks pass — %s is ready to release\033[0m\n' "$TAG"
+    printf '  run \033[1mscripts/release.sh\033[0m to tag, build and verify.\n'
+    ;;
+  run)
+    do_tag
+    do_build
+    do_verify
+    summary
+    do_dry_run
+    printf '\n\033[1m── ready ───────────────────────────────\033[0m\n'
+    printf '  %s is tagged, pushed, built and verified.\n' "$TAG"
+    printf '\n  The upload is yours — it cannot be undone, and there are no\n'
+    printf '  credentials here. Run:\n\n'
+    printf '      \033[1mpoetry publish\033[0m\n'
+    printf '\n  Do NOT rebuild first; dist/ holds the verified artefacts.\n'
+    printf '  Afterwards: \033[1mscripts/release.sh --post\033[0m\n'
+    ;;
+  post)
+    do_post
+    summary
+    printf '\n\033[32m  %s is fully released.\033[0m\n' "$TAG"
+    ;;
+esac

--- a/tests/test_version.py
+++ b/tests/test_version.py
@@ -10,7 +10,11 @@ from click.testing import CliRunner
 import rdf_construct
 from rdf_construct.cli import cli
 
-PYPROJECT = Path(__file__).resolve().parent.parent / "pyproject.toml"
+ROOT = Path(__file__).resolve().parent.parent
+PYPROJECT = ROOT / "pyproject.toml"
+README = ROOT / "README.md"
+CLAUDE_MD = ROOT / "CLAUDE.md"
+CHANGELOG = ROOT / "CHANGELOG.md"
 
 
 class TestVersionOption:
@@ -74,3 +78,69 @@ class TestVersionStringsAgree:
 
         assert match is not None, "no version line found in pyproject.toml"
         assert match.group(1) == rdf_construct.__version__
+
+
+class TestDocumentedVersionsAgree:
+    """Prose that states the version must not drift from the code (#98).
+
+    These are the strings that actually went stale: README claimed v0.4.1 for
+    four releases, and CLAUDE.md carried a wrong version alongside a wrong
+    command and subpackage count. `scripts/release.sh` checks all of this
+    before a release, but a release is a rare event and the script is easy not
+    to run — so the suite guards it on every commit too.
+    """
+
+    def test_readme_names_no_other_version(self) -> None:
+        """Every `vX.Y.Z` in README.md is the current version."""
+        found = set(re.findall(r"v(\d+\.\d+\.\d+)", README.read_text(encoding="utf-8")))
+
+        assert found, "README.md names no version at all — it used to name two"
+        assert found == {
+            rdf_construct.__version__
+        }, f"README.md names {sorted(found)}, expected only {rdf_construct.__version__}"
+
+    def test_claude_md_names_the_current_version(self) -> None:
+        """CLAUDE.md's stated version matches the code."""
+        text = CLAUDE_MD.read_text(encoding="utf-8")
+
+        assert (
+            f"v{rdf_construct.__version__}" in text
+        ), f"CLAUDE.md does not name v{rdf_construct.__version__}"
+
+    def test_changelog_top_entry_is_the_current_version(self) -> None:
+        """The newest dated CHANGELOG entry is this version, and it has a date."""
+        match = re.search(
+            r"^## \[(\d+\.\d+\.\d+)\] - (\d{4}-\d{2}-\d{2})$",
+            CHANGELOG.read_text(encoding="utf-8"),
+            re.MULTILINE,
+        )
+
+        assert match is not None, "no dated release heading found in CHANGELOG.md"
+        assert match.group(1) == rdf_construct.__version__
+
+
+class TestClaudeMdCounts:
+    """CLAUDE.md states counts as fact; the size guard measures bytes, not truth."""
+
+    def test_command_count_is_accurate(self) -> None:
+        """The stated command count matches the CLI's actual top-level commands."""
+        stated = re.search(r"^(\d+) commands across", CLAUDE_MD.read_text(encoding="utf-8"), re.M)
+
+        assert stated is not None, "CLAUDE.md no longer states a command count"
+        assert int(stated.group(1)) == len(cli.commands)
+
+    def test_subpackage_count_is_accurate(self) -> None:
+        """The stated subpackage count matches the directories on disk."""
+        stated = re.search(
+            r"commands across (\d+) subpackages", CLAUDE_MD.read_text(encoding="utf-8")
+        )
+        packages = [
+            d
+            for d in (ROOT / "src" / "rdf_construct").iterdir()
+            if d.is_dir() and not d.name.startswith("__")
+        ]
+
+        assert stated is not None, "CLAUDE.md no longer states a subpackage count"
+        assert int(stated.group(1)) == len(
+            packages
+        ), f"CLAUDE.md says {stated.group(1)}, found {sorted(p.name for p in packages)}"


### PR DESCRIPTION
Closes #98. `scripts/release.sh` runs the release cycle, as `ci-local.sh` runs
the pre-PR checks.

## Why, concretely

The scope came from watching the v0.5.0 cycle rather than from imagining how one
might go wrong. The manual steps were skipped repeatedly and silently:

- **0.4.1, 0.4.4, 0.4.5 and 0.4.6 were never tagged.** Not mistagged — no tag at
  all, so no commit was on record as being those releases. They were only
  recoverable because the sdists were still on PyPI and each upload happened
  within minutes of a version bump. That is luck.
- **12 of 13 versions had no GitHub release**, so 8 CHANGELOG links 404'd.
- **README named v0.4.1** for four releases; CLAUDE.md had a wrong version
  alongside a wrong command count and subpackage count.

## Two design rules

**Refuse, don't assist.** Every check names what to fix and the script never
edits a file to make itself pass. Preparing a release is judgement — which
version, what the notes say — so those stay manual and the script gates them.

**The upload stays human.** A PyPI version can never be replaced once uploaded,
and there are no credentials on this machine regardless, so the run stops and
prints the one command to type.

## Modes

```bash
scripts/release.sh --check   # changes nothing, anywhere
scripts/release.sh           # tag, push, clean build, verify wheel, dry run
poetry publish               # yours
scripts/release.sh --post    # GitHub release from the CHANGELOG, close milestone
```

`--check` covers: on `main`, clean, in sync; the `ci-local.sh` gate; the version
agreeing across `pyproject.toml`, `__init__.py`, `CHANGELOG.md`, `README.md` and
`CLAUDE.md`; the CHANGELOG's top entry dated and `[Unreleased]` empty; the
footer carrying this version's compare link and `[Unreleased]` rebased on it;
and the tag not already existing locally or on origin.

The build goes into a cleaned `dist/` — not because Poetry would re-upload old
versions (it will not; it globs the current version only), but because a **stale
same-version** artefact would publish an earlier tree under the right filename.

Then it installs the wheel into a throwaway virtualenv and asks it `--version`.
A non-editable install is exactly where a version read from package metadata
goes wrong, which is how #66 survived so long.

## Demonstrated, not asserted

Run against this branch, `--check` correctly refuses — wrong branch, tag already
exists — while every consistency check passes:

```
──▶ version strings agree (0.5.0)
   ✓ src/rdf_construct/__init__.py
   ✓ README.md
   ✓ CLAUDE.md
──▶ CHANGELOG
   ✓ top entry is [0.5.0], dated 2026-08-22
   ✓ [Unreleased] is empty
   ✓ footer has the compare link for 0.5.0
   ✓ [Unreleased] link is based on v0.5.0
──▶ tag v0.5.0 is free
   ✗ v0.5.0 already exists locally
```

I then reintroduced two of the historical failures — README back to v0.4.1, and
an entry left under `[Unreleased]` — and both were caught, so the checks are not
passing vacuously.

## Also: the suite now guards the same facts

`tests/test_version.py` gains five tests covering README, CLAUDE.md and the
CHANGELOG heading, plus CLAUDE.md's command and subpackage counts against
`len(cli.commands)` and the directories on disk (17 and 14). A release is rare
and the script is easy not to run; these check on every commit. All five fail
against the tree as it stood this morning.

Suite at **630 tests**, gate green.

## Note on the usage text

It is a heredoc, not a line-range slice of the script's own header comments.
`ci-local.sh` does the latter and it silently drifted into printing
`set -uo pipefail` as help text — that is #93, and there was no reason to
reproduce the pattern in a new file.
