### PR TITLE
chore: pin black exactly, name the gate fix, and stop --help drifting

### DIFF
--- a/poetry.lock
+++ b/poetry.lock
@@ -1071,4 +1071,4 @@ typing-extensions = {version = ">=4.13.2", markers = "python_version < \"3.11\""
 [metadata]
 lock-version = "2.1"
 python-versions = "^3.10"
-content-hash = "d721f9f515541130dd6eef2069321df6aa1b3edae80728402eb87beb94627ae4"
+content-hash = "fff9602a49c45a9a748224efcc92dd082298dff09078f68e0d4f37e4297e875d"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -68,7 +68,11 @@ rich = "^13.0.0"
 jinja2 = "^3.1.0"
 
 [tool.poetry.group.dev.dependencies]
-black = "^24.0.0"
+# Pinned exactly, not "^24.0.0" (#92). The black pre-commit hook carries its own
+# `rev`, so a caret range lets the hook and `scripts/ci-local.sh` resolve
+# different versions and disagree about whether the same file is formatted.
+# Keep this in step with `rev:` in .pre-commit-config.yaml.
+black = "24.10.0"
 ruff = "^0.1.0"
 mypy = "^1.8.0"
 pytest = "^8.0.0"

--- a/scripts/ci-local.sh
+++ b/scripts/ci-local.sh
@@ -1,5 +1,11 @@
 #!/usr/bin/env bash
 #
+# The block between the help:start and help:end markers below is what `--help`
+# prints. It used to be a hard-coded line range, which drifted the moment anyone
+# added a comment and silently emitted `set -uo pipefail` as help text (#93).
+# Add or remove lines inside the markers freely; they move with the content.
+#
+# help:start
 # ci-local.sh — the pre-PR check runner for rdf-construct.
 #
 # Copyright (c) 2026 Dave Dyke / Agilit Ltd. MIT licence.
@@ -37,8 +43,16 @@
 #   scripts/ci-local.sh --tests-only # the pytest gate alone (fast)
 #   scripts/ci-local.sh --lint-only  # the non-pytest checks (black, ruff, mypy, memory guard)
 #   scripts/ci-local.sh -h|--help
+# help:end
 
 set -uo pipefail
+
+# Print the comment block between the help markers, minus the markers and the
+# leading "# ". Bounded by content rather than by line number, so adding a
+# comment above cannot silently push shell code into the help text (#93).
+show_help() {
+  awk '/^# help:start$/{f=1;next} /^# help:end$/{f=0} f' "$0" | sed 's/^# \{0,1\}//'
+}
 
 cd "$(git rev-parse --show-toplevel)" || { echo "not in a git repo" >&2; exit 2; }
 
@@ -48,7 +62,7 @@ RUN_OTHER=1
 case "${1-}" in
   --tests-only) RUN_OTHER=0 ;;
   --lint-only)  RUN_TESTS=0 ;;
-  -h|--help)    sed -n '2,39p' "$0" | sed 's/^# \{0,1\}//'; exit 0 ;;
+  -h|--help)    show_help; exit 0 ;;
   "")           ;;
   *)            echo "unknown option: $1 (try --help)" >&2; exit 2 ;;
 esac

--- a/scripts/ci-local.sh
+++ b/scripts/ci-local.sh
@@ -118,8 +118,16 @@ s_version() {
 
 # GATE (#77): clean repo-wide as at 2026-08-22 — 142 of 142 files. `black` is also a
 # pre-commit hook, so a failure here usually means the hook is not installed locally
-# (`pre-commit install`) rather than a genuine surprise.
-s_black() { $PYRUN black --check .; }
+# rather than a genuine surprise. On failure it prints the recovery command, because
+# `black --check` names the files it would reformat but never what to run (#92). The
+# hint is safe to follow: the black version is pinned exactly in pyproject.toml, so
+# `black .` here and the hook agree about what "formatted" means.
+s_black() {
+  $PYRUN black --check . && return 0
+  printf '   \033[2m→ fix: %s black .\033[0m\n' "$PYRUN"
+  printf '   \033[2m  (if this keeps recurring, run `pre-commit install`)\033[0m\n'
+  return 1
+}
 
 # ADVISORY (#78): 610 errors as at 2026-08-22, after the #77 sweep.
 s_ruff() { $PYRUN ruff check .; }


### PR DESCRIPTION
Closes #92 and #93 — the two chores left over from the #77 panel. Three
commits, readable in order.

## 1. Pin black exactly (#92)

`black = "^24.0.0"` let the resolved version drift from `rev: 24.10.0` in
`.pre-commit-config.yaml`. They agreed only because the lock happened to resolve
24.10.0; #77 left a comment asking the next maintainer to keep them in step,
which is weaker than a constraint.

**No dependency actually moves.** The resolved version was already 24.10.0, so
the only change in `poetry.lock` is its content-hash — verified by diffing every
`name`/`version` pair before and after:

```
$ diff <(grep -E '^(name|version) = ' lock.before) <(grep -E '^(name|version) = ' poetry.lock)
NO package or version changed
```

## 2. Name the fix when the black gate fails (#92)

`black --check` reports which files it would reformat but never what to run. Now:

```
   ✗ black formatting (GATE)
   → fix: poetry run black .
     (if this keeps recurring, run `pre-commit install`)
```

Uses `$PYRUN`, so it stays correct under `CI_LOCAL_PYRUN=""`. Kept local to
`s_black` rather than added to `step`, which every check shares.

**Ordered after the pin deliberately** — that was the whole reason #92 carried
both items. Under version drift `black .` is the wrong thing to recommend: the
hook undoes it and the gate fails again. The pin makes the advice sound.

## 3. Bound `--help` by markers (#93)

`sed -n '2,39p' "$0"` tied the help to line numbers nothing maintained. It had
already drifted far enough to print `set -uo pipefail` as help text, unnoticed,
and the trigger is the most ordinary edit there is — adding a comment.

`show_help` now prints between `# help:start` and `# help:end`, excluding the
markers. Verified by reproducing the original trigger: inserting a comment high
in the file leaves the help correct, includes the new line, and leaks no shell.
Under the old range that same edit pushed script into the output.

I used the sentinel rather than the heredoc that `scripts/release.sh` uses.
Different files, different trade-off: a new file has no reason for its help to
double as its source comment, but ci-local.sh's header *is* the documentation,
and the property worth keeping is that a reader of the source and a reader of
`--help` see the same words.

## Verified

Gate green, 630 tests. Both behaviours demonstrated by reproducing the failure
they fix, then reverting.
