### PR TITLE
feat(docs): render SKOS concepts and schemes as first-class entities (#63)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,77 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+- **First-class SKOS support in the `docs` command** (#63). `skos:Concept` and
+  `skos:ConceptScheme` are now rendered as a distinct entity type alongside
+  Classes, Properties, Instances and Shapes, in HTML, Markdown and JSON output:
+  - Concepts and schemes get their own pages under `concepts/`, sharing the
+    directory and distinguished by kind badges (`skos concept`,
+    `skos concept scheme`) — the arrangement NodeShapes and PropertyShapes
+    already have in `shapes/`
+  - Labels are grouped **by language**: one row per language tag carrying
+    `skos:prefLabel`, `skos:altLabel` and `skos:hiddenLabel` together, rather
+    than rendering as duplicate triples
+  - All **seven** SKOS documentation properties render with their language
+    tags — `skos:definition`, `skos:scopeNote`, `skos:example`, `skos:note`,
+    `skos:historyNote`, `skos:editorialNote` and `skos:changeNote` (the
+    seventh is beyond the six the issue listed, but the SKOS spec defines it
+    alongside them and it was already being collected)
+  - `skos:broader` / `skos:narrower` render as a tree on the scheme page and
+    as inline cross-links on each concept page. **`skos:broader` is not
+    treated as `rdfs:subClassOf`** — nothing is inherited along it; the tree
+    is a navigation aid
+  - `skos:broader`/`skos:narrower` are materialised **in both directions**,
+    since SKOS declares them inverses, so a vocabulary that asserts only one
+    direction documents the same hierarchy. `skos:related` is treated as
+    symmetric and `skos:topConceptOf` as implying `skos:inScheme`, which it is
+    a sub-property of
+  - **Cyclic `skos:broader` is tolerated.** SKOS does not promise acyclicity:
+    the tree walker never expands a concept twice on one path, and any concept
+    a cycle leaves unreachable from a root is promoted to a root rather than
+    silently dropped
+  - `skos:inScheme` membership renders on both sides — the concept links to
+    its scheme, the scheme lists its members. A concept in **no** scheme is
+    still documented
+  - Mappings (`skos:exactMatch` and friends) and any other predicate get a
+    visible key-value fallback rather than being dropped
+  - Search index entries cover concepts and schemes, indexing alternative and
+    hidden labels across all languages — hidden labels exist to catch
+    misspellings, which is exactly what a search index is for
+  - New `--no-skos` flag; `concepts` accepted in `--include` / `--exclude`;
+    new `include_skos` config key. One toggle covers both SKOS kinds
+  - `skos:Collection`, `skos:OrderedCollection` and SKOS-XL are deferred —
+    no real-world material in the test set exercises them
+- New `EntityKind` members `SKOS_CONCEPT` and `SKOS_CONCEPT_SCHEME`, and new
+  `ConceptInfo`, `ConceptSchemeInfo`, `ConceptNode`, `LabelGroup` and
+  `NoteValue` dataclasses, all exported from `rdf_construct.docs` along with
+  `build_concept_tree()`
+- New tracked SKOS test fixture (`tests/fixtures/docs/skos_vocabulary.ttl`).
+  The repository previously contained no `skos:Concept`, `skos:ConceptScheme`,
+  `skos:broader`, `skos:narrower` or `skos:inScheme` at all, so there was
+  nothing to demonstrate the feature against. It deliberately includes a
+  `skos:broader` cycle, which is why it is a fixture rather than a shipped
+  example
+- SKOS badge colours, chosen against measured figures rather than by eye:
+  `skos_concept` `#1d4ed8` (6.70:1 against white) and `skos_concept_scheme`
+  `#1e3a8a` (10.36:1), both clearing WCAG AA for normal text. The indigo
+  family originally proposed was rejected on measurement — it sits 11.3
+  CIEDE2000 units from the existing object-property violet (10.7 under
+  simulated deuteranopia); blue keeps 15.3 / 17.7 / 21.3 (normal /
+  deuteranopia / protanopia). Its weakest axis is tritanopia at 6.0 against
+  the instance emerald, where the badge's text label carries the category
+
+### Changed
+- **Breaking (JSON output):** `skos:Concept` and `skos:ConceptScheme` subjects
+  have left the `instances` array for new top-level `concepts` and
+  `concept_schemes` arrays, mirroring what v0.5.0 did for shapes. The
+  `statistics` block gains `concepts` and `concept_schemes` counts. Consumers
+  reading `instances` for SKOS entities must read the new arrays
+- A subject typed both `skos:Concept` and `owl:Class` (or a property, or a
+  SHACL shape) keeps its existing page and does not gain a second one: classes,
+  properties and shapes outrank SKOS in routing. It remains listed as a member
+  of its scheme, cross-linked to the page it does have
+
 ## [0.5.0] - 2026-08-22
 
 ### Added

--- a/docs/user_guides/DOCS_GUIDE.md
+++ b/docs/user_guides/DOCS_GUIDE.md
@@ -97,7 +97,9 @@ The top-level shape of `index.json` is:
     "datatype_properties": 5,
     "annotation_properties": 2,
     "instances": 3,
-    "shapes": 4
+    "shapes": 4,
+    "concepts": 7,
+    "concept_schemes": 2
   },
   "classes":               [{ "uri": "...", "qname": "...", "label": "..." }, ...],
   "object_properties":     [{ "uri": "...", "qname": "...", "label": "..." }, ...],
@@ -105,14 +107,18 @@ The top-level shape of `index.json` is:
   "annotation_properties": [{ "uri": "...", "qname": "...", "label": "..." }, ...],
   "instances":             [{ "uri": "...", "qname": "...", "label": "..." }, ...],
   "shapes":                [{ "uri": "...", "qname": "...", "label": "...",
-                              "kinds": ["shape", "node_shape"] }, ...]
+                              "kinds": ["shape", "node_shape"] }, ...],
+  "concepts":              [{ "uri": "...", "qname": "...", "label": "...",
+                              "kinds": ["skos_concept"] }, ...],
+  "concept_schemes":       [{ "uri": "...", "qname": "...", "label": "...",
+                              "kinds": ["skos_concept_scheme"] }, ...]
 }
 ```
 
 Each entity also gets a full per-page JSON file under its type directory
 (`classes/`, `properties/object/`, `properties/datatype/`,
-`properties/annotation/`, `instances/`, or `shapes/`). Per-page files
-contain the complete entity record including all fields.
+`properties/annotation/`, `instances/`, `shapes/`, or `concepts/`).
+Per-page files contain the complete entity record including all fields.
 
 > **Breaking change in v0.5.0.** SHACL shapes
 > (`sh:NodeShape` / `sh:PropertyShape` instances) used to appear in the
@@ -120,6 +126,13 @@ contain the complete entity record including all fields.
 > v0.5.0 introduces a top-level `shapes` array; shapes no longer appear
 > in `instances`. JSON consumers updating from v0.4.x must read both
 > arrays. See "SHACL Shapes" below for the per-page schema.
+
+> **Breaking change in v0.6.0.** SKOS concepts and concept schemes
+> (`skos:Concept` / `skos:ConceptScheme`) used to appear in the
+> `instances` array for the same reason. v0.6.0 introduces top-level
+> `concepts` and `concept_schemes` arrays; neither appears in
+> `instances` any more. See "SKOS Vocabularies" below for the per-page
+> schema.
 
 ## SHACL Shapes
 
@@ -219,6 +232,125 @@ Schema notes:
   SHACL predicate not in the first-class set. Order is the order in
   which the predicates were encountered.
 
+## SKOS Vocabularies
+
+`rdf-construct docs` recognises `skos:Concept` and `skos:ConceptScheme`
+as a first-class entity type, so a controlled vocabulary documents as a
+vocabulary rather than as a heap of generic instances. Concepts and
+schemes share the `concepts/` directory and are told apart by their kind
+badges (`skos concept`, `skos concept scheme`) — the same arrangement
+NodeShapes and PropertyShapes have in `shapes/`.
+
+Each concept page carries:
+
+- **Labels grouped by language.** One row per language tag, with
+  `skos:prefLabel`, `skos:altLabel` and `skos:hiddenLabel` side by side,
+  so "what does this look like in French" is one line rather than a
+  scatter of duplicate triples.
+- **Semantic relations.** `skos:broader`, `skos:narrower` and
+  `skos:related`, rendered as cross-links.
+- **Scheme membership.** `skos:inScheme` and `skos:topConceptOf`, linking
+  to the scheme page; the scheme page lists its members in return.
+- **All seven SKOS documentation properties** — `skos:definition`,
+  `skos:scopeNote`, `skos:example`, `skos:note`, `skos:historyNote`,
+  `skos:editorialNote` and `skos:changeNote` — each keeping its language
+  tag.
+- **Anything else asserted about the concept**, including mappings such
+  as `skos:exactMatch`, in a visible key-value fallback rather than being
+  dropped.
+
+The scheme page additionally carries the vocabulary's
+`skos:broader`/`skos:narrower` tree.
+
+### What the renderer infers, and what it does not
+
+- **`skos:broader` and `skos:narrower` are treated as inverses**, because
+  SKOS declares them to be. A vocabulary that only ever asserts one
+  direction still documents both, and the hierarchy is the same either
+  way. `skos:related` is likewise treated as symmetric, and
+  `skos:topConceptOf` as implying `skos:inScheme` (it is a sub-property
+  of it).
+- **`skos:broader` is not `rdfs:subClassOf`.** It renders as a tree
+  because that is how vocabularies are navigated, not because a concept
+  hierarchy is a class hierarchy; nothing is inherited along it.
+- **Cycles are tolerated.** SKOS does not promise an acyclic hierarchy.
+  The tree walker will not expand a concept twice on one path, and any
+  concept a cycle leaves unreachable is promoted to a root of its own
+  rather than disappearing.
+- **A concept in no scheme is still documented.** It appears in the index
+  and gets its own page; only the per-scheme tree needs a scheme.
+
+### Punning: a subject that is a concept *and* something else
+
+Classes, properties and SHACL shapes outrank SKOS in routing, so a
+subject typed both `owl:Class` and `skos:Concept` keeps its class page
+and does not get a second page under `concepts/`. It stays visible in
+its scheme's member list, which links to the class page. A concept that
+is also `owl:NamedIndividual` routes to `concepts/`.
+
+### Concept JSON schema
+
+```json
+{
+  "uri": "http://example.org/vocab#Building",
+  "qname": "ex:Building",
+  "kinds": ["skos_concept"],
+  "label": "Building",
+  "definition": "A permanent, roofed construction intended for occupation.",
+  "labels": [
+    { "language": "en", "preferred": ["Building"],
+      "alternative": ["Structure"], "hidden": ["buildin"] },
+    { "language": "fr", "preferred": ["Bâtiment"],
+      "alternative": ["Édifice"], "hidden": [] }
+  ],
+  "notes": {
+    "definition": [
+      { "text": "A permanent, roofed construction...", "language": "en" },
+      { "text": "Construction permanente et couverte...", "language": "fr" }
+    ],
+    "scopeNote": [{ "text": "Excludes temporary structures.", "language": "en" }]
+  },
+  "broader":        [],
+  "narrower":       ["http://example.org/vocab#Dwelling"],
+  "related":        [],
+  "in_schemes":     ["http://example.org/vocab#BuildingScheme"],
+  "top_concept_of": ["http://example.org/vocab#BuildingScheme"],
+  "types":          ["http://www.w3.org/2004/02/skos/core#Concept"],
+  "properties":     {},
+  "annotations":    {}
+}
+```
+
+A concept scheme entry carries `labels`, `notes`, `top_concepts`,
+`concepts` (its members) and — in the per-page file only — `hierarchy`,
+the nested broader/narrower tree, so a consumer does not have to rebuild
+it:
+
+```json
+{
+  "qname": "ex:BuildingScheme",
+  "kinds": ["skos_concept_scheme"],
+  "top_concepts": ["http://example.org/vocab#Building"],
+  "concepts": ["http://example.org/vocab#Building", "..."],
+  "hierarchy": [
+    { "uri": "...", "qname": "ex:Building", "label": "Building",
+      "children": [{ "qname": "ex:Dwelling", "children": [] }] }
+  ]
+}
+```
+
+Schema notes:
+
+- An untagged literal appears under `"language": ""` rather than being
+  dropped.
+- `broader` and `narrower` include inverse-derived neighbours, as
+  described above.
+- `notes` keys are the SKOS property local names.
+
+Not covered: `skos:Collection` / `skos:OrderedCollection` and SKOS-XL
+(`skosxl:Label`). Both fall through to their existing treatment; file an
+issue if a real vocabulary needs them.
+
 ## Command Options
 
 ```bash
@@ -237,6 +369,7 @@ rdf-construct docs [OPTIONS] SOURCES...
 | `--no-search` | Disable search index (HTML only) |
 | `--no-instances` | Exclude instances from output |
 | `--no-shapes` | Exclude SHACL shapes from output |
+| `--no-skos` | Exclude SKOS concepts and concept schemes from output |
 | `--include TYPES` | Include only these types (comma-separated) |
 | `--exclude TYPES` | Exclude these types (comma-separated) |
 
@@ -253,9 +386,15 @@ poetry run rdf-construct docs ontology.ttl --include classes
 
 # Classes and shapes only
 poetry run rdf-construct docs ontology.ttl --include classes,shapes
+
+# A vocabulary's SKOS entities only
+poetry run rdf-construct docs vocabulary.ttl --include concepts
 ```
 
-Valid type names: `classes`, `properties`, `object_properties`, `datatype_properties`, `annotation_properties`, `instances`, `shapes`
+Valid type names: `classes`, `properties`, `object_properties`, `datatype_properties`, `annotation_properties`, `instances`, `shapes`, `concepts`
+
+`concepts` covers both SKOS kinds — concepts and concept schemes are one
+toggle. `concept_schemes` and `skos` are accepted as spellings of it.
 
 ## Configuration File
 
@@ -274,6 +413,7 @@ include_datatype_properties: true
 include_annotation_properties: false
 include_instances: true
 include_shapes: true
+include_skos: true
 
 include_search: true
 include_hierarchy: true

--- a/src/rdf_construct/cli.py
+++ b/src/rdf_construct/cli.py
@@ -1193,14 +1193,25 @@ def diff(
     help="Exclude SHACL shapes from documentation",
 )
 @click.option(
+    "--no-skos",
+    is_flag=True,
+    help="Exclude SKOS concepts and concept schemes from documentation",
+)
+@click.option(
     "--include",
     type=str,
-    help="Include only these entity types (comma-separated: classes,properties,instances,shapes)",
+    help=(
+        "Include only these entity types "
+        "(comma-separated: classes,properties,instances,shapes,concepts)"
+    ),
 )
 @click.option(
     "--exclude",
     type=str,
-    help="Exclude these entity types (comma-separated: classes,properties,instances,shapes)",
+    help=(
+        "Exclude these entity types "
+        "(comma-separated: classes,properties,instances,shapes,concepts)"
+    ),
 )
 def docs(
     sources: tuple[Path, ...],
@@ -1213,6 +1224,7 @@ def docs(
     no_search: bool,
     no_instances: bool,
     no_shapes: bool,
+    no_skos: bool,
     include: str | None,
     exclude: str | None,
 ):
@@ -1263,6 +1275,7 @@ def docs(
     doc_config.include_search = not no_search
     doc_config.include_instances = not no_instances
     doc_config.include_shapes = not no_shapes
+    doc_config.include_skos = not no_skos
 
     if template:
         doc_config.template_dir = template
@@ -1282,6 +1295,9 @@ def docs(
         )
         doc_config.include_instances = "instances" in types
         doc_config.include_shapes = "shapes" in types
+        # One toggle covers both SKOS kinds; "concepts", "concept_schemes"
+        # and "skos" are accepted spellings of it.
+        doc_config.include_skos = any(t in types for t in ("concepts", "concept_schemes", "skos"))
 
     if exclude:
         types = [t.strip().lower() for t in exclude.split(",")]
@@ -1295,6 +1311,8 @@ def docs(
             doc_config.include_instances = False
         if "shapes" in types:
             doc_config.include_shapes = False
+        if any(t in types for t in ("concepts", "concept_schemes", "skos")):
+            doc_config.include_skos = False
 
     # Load RDF sources
     click.echo(f"Loading {len(sources)} source file(s)...")
@@ -1336,6 +1354,11 @@ def docs(
     click.echo(f"  Classes: {result.classes_count}")
     click.echo(f"  Properties: {result.properties_count}")
     click.echo(f"  Instances: {result.instances_count}")
+    if result.shapes_count:
+        click.echo(f"  Shapes: {result.shapes_count}")
+    if result.concepts_count or result.concept_schemes_count:
+        click.echo(f"  Concepts: {result.concepts_count}")
+        click.echo(f"  Concept schemes: {result.concept_schemes_count}")
 
     # Show entry point
     if doc_config.format == "html":

--- a/src/rdf_construct/docs/__init__.py
+++ b/src/rdf_construct/docs/__init__.py
@@ -29,13 +29,19 @@ For more control, use the DocsGenerator class directly:
 from rdf_construct.docs.config import DocsConfig, load_docs_config
 from rdf_construct.docs.extractors import (
     ClassInfo,
+    ConceptInfo,
+    ConceptNode,
+    ConceptSchemeInfo,
     EntityKind,
     ExtractedEntities,
     InstanceInfo,
+    LabelGroup,
+    NoteValue,
     OntologyInfo,
     PropertyInfo,
     PropertyShapeInfo,
     ShapeInfo,
+    build_concept_tree,
     extract_all,
 )
 from rdf_construct.docs.generator import DocsGenerator, GenerationResult, generate_docs
@@ -57,9 +63,15 @@ __all__ = [
     "ExtractedEntities",
     "ShapeInfo",
     "PropertyShapeInfo",
+    "ConceptInfo",
+    "ConceptSchemeInfo",
+    "ConceptNode",
+    "LabelGroup",
+    "NoteValue",
     "EntityKind",
     # Extraction
     "extract_all",
+    "build_concept_tree",
     # Search
     "SearchEntry",
     "generate_search_index",

--- a/src/rdf_construct/docs/config.py
+++ b/src/rdf_construct/docs/config.py
@@ -25,6 +25,10 @@ class DocsConfig:
             named PropertyShapes) as a first-class entity type. Default
             True. When False, shapes are excluded entirely from output
             and from the search index.
+        include_skos: Whether to include SKOS concepts and concept schemes
+            as a first-class entity type. Default True. When False, both
+            are excluded entirely from output and from the search index —
+            they do not fall back to the Instances section.
         include_imports: List of namespaces to treat as "internal".
         exclude_namespaces: List of namespaces to exclude from output.
         language: Preferred language for labels/definitions.
@@ -44,6 +48,7 @@ class DocsConfig:
     single_page: bool = False
     include_instances: bool = True
     include_shapes: bool = True
+    include_skos: bool = True
     include_imports: list[str] = field(default_factory=list)
     exclude_namespaces: list[str] = field(default_factory=list)
     language: str = "en"
@@ -88,6 +93,8 @@ class DocsConfig:
             config.include_instances = data["include_instances"]
         if "include_shapes" in data:
             config.include_shapes = data["include_shapes"]
+        if "include_skos" in data:
+            config.include_skos = data["include_skos"]
         if "include_imports" in data:
             config.include_imports = data["include_imports"]
         if "exclude_namespaces" in data:
@@ -196,7 +203,8 @@ def entity_to_path(
         qname: Entity qualified name.
         entity_type: Type of entity. Accepts ``"class"``,
             ``"object_property"``, ``"datatype_property"``,
-            ``"annotation_property"``, ``"instance"``, or ``"shape"``.
+            ``"annotation_property"``, ``"instance"``, ``"shape"``,
+            ``"skos_concept"`` or ``"skos_concept_scheme"``.
             ``EntityKind`` members are also accepted directly (they
             compare equal to their string values).
         config: Documentation configuration.
@@ -216,7 +224,10 @@ def entity_to_path(
 
     # Organise by entity type. NodeShapes and named PropertyShapes share
     # the shapes/ directory — the kind badge on the page distinguishes
-    # them. See issue #60.
+    # them. See issue #60. SKOS concepts and concept schemes share
+    # concepts/ on the same principle (#63): a scheme is the container for
+    # a vocabulary, but readers reach it from the index rather than by
+    # browsing a directory of its own.
     type_dirs = {
         "class": "classes",
         "object_property": "properties/object",
@@ -224,6 +235,8 @@ def entity_to_path(
         "annotation_property": "properties/annotation",
         "instance": "instances",
         "shape": "shapes",
+        "skos_concept": "concepts",
+        "skos_concept_scheme": "concepts",
     }
 
     subdir = type_dirs.get(entity_type, "other")

--- a/src/rdf_construct/docs/extractors.py
+++ b/src/rdf_construct/docs/extractors.py
@@ -13,6 +13,8 @@ from typing import TYPE_CHECKING
 from rdflib import BNode, RDF, RDFS, Literal, URIRef
 from rdflib.namespace import DCTERMS, OWL, SH, SKOS
 
+from rdf_construct.core.vocab import ALL_PROPERTY_TYPES, CLASS_TYPES
+
 if TYPE_CHECKING:
     from rdflib import Graph
 
@@ -52,6 +54,10 @@ class EntityKind(str, Enum):
     NODE_SHAPE = "node_shape"
     PROPERTY_SHAPE = "property_shape"
 
+    # SKOS vocabulary entities (#63)
+    SKOS_CONCEPT = "skos_concept"
+    SKOS_CONCEPT_SCHEME = "skos_concept_scheme"
+
     def __str__(self) -> str:
         # Return the string value so f-strings and Jinja render
         # "shape" rather than "EntityKind.SHAPE". See class docstring.
@@ -70,6 +76,64 @@ DEFINITION_PREDICATES = [
     SKOS.definition,
     DCTERMS.description,
 ]
+
+# Standard annotation predicates extracted for every entity, paired with the
+# name they are grouped under. Module-level so consumers that need to know
+# which predicates are already captured (see ``_other_properties``) can ask
+# rather than reproduce the list.
+ANNOTATION_PREDICATES = [
+    (RDFS.seeAlso, "seeAlso"),
+    (RDFS.isDefinedBy, "isDefinedBy"),
+    (OWL.versionInfo, "versionInfo"),
+    (OWL.deprecated, "deprecated"),
+    (SKOS.example, "example"),
+    (SKOS.note, "note"),
+    (SKOS.historyNote, "historyNote"),
+    (SKOS.editorialNote, "editorialNote"),
+    (SKOS.changeNote, "changeNote"),
+    (SKOS.scopeNote, "scopeNote"),
+    (DCTERMS.creator, "creator"),
+    (DCTERMS.created, "created"),
+    (DCTERMS.modified, "modified"),
+    (DCTERMS.source, "source"),
+]
+
+# SKOS documentation properties, in the order they render on a concept or
+# scheme page (#63). The SKOS spec defines seven; issue #63 lists six,
+# omitting ``skos:changeNote`` — which is rendered here too, since dropping
+# it would lose a value that ``get_annotations`` was already surfacing.
+SKOS_NOTE_PREDICATES: list[tuple[URIRef, str]] = [
+    (SKOS.definition, "definition"),
+    (SKOS.scopeNote, "scopeNote"),
+    (SKOS.example, "example"),
+    (SKOS.note, "note"),
+    (SKOS.historyNote, "historyNote"),
+    (SKOS.editorialNote, "editorialNote"),
+    (SKOS.changeNote, "changeNote"),
+]
+
+# SKOS labelling properties. Values are grouped by language tag rather than
+# by property, so a reader can see one language at a time.
+SKOS_LABEL_PREDICATES: list[tuple[URIRef, str]] = [
+    (SKOS.prefLabel, "preferred"),
+    (SKOS.altLabel, "alternative"),
+    (SKOS.hiddenLabel, "hidden"),
+]
+
+# SKOS predicates rendered structurally on a concept or scheme page. They are
+# excluded from the generic key-value fallback so nothing renders twice.
+SKOS_STRUCTURAL_PREDICATES: frozenset[URIRef] = frozenset(
+    {
+        SKOS.broader,
+        SKOS.narrower,
+        SKOS.related,
+        SKOS.inScheme,
+        SKOS.topConceptOf,
+        SKOS.hasTopConcept,
+    }
+    | {pred for pred, _ in SKOS_NOTE_PREDICATES}
+    | {pred for pred, _ in SKOS_LABEL_PREDICATES}
+)
 
 
 @dataclass
@@ -250,6 +314,106 @@ class ShapeInfo:
     other_constraints: dict[URIRef, list[URIRef | str]] = field(default_factory=dict)
 
 
+@dataclass
+class NoteValue:
+    """A single SKOS documentation-property value and its language tag.
+
+    ``language`` is the empty string for a plain (untagged) literal or for
+    a value that was a resource rather than a literal.
+    """
+
+    text: str
+    language: str = ""
+
+
+@dataclass
+class LabelGroup:
+    """SKOS labels for one language.
+
+    Groups ``skos:prefLabel``, ``skos:altLabel`` and ``skos:hiddenLabel``
+    by language tag rather than by property, so a reader can ask "what does
+    this concept look like in French" and get one row. ``language`` is the
+    empty string for untagged literals.
+    """
+
+    language: str
+    preferred: list[str] = field(default_factory=list)
+    alternative: list[str] = field(default_factory=list)
+    hidden: list[str] = field(default_factory=list)
+
+
+@dataclass
+class ConceptInfo:
+    """Information about a ``skos:Concept`` for documentation.
+
+    ``broader`` and ``narrower`` carry both directions: SKOS declares
+    ``skos:narrower`` to be the inverse of ``skos:broader``, so a
+    vocabulary that asserts only one direction still documents both. See
+    :func:`_related_concepts`.
+
+    ``in_schemes`` likewise includes schemes reached via
+    ``skos:topConceptOf`` (a sub-property of ``skos:inScheme``) and via a
+    scheme's own ``skos:hasTopConcept``.
+    """
+
+    uri: URIRef
+    qname: str
+    kinds: list[EntityKind] = field(default_factory=list)
+    label: str | None = None
+    definition: str | None = None
+
+    # Labels grouped by language, and the seven SKOS note properties.
+    labels: list[LabelGroup] = field(default_factory=list)
+    notes: dict[str, list[NoteValue]] = field(default_factory=dict)
+
+    # Semantic relations and scheme membership
+    broader: list[URIRef] = field(default_factory=list)
+    narrower: list[URIRef] = field(default_factory=list)
+    related: list[URIRef] = field(default_factory=list)
+    in_schemes: list[URIRef] = field(default_factory=list)
+    top_concept_of: list[URIRef] = field(default_factory=list)
+
+    # Everything else asserted about the concept
+    types: list[URIRef] = field(default_factory=list)
+    properties: dict[URIRef, list[str | URIRef]] = field(default_factory=dict)
+    annotations: dict[str, list[str]] = field(default_factory=dict)
+
+
+@dataclass
+class ConceptSchemeInfo:
+    """Information about a ``skos:ConceptScheme`` for documentation.
+
+    ``top_concepts`` merges the scheme's ``skos:hasTopConcept`` arcs with
+    concepts asserting ``skos:topConceptOf`` back at it; ``concepts`` is
+    every member reachable through ``skos:inScheme`` or through being a top
+    concept.
+    """
+
+    uri: URIRef
+    qname: str
+    kinds: list[EntityKind] = field(default_factory=list)
+    label: str | None = None
+    definition: str | None = None
+
+    labels: list[LabelGroup] = field(default_factory=list)
+    notes: dict[str, list[NoteValue]] = field(default_factory=dict)
+
+    top_concepts: list[URIRef] = field(default_factory=list)
+    concepts: list[URIRef] = field(default_factory=list)
+
+    types: list[URIRef] = field(default_factory=list)
+    properties: dict[URIRef, list[str | URIRef]] = field(default_factory=dict)
+    annotations: dict[str, list[str]] = field(default_factory=dict)
+
+
+@dataclass
+class ConceptNode:
+    """One node of a ``skos:broader`` / ``skos:narrower`` hierarchy tree."""
+
+    concept: ConceptInfo
+    children: list["ConceptNode"] = field(default_factory=list)
+
+
 def get_qname(graph: Graph, uri: URIRef) -> str:
     """Get a qualified name (CURIE) for a URI.
 
@@ -329,25 +493,7 @@ def get_annotations(graph: Graph, uri: URIRef) -> dict[str, list[str]]:
     """
     annotations: dict[str, list[str]] = {}
 
-    # Standard annotation predicates to extract
-    annotation_preds = [
-        (RDFS.seeAlso, "seeAlso"),
-        (RDFS.isDefinedBy, "isDefinedBy"),
-        (OWL.versionInfo, "versionInfo"),
-        (OWL.deprecated, "deprecated"),
-        (SKOS.example, "example"),
-        (SKOS.note, "note"),
-        (SKOS.historyNote, "historyNote"),
-        (SKOS.editorialNote, "editorialNote"),
-        (SKOS.changeNote, "changeNote"),
-        (SKOS.scopeNote, "scopeNote"),
-        (DCTERMS.creator, "creator"),
-        (DCTERMS.created, "created"),
-        (DCTERMS.modified, "modified"),
-        (DCTERMS.source, "source"),
-    ]
-
-    for pred, name in annotation_preds:
+    for pred, name in ANNOTATION_PREDICATES:
         values = []
         for obj in graph.objects(uri, pred):
             if isinstance(obj, Literal):
@@ -922,6 +1068,354 @@ def extract_all_shapes(graph: Graph) -> list[ShapeInfo]:
     return shapes
 
 
+def _skos_label_groups(graph: Graph, uri: URIRef) -> list[LabelGroup]:
+    """Group an entity's SKOS labels by language tag.
+
+    Args:
+        graph: RDF graph to query.
+        uri: Concept or scheme URI.
+
+    Returns:
+        One :class:`LabelGroup` per language tag, ordered by tag with
+        untagged literals last.
+    """
+    collected: dict[str, dict[str, list[str]]] = {}
+
+    for pred, slot in SKOS_LABEL_PREDICATES:
+        for obj in graph.objects(uri, pred):
+            if not isinstance(obj, Literal):
+                continue
+            language = obj.language or ""
+            by_slot = collected.setdefault(language, {})
+            by_slot.setdefault(slot, []).append(str(obj))
+
+    # Untagged literals sort last; everything else alphabetically by tag.
+    languages = sorted(collected, key=lambda lang: (lang == "", lang))
+    return [
+        LabelGroup(
+            language=language,
+            preferred=sorted(collected[language].get("preferred", [])),
+            alternative=sorted(collected[language].get("alternative", [])),
+            hidden=sorted(collected[language].get("hidden", [])),
+        )
+        for language in languages
+    ]
+
+
+def _skos_notes(graph: Graph, uri: URIRef) -> dict[str, list[NoteValue]]:
+    """Extract the SKOS documentation properties for an entity.
+
+    Args:
+        graph: RDF graph to query.
+        uri: Concept or scheme URI.
+
+    Returns:
+        Note values keyed by the property's local name, in the order
+        given by ``SKOS_NOTE_PREDICATES``. Resource-valued notes are kept
+        as their URI string rather than dropped.
+    """
+    notes: dict[str, list[NoteValue]] = {}
+
+    for pred, name in SKOS_NOTE_PREDICATES:
+        values: list[NoteValue] = []
+        for obj in graph.objects(uri, pred):
+            if isinstance(obj, Literal):
+                values.append(NoteValue(text=str(obj), language=obj.language or ""))
+            elif isinstance(obj, URIRef):
+                values.append(NoteValue(text=str(obj)))
+        if values:
+            notes[name] = sorted(values, key=lambda value: (value.language, value.text))
+
+    return notes
+
+
+def _other_properties(
+    graph: Graph,
+    uri: URIRef,
+    handled: frozenset[URIRef],
+) -> dict[URIRef, list[str | URIRef]]:
+    """Collect predicates not already rendered by a first-class field.
+
+    Anything a concept or scheme asserts that is neither structural SKOS,
+    nor a label, nor one of the standard annotations lands here so it stays
+    visible rather than being silently dropped — the same posture the SHACL
+    renderer takes with long-tail constraints.
+
+    Args:
+        graph: RDF graph to query.
+        uri: Entity URI.
+        handled: Predicates already rendered elsewhere on the page.
+
+    Returns:
+        Raw object terms keyed by predicate URI.
+    """
+    captured = (
+        handled
+        | {pred for pred, _ in ANNOTATION_PREDICATES}
+        | {RDF.type, RDFS.label, RDFS.comment, DCTERMS.title, DCTERMS.description}
+    )
+
+    properties: dict[URIRef, list[str | URIRef]] = {}
+    for pred, obj in graph.predicate_objects(uri):
+        if not isinstance(pred, URIRef) or pred in captured:
+            continue
+        if isinstance(obj, Literal):
+            properties.setdefault(pred, []).append(str(obj))
+        elif isinstance(obj, URIRef):
+            properties.setdefault(pred, []).append(obj)
+
+    return properties
+
+
+def _related_concepts(
+    graph: Graph,
+    uri: URIRef,
+    forward: URIRef,
+    inverse: URIRef,
+) -> list[URIRef]:
+    """Collect concepts related to ``uri``, in both assertion directions.
+
+    SKOS declares ``skos:broader`` and ``skos:narrower`` to be inverses of
+    one another, so a vocabulary that only ever writes ``skos:narrower``
+    still has to produce a broader link on the child's page. Materialising
+    the inverse here means the hierarchy is complete whichever direction
+    the author chose.
+
+    Args:
+        graph: RDF graph to query.
+        uri: Concept URI.
+        forward: Predicate asserted on this concept.
+        inverse: Predicate asserted on the other concept, pointing back.
+
+    Returns:
+        Sorted, de-duplicated concept URIs.
+    """
+    found: set[URIRef] = {obj for obj in graph.objects(uri, forward) if isinstance(obj, URIRef)}
+    found |= {subj for subj in graph.subjects(inverse, uri) if isinstance(subj, URIRef)}
+    return sorted(found)
+
+
+def extract_concept_info(graph: Graph, uri: URIRef) -> ConceptInfo:
+    """Extract comprehensive information about a SKOS concept.
+
+    Args:
+        graph: RDF graph to query.
+        uri: Concept URI to extract info for.
+
+    Returns:
+        ConceptInfo with all available metadata.
+    """
+    info = ConceptInfo(
+        uri=uri,
+        qname=get_qname(graph, uri),
+        kinds=[EntityKind.SKOS_CONCEPT],
+        label=get_label(graph, uri),
+        definition=get_definition(graph, uri),
+        labels=_skos_label_groups(graph, uri),
+        notes=_skos_notes(graph, uri),
+        annotations=get_annotations(graph, uri),
+    )
+
+    # The SKOS notes are rendered from `notes`, with their language tags.
+    # Drop the copies get_annotations() collected so they render once.
+    for _, name in SKOS_NOTE_PREDICATES:
+        info.annotations.pop(name, None)
+
+    info.broader = _related_concepts(graph, uri, SKOS.broader, SKOS.narrower)
+    info.narrower = _related_concepts(graph, uri, SKOS.narrower, SKOS.broader)
+    # skos:related is symmetric, so both directions count.
+    info.related = _related_concepts(graph, uri, SKOS.related, SKOS.related)
+    info.top_concept_of = _related_concepts(graph, uri, SKOS.topConceptOf, SKOS.hasTopConcept)
+
+    # skos:topConceptOf is a sub-property of skos:inScheme, so a top concept
+    # belongs to its scheme even without an explicit inScheme triple.
+    schemes: set[URIRef] = {
+        obj for obj in graph.objects(uri, SKOS.inScheme) if isinstance(obj, URIRef)
+    }
+    schemes |= set(info.top_concept_of)
+    info.in_schemes = sorted(schemes)
+
+    for obj in graph.objects(uri, RDF.type):
+        if isinstance(obj, URIRef):
+            info.types.append(obj)
+
+    info.properties = _other_properties(graph, uri, SKOS_STRUCTURAL_PREDICATES)
+
+    return info
+
+
+def extract_concept_scheme_info(graph: Graph, uri: URIRef) -> ConceptSchemeInfo:
+    """Extract comprehensive information about a SKOS concept scheme.
+
+    Args:
+        graph: RDF graph to query.
+        uri: Concept scheme URI to extract info for.
+
+    Returns:
+        ConceptSchemeInfo with all available metadata.
+    """
+    info = ConceptSchemeInfo(
+        uri=uri,
+        qname=get_qname(graph, uri),
+        kinds=[EntityKind.SKOS_CONCEPT_SCHEME],
+        label=get_label(graph, uri),
+        definition=get_definition(graph, uri),
+        labels=_skos_label_groups(graph, uri),
+        notes=_skos_notes(graph, uri),
+        annotations=get_annotations(graph, uri),
+    )
+
+    for _, name in SKOS_NOTE_PREDICATES:
+        info.annotations.pop(name, None)
+
+    info.top_concepts = _related_concepts(graph, uri, SKOS.hasTopConcept, SKOS.topConceptOf)
+
+    members: set[URIRef] = {
+        subj for subj in graph.subjects(SKOS.inScheme, uri) if isinstance(subj, URIRef)
+    }
+    members |= set(info.top_concepts)
+    info.concepts = sorted(members)
+
+    for obj in graph.objects(uri, RDF.type):
+        if isinstance(obj, URIRef):
+            info.types.append(obj)
+
+    info.properties = _other_properties(graph, uri, SKOS_STRUCTURAL_PREDICATES)
+
+    return info
+
+
+def _claimed_by_other_buckets(graph: Graph) -> set[URIRef]:
+    """Collect subjects that classes, properties or shapes already document.
+
+    SKOS entities sit between shapes and plain instances in the routing
+    order, so a subject that is also a class, a property or a SHACL shape
+    keeps the page it already had rather than gaining a second one. The
+    type sets come from :mod:`rdf_construct.core.vocab` — a term declared
+    only by an OWL characteristic is still a property.
+
+    Args:
+        graph: RDF graph to query.
+
+    Returns:
+        Set of URIs owned by a higher-priority bucket.
+    """
+    claimed: set[URIRef] = set()
+    higher_priority_types = (
+        set(CLASS_TYPES) | set(ALL_PROPERTY_TYPES) | {SH.NodeShape, SH.PropertyShape}
+    )
+    for type_uri in higher_priority_types:
+        for subj in graph.subjects(RDF.type, type_uri):
+            if isinstance(subj, URIRef):
+                claimed.add(subj)
+    return claimed
+
+
+def extract_all_concepts(graph: Graph) -> list[ConceptInfo]:
+    """Extract information for all SKOS concepts in the graph.
+
+    Subjects already documented as a class, property or SHACL shape are
+    skipped — SKOS/OWL punning is legal, and documenting the same subject
+    twice serves nobody. See :func:`_claimed_by_other_buckets`.
+
+    Args:
+        graph: RDF graph to query.
+
+    Returns:
+        List of ConceptInfo objects, sorted by qname.
+    """
+    claimed = _claimed_by_other_buckets(graph)
+
+    concepts = []
+    seen: set[URIRef] = set()
+    for uri in graph.subjects(RDF.type, SKOS.Concept):
+        if isinstance(uri, URIRef) and uri not in seen and uri not in claimed:
+            seen.add(uri)
+            concepts.append(extract_concept_info(graph, uri))
+
+    concepts.sort(key=lambda c: c.qname)
+    return concepts
+
+
+def extract_all_concept_schemes(graph: Graph) -> list[ConceptSchemeInfo]:
+    """Extract information for all SKOS concept schemes in the graph.
+
+    Args:
+        graph: RDF graph to query.
+
+    Returns:
+        List of ConceptSchemeInfo objects, sorted by qname.
+    """
+    claimed = _claimed_by_other_buckets(graph)
+
+    schemes = []
+    seen: set[URIRef] = set()
+    for uri in graph.subjects(RDF.type, SKOS.ConceptScheme):
+        if isinstance(uri, URIRef) and uri not in seen and uri not in claimed:
+            seen.add(uri)
+            schemes.append(extract_concept_scheme_info(graph, uri))
+
+    schemes.sort(key=lambda s: s.qname)
+    return schemes
+
+
+def build_concept_tree(
+    concepts: list[ConceptInfo],
+    scheme: URIRef | None = None,
+) -> list[ConceptNode]:
+    """Build a ``skos:broader`` / ``skos:narrower`` tree.
+
+    SKOS does not promise an acyclic hierarchy, and a cycle would leave no
+    concept without an internal parent — so the walker (a) refuses to
+    revisit a concept already on the current path, and (b) promotes any
+    concept the roots could not reach to a root of its own. A cyclic
+    vocabulary therefore renders in full rather than either looping
+    forever or silently losing concepts.
+
+    Args:
+        concepts: Concepts to build the tree from.
+        scheme: Restrict to members of this scheme. ``None`` uses every
+            concept given.
+
+    Returns:
+        Root nodes, sorted by qname.
+    """
+    if scheme is not None:
+        members = [c for c in concepts if scheme in c.in_schemes]
+    else:
+        members = list(concepts)
+
+    by_uri = {str(c.uri): c for c in members}
+    visited: set[str] = set()
+
+    def build(concept: ConceptInfo, ancestors: frozenset[str]) -> ConceptNode:
+        visited.add(str(concept.uri))
+        path = ancestors | {str(concept.uri)}
+        children = [
+            build(by_uri[key], path)
+            for key in (str(uri) for uri in concept.narrower)
+            if key in by_uri and key not in path
+        ]
+        children.sort(key=lambda node: node.concept.qname)
+        return ConceptNode(concept=concept, children=children)
+
+    # Declared top concepts anchor the tree; without any, everything with no
+    # parent inside the scheme becomes a root.
+    roots = [c for c in members if scheme is not None and scheme in c.top_concept_of]
+    if not roots:
+        roots = [c for c in members if not any(str(uri) in by_uri for uri in c.broader)]
+
+    nodes = [build(c, frozenset()) for c in sorted(roots, key=lambda c: c.qname)]
+
+    # Anything unreachable from a root — a cycle, or a concept whose only
+    # parents sit in another scheme — still gets rendered.
+    for concept in sorted(members, key=lambda c: c.qname):
+        if str(concept.uri) not in visited:
+            nodes.append(build(concept, frozenset()))
+
+    return nodes
+
+
 def extract_all_classes(graph: Graph) -> list[ClassInfo]:
     """Extract information for all classes in the graph.
 
@@ -1033,10 +1527,27 @@ def extract_all_instances(graph: Graph) -> list[InstanceInfo]:
             if isinstance(uri, URIRef):
                 shape_uris.add(uri)
 
-    # Find all subjects with rdf:type that aren't classes, properties, or shapes
+    # Exclude SKOS concepts and concept schemes (#63) — they have their own
+    # buckets via extract_all_concepts() / extract_all_concept_schemes().
+    # A concept that is also a class, property or shape is not excluded here
+    # because it was never routed to SKOS in the first place: those buckets
+    # outrank SKOS, and the class/property/shape filters above already claim it.
+    skos_uris: set[URIRef] = set()
+    for skos_type in [SKOS.Concept, SKOS.ConceptScheme]:
+        for uri in graph.subjects(RDF.type, skos_type):
+            if isinstance(uri, URIRef):
+                skos_uris.add(uri)
+
+    # Find all subjects with rdf:type that aren't classes, properties, shapes
+    # or SKOS entities
     for subj, _, obj in graph.triples((None, RDF.type, None)):
         if isinstance(subj, URIRef) and subj not in seen:
-            if subj not in class_uris and subj not in property_uris and subj not in shape_uris:
+            if (
+                subj not in class_uris
+                and subj not in property_uris
+                and subj not in shape_uris
+                and subj not in skos_uris
+            ):
                 seen.add(subj)
                 instances.append(extract_instance_info(graph, subj))
 
@@ -1054,6 +1565,8 @@ class ExtractedEntities:
     properties: list[PropertyInfo]
     instances: list[InstanceInfo]
     shapes: list[ShapeInfo] = field(default_factory=list)
+    concepts: list[ConceptInfo] = field(default_factory=list)
+    concept_schemes: list[ConceptSchemeInfo] = field(default_factory=list)
 
     @property
     def object_properties(self) -> list[PropertyInfo]:
@@ -1093,7 +1606,7 @@ def extract_all(graph: Graph) -> ExtractedEntities:
 
     Returns:
         ExtractedEntities containing all classes, properties, instances,
-        and SHACL shapes.
+        SHACL shapes, SKOS concepts and SKOS concept schemes.
     """
     return ExtractedEntities(
         ontology=extract_ontology_info(graph),
@@ -1101,4 +1614,6 @@ def extract_all(graph: Graph) -> ExtractedEntities:
         properties=extract_all_properties(graph),
         instances=extract_all_instances(graph),
         shapes=extract_all_shapes(graph),
+        concepts=extract_all_concepts(graph),
+        concept_schemes=extract_all_concept_schemes(graph),
     )

--- a/src/rdf_construct/docs/generator.py
+++ b/src/rdf_construct/docs/generator.py
@@ -16,7 +16,16 @@ from rdf_construct.docs.extractors import ExtractedEntities, extract_all
 from rdf_construct.docs.search import generate_search_index, write_search_index
 
 if TYPE_CHECKING:
-    pass
+    # BaseRenderer's signatures reference these by name only; without the
+    # import the annotations are unresolvable to a type checker.
+    from rdf_construct.docs.extractors import (
+        ClassInfo,
+        ConceptInfo,
+        ConceptSchemeInfo,
+        InstanceInfo,
+        PropertyInfo,
+        ShapeInfo,
+    )
 
 
 class DocsGenerator:
@@ -146,6 +155,20 @@ class DocsGenerator:
                     result.files_created.append(shape_path)
                     result.shapes_count += 1
 
+            # SKOS vocabulary entities (#63). Concepts and concept schemes
+            # share the concepts/ directory and are told apart by their kind
+            # badges, exactly as NodeShapes and PropertyShapes share shapes/.
+            if self.config.include_skos:
+                for scheme_info in entities.concept_schemes:
+                    scheme_path = self.renderer.render_concept_scheme(scheme_info, entities)
+                    result.files_created.append(scheme_path)
+                    result.concept_schemes_count += 1
+
+                for concept_info in entities.concepts:
+                    concept_path = self.renderer.render_concept(concept_info, entities)
+                    result.files_created.append(concept_path)
+                    result.concepts_count += 1
+
             # Namespace page
             namespace_path = self.renderer.render_namespaces(entities)
             result.files_created.append(namespace_path)
@@ -213,6 +236,8 @@ class GenerationResult:
         self.properties_count = 0
         self.instances_count = 0
         self.shapes_count = 0
+        self.concepts_count = 0
+        self.concept_schemes_count = 0
 
     @property
     def total_pages(self) -> int:
@@ -229,6 +254,10 @@ class GenerationResult:
         ]
         if self.shapes_count > 0:
             lines.append(f"  Shapes: {self.shapes_count}")
+        if self.concepts_count > 0:
+            lines.append(f"  Concepts: {self.concepts_count}")
+        if self.concept_schemes_count > 0:
+            lines.append(f"  Concept schemes: {self.concept_schemes_count}")
         return "\n".join(lines)
 
 
@@ -331,6 +360,41 @@ class BaseRenderer:
 
         Args:
             shape_info: Shape to render.
+            entities: All extracted entities (for cross-references).
+
+        Returns:
+            Path to the rendered file.
+        """
+        raise NotImplementedError
+
+    def render_concept(
+        self,
+        concept_info: "ConceptInfo",
+        entities: ExtractedEntities,
+    ) -> Path:
+        """Render a SKOS concept documentation page.
+
+        Args:
+            concept_info: Concept to render.
+            entities: All extracted entities (for cross-references).
+
+        Returns:
+            Path to the rendered file.
+        """
+        raise NotImplementedError
+
+    def render_concept_scheme(
+        self,
+        scheme_info: "ConceptSchemeInfo",
+        entities: ExtractedEntities,
+    ) -> Path:
+        """Render a SKOS concept scheme documentation page.
+
+        The scheme page carries the vocabulary's broader/narrower tree;
+        individual concept pages carry inline neighbours. See issue #63.
+
+        Args:
+            scheme_info: Concept scheme to render.
             entities: All extracted entities (for cross-references).
 
         Returns:

--- a/src/rdf_construct/docs/renderers/html.py
+++ b/src/rdf_construct/docs/renderers/html.py
@@ -39,6 +39,11 @@ class HTMLRenderer:
         # that resolve correctly from the page's own location when no
         # absolute `config.base_url` is set. See issue #59.
         self._current_page: Path | None = None
+        # Cached URI -> link-pieces index; see `_reference_index`. Keyed by
+        # the identity of the entity set it was built from so a second
+        # generate() on the same renderer cannot serve a stale index.
+        self._ref_index: dict[str, dict[str, Any]] | None = None
+        self._ref_index_for: "ExtractedEntities | None" = None
 
     @property
     def env(self) -> Environment:
@@ -181,6 +186,56 @@ class HTMLRenderer:
             **extra,
         }
 
+    def _reference_index(
+        self,
+        entities: "ExtractedEntities",
+    ) -> dict[str, dict[str, Any]]:
+        """Build (once) a URI -> link-pieces index for cross-referencing.
+
+        Built once per set of extracted entities and cached on the
+        renderer, rather than scanning every bucket for every reference:
+        a vocabulary with a few thousand concepts renders several
+        references per page, and the linear form is quadratic in the size
+        of the ontology.
+
+        Later buckets do not overwrite earlier ones, which is what
+        encodes the routing order — a subject documented as a class links
+        to its class page even when it is also a concept.
+
+        Args:
+            entities: All extracted entities.
+
+        Returns:
+            Mapping of URI string to ``label`` / ``qname`` /
+            ``entity_type`` dicts.
+        """
+        if self._ref_index is not None and self._ref_index_for is entities:
+            return self._ref_index
+
+        index: dict[str, dict[str, Any]] = {}
+
+        def add(uri: Any, label: str | None, qname: str, entity_type: str) -> None:
+            key = str(uri)
+            if key not in index:
+                index[key] = {"label": label or qname, "qname": qname, "entity_type": entity_type}
+
+        for class_info in entities.classes:
+            add(class_info.uri, class_info.label, class_info.qname, "class")
+        for prop in entities.properties:
+            add(prop.uri, prop.label, prop.qname, f"{prop.property_type}_property")
+        for shape in entities.shapes:
+            add(shape.uri, shape.label, shape.qname, "shape")
+        for scheme in entities.concept_schemes:
+            add(scheme.uri, scheme.label, scheme.qname, "skos_concept_scheme")
+        for concept in entities.concepts:
+            add(concept.uri, concept.label, concept.qname, "skos_concept")
+        for instance in entities.instances:
+            add(instance.uri, instance.label, instance.qname, "instance")
+
+        self._ref_index = index
+        self._ref_index_for = entities
+        return index
+
     def _entity_reference(
         self,
         uri: "URIRef | str",
@@ -203,50 +258,9 @@ class HTMLRenderer:
             Dict with ``label``, ``qname`` and ``entity_type`` keys.
         """
         uri_str = str(uri)
-
-        for concept in entities.concepts:
-            if str(concept.uri) == uri_str:
-                return {
-                    "label": concept.label or concept.qname,
-                    "qname": concept.qname,
-                    "entity_type": "skos_concept",
-                }
-        for scheme in entities.concept_schemes:
-            if str(scheme.uri) == uri_str:
-                return {
-                    "label": scheme.label or scheme.qname,
-                    "qname": scheme.qname,
-                    "entity_type": "skos_concept_scheme",
-                }
-        for class_info in entities.classes:
-            if str(class_info.uri) == uri_str:
-                return {
-                    "label": class_info.label or class_info.qname,
-                    "qname": class_info.qname,
-                    "entity_type": "class",
-                }
-        for prop in entities.properties:
-            if str(prop.uri) == uri_str:
-                return {
-                    "label": prop.label or prop.qname,
-                    "qname": prop.qname,
-                    "entity_type": f"{prop.property_type}_property",
-                }
-        for instance in entities.instances:
-            if str(instance.uri) == uri_str:
-                return {
-                    "label": instance.label or instance.qname,
-                    "qname": instance.qname,
-                    "entity_type": "instance",
-                }
-        for shape in entities.shapes:
-            if str(shape.uri) == uri_str:
-                return {
-                    "label": shape.label or shape.qname,
-                    "qname": shape.qname,
-                    "entity_type": "shape",
-                }
-
+        resolved = self._reference_index(entities).get(uri_str)
+        if resolved is not None:
+            return resolved
         return {"label": uri_str, "qname": uri_str, "entity_type": None}
 
     def _entity_references(

--- a/src/rdf_construct/docs/renderers/html.py
+++ b/src/rdf_construct/docs/renderers/html.py
@@ -9,9 +9,13 @@ from typing import TYPE_CHECKING, Any
 from jinja2 import Environment, FileSystemLoader, PackageLoader, select_autoescape
 
 if TYPE_CHECKING:
+    from rdflib import URIRef
+
     from ..config import DocsConfig
     from ..extractors import (
         ClassInfo,
+        ConceptInfo,
+        ConceptSchemeInfo,
         ExtractedEntities,
         InstanceInfo,
         PropertyInfo,
@@ -171,9 +175,87 @@ class HTMLRenderer:
             "shapes": entities.shapes,
             "node_shapes": entities.node_shapes,
             "property_shapes": entities.property_shapes,
+            "concepts": entities.concepts,
+            "concept_schemes": entities.concept_schemes,
             "config": self.config,
             **extra,
         }
+
+    def _entity_reference(
+        self,
+        uri: "URIRef | str",
+        entities: "ExtractedEntities",
+    ) -> dict[str, Any]:
+        """Resolve a URI to the pieces a template needs to link to it.
+
+        Returns ``qname`` and ``entity_type`` rather than a finished URL:
+        the ``entity_url`` filter has to run during template rendering, when
+        the renderer knows which page the link is being written on. A URI
+        that belongs to no documented entity comes back with
+        ``entity_type=None`` so the template can fall back to plain text
+        rather than emitting a link to a page that was never generated.
+
+        Args:
+            uri: URI to resolve.
+            entities: All extracted entities.
+
+        Returns:
+            Dict with ``label``, ``qname`` and ``entity_type`` keys.
+        """
+        uri_str = str(uri)
+
+        for concept in entities.concepts:
+            if str(concept.uri) == uri_str:
+                return {
+                    "label": concept.label or concept.qname,
+                    "qname": concept.qname,
+                    "entity_type": "skos_concept",
+                }
+        for scheme in entities.concept_schemes:
+            if str(scheme.uri) == uri_str:
+                return {
+                    "label": scheme.label or scheme.qname,
+                    "qname": scheme.qname,
+                    "entity_type": "skos_concept_scheme",
+                }
+        for class_info in entities.classes:
+            if str(class_info.uri) == uri_str:
+                return {
+                    "label": class_info.label or class_info.qname,
+                    "qname": class_info.qname,
+                    "entity_type": "class",
+                }
+        for prop in entities.properties:
+            if str(prop.uri) == uri_str:
+                return {
+                    "label": prop.label or prop.qname,
+                    "qname": prop.qname,
+                    "entity_type": f"{prop.property_type}_property",
+                }
+        for instance in entities.instances:
+            if str(instance.uri) == uri_str:
+                return {
+                    "label": instance.label or instance.qname,
+                    "qname": instance.qname,
+                    "entity_type": "instance",
+                }
+        for shape in entities.shapes:
+            if str(shape.uri) == uri_str:
+                return {
+                    "label": shape.label or shape.qname,
+                    "qname": shape.qname,
+                    "entity_type": "shape",
+                }
+
+        return {"label": uri_str, "qname": uri_str, "entity_type": None}
+
+    def _entity_references(
+        self,
+        uris: "list[URIRef]",
+        entities: "ExtractedEntities",
+    ) -> list[dict[str, Any]]:
+        """Resolve a list of URIs. See :meth:`_entity_reference`."""
+        return [self._entity_reference(uri, entities) for uri in uris]
 
     def _render_page(
         self,
@@ -430,6 +512,77 @@ class HTMLRenderer:
         rel_path = entity_to_path(shape_info.qname, "shape", self.config)
         return self._render_page("shape.html.jinja", rel_path, context)
 
+    def render_concept(
+        self,
+        concept_info: "ConceptInfo",
+        entities: "ExtractedEntities",
+    ) -> Path:
+        """Render a SKOS concept documentation page.
+
+        Broader, narrower, related and scheme references are resolved to
+        cross-links here rather than in the template, so a reference to a
+        concept that was never documented degrades to plain text instead of
+        a dead link.
+
+        Args:
+            concept_info: Concept to render.
+            entities: All extracted entities (for cross-references).
+
+        Returns:
+            Path to the rendered file.
+        """
+        context = self._build_context(
+            entities,
+            concept_info=concept_info,
+            broader_refs=self._entity_references(concept_info.broader, entities),
+            narrower_refs=self._entity_references(concept_info.narrower, entities),
+            related_refs=self._entity_references(concept_info.related, entities),
+            scheme_refs=self._entity_references(concept_info.in_schemes, entities),
+            top_concept_of_refs=self._entity_references(concept_info.top_concept_of, entities),
+            type_refs=self._entity_references(concept_info.types, entities),
+        )
+
+        from ..config import entity_to_path
+
+        rel_path = entity_to_path(concept_info.qname, "skos_concept", self.config)
+        return self._render_page("concept.html.jinja", rel_path, context)
+
+    def render_concept_scheme(
+        self,
+        scheme_info: "ConceptSchemeInfo",
+        entities: "ExtractedEntities",
+    ) -> Path:
+        """Render a SKOS concept scheme documentation page.
+
+        Carries the scheme's broader/narrower tree — the natural way to
+        navigate a vocabulary — alongside a flat member list. The tree
+        walker is cycle-safe; see
+        :func:`rdf_construct.docs.extractors.build_concept_tree`.
+
+        Args:
+            scheme_info: Concept scheme to render.
+            entities: All extracted entities (for cross-references).
+
+        Returns:
+            Path to the rendered file.
+        """
+        from ..extractors import build_concept_tree
+
+        tree = build_concept_tree(entities.concepts, scheme_info.uri)
+
+        context = self._build_context(
+            entities,
+            scheme_info=scheme_info,
+            concept_tree=tree,
+            top_concept_refs=self._entity_references(scheme_info.top_concepts, entities),
+            member_refs=self._entity_references(scheme_info.concepts, entities),
+        )
+
+        from ..config import entity_to_path
+
+        rel_path = entity_to_path(scheme_info.qname, "skos_concept_scheme", self.config)
+        return self._render_page("concept_scheme.html.jinja", rel_path, context)
+
     def render_namespaces(self, entities: "ExtractedEntities") -> Path:
         """Render the namespace reference page.
 
@@ -672,6 +825,45 @@ h4 { font-size: 1.1rem; }
 .entity-type.shape { background: #dc2626; }
 .entity-type.node_shape { background: #b91c1c; }
 .entity-type.property_shape { background: #e11d48; }
+
+/* SKOS badges (#63). Blue family, with the scheme darker than the concept
+   so the container reads as the parent — the same gradient the shape
+   family uses. Contrast against the badge's white text:
+     .skos_concept        #1d4ed8   6.70:1
+     .skos_concept_scheme #1e3a8a  10.36:1
+   Both clear WCAG AA for normal text. Blue was measured against the
+   existing badges rather than assumed: the indigo family suggested in
+   #63 sits only 11.3 CIEDE2000 units from the object-property violet
+   (10.7 under simulated deuteranopia), which is too close to call apart,
+   whereas #1d4ed8 keeps 15.3 (17.7 deuteranopia, 21.3 protanopia). Its
+   one weak axis is tritanopia, where it falls to 6.0 against the instance
+   emerald — still distinguishable, and the badge's text label carries the
+   category regardless. */
+.entity-type.skos_concept { background: #1d4ed8; }
+.entity-type.skos_concept_scheme { background: #1e3a8a; }
+
+/* Language tag beside a SKOS label or note value. */
+.lang-tag {
+    font-family: 'SF Mono', Consolas, monospace;
+    font-size: 0.75rem;
+    color: var(--text-muted);
+    border: 1px solid var(--border);
+    border-radius: 0.25rem;
+    padding: 0 0.25rem;
+    margin-left: 0.25rem;
+}
+
+/* Concept hierarchy tree on a scheme page — reuses the class-hierarchy
+   connectors so a vocabulary tree looks like the class tree. */
+.concept-tree {
+    list-style: none;
+    padding-left: 1.5rem;
+}
+
+.concept-tree li {
+    position: relative;
+    padding: 0.25rem 0;
+}
 
 /* PropertyShape constraint table on shape pages. Tighter than the
    default annotations table — the `th` is the constraint name, the

--- a/src/rdf_construct/docs/renderers/json.py
+++ b/src/rdf_construct/docs/renderers/json.py
@@ -10,8 +10,13 @@ if TYPE_CHECKING:
     from ..config import DocsConfig
     from ..extractors import (
         ClassInfo,
+        ConceptInfo,
+        ConceptNode,
+        ConceptSchemeInfo,
         ExtractedEntities,
         InstanceInfo,
+        LabelGroup,
+        NoteValue,
         PropertyInfo,
         PropertyShapeInfo,
         ShapeInfo,
@@ -219,6 +224,112 @@ class JSONRenderer:
             },
         }
 
+    def _label_groups_to_list(self, labels: list["LabelGroup"]) -> list[dict[str, Any]]:
+        """Convert SKOS label groups to a serialisable list.
+
+        One entry per language tag; the untagged group carries an empty
+        ``language`` string rather than being dropped.
+        """
+        return [
+            {
+                "language": group.language,
+                "preferred": list(group.preferred),
+                "alternative": list(group.alternative),
+                "hidden": list(group.hidden),
+            }
+            for group in labels
+        ]
+
+    def _notes_to_dict(
+        self,
+        notes: dict[str, list["NoteValue"]],
+    ) -> dict[str, list[dict[str, str]]]:
+        """Convert SKOS notes to a serialisable mapping.
+
+        Each value keeps its language tag, so a consumer can tell an
+        English scope note from a French one.
+        """
+        return {
+            name: [{"text": value.text, "language": value.language} for value in values]
+            for name, values in notes.items()
+        }
+
+    def _concept_to_dict(self, concept_info: "ConceptInfo") -> dict[str, Any]:
+        """Convert a ConceptInfo to a dictionary.
+
+        ``broader`` and ``narrower`` carry both asserted and inverse-derived
+        neighbours — SKOS declares the two properties to be inverses, so a
+        consumer sees the same hierarchy whichever direction the source
+        vocabulary asserted.
+
+        Args:
+            concept_info: Concept to convert.
+
+        Returns:
+            Dictionary representation.
+        """
+        properties: dict[str, list[str]] = {}
+        for pred, values in concept_info.properties.items():
+            properties[str(pred)] = [str(v) for v in values]
+
+        return {
+            "uri": str(concept_info.uri),
+            "qname": concept_info.qname,
+            "kinds": [str(k) for k in concept_info.kinds],
+            "label": concept_info.label,
+            "definition": concept_info.definition,
+            "labels": self._label_groups_to_list(concept_info.labels),
+            "notes": self._notes_to_dict(concept_info.notes),
+            "broader": [str(uri) for uri in concept_info.broader],
+            "narrower": [str(uri) for uri in concept_info.narrower],
+            "related": [str(uri) for uri in concept_info.related],
+            "in_schemes": [str(uri) for uri in concept_info.in_schemes],
+            "top_concept_of": [str(uri) for uri in concept_info.top_concept_of],
+            "types": [str(uri) for uri in concept_info.types],
+            "properties": properties,
+            "annotations": concept_info.annotations,
+        }
+
+    def _concept_scheme_to_dict(self, scheme_info: "ConceptSchemeInfo") -> dict[str, Any]:
+        """Convert a ConceptSchemeInfo to a dictionary.
+
+        Args:
+            scheme_info: Concept scheme to convert.
+
+        Returns:
+            Dictionary representation.
+        """
+        properties: dict[str, list[str]] = {}
+        for pred, values in scheme_info.properties.items():
+            properties[str(pred)] = [str(v) for v in values]
+
+        return {
+            "uri": str(scheme_info.uri),
+            "qname": scheme_info.qname,
+            "kinds": [str(k) for k in scheme_info.kinds],
+            "label": scheme_info.label,
+            "definition": scheme_info.definition,
+            "labels": self._label_groups_to_list(scheme_info.labels),
+            "notes": self._notes_to_dict(scheme_info.notes),
+            "top_concepts": [str(uri) for uri in scheme_info.top_concepts],
+            "concepts": [str(uri) for uri in scheme_info.concepts],
+            "types": [str(uri) for uri in scheme_info.types],
+            "properties": properties,
+            "annotations": scheme_info.annotations,
+        }
+
+    def _concept_tree_to_json(self, nodes: list["ConceptNode"]) -> list[dict[str, Any]]:
+        """Convert a concept hierarchy tree to nested dictionaries."""
+        return [
+            {
+                "uri": str(node.concept.uri),
+                "qname": node.concept.qname,
+                "label": node.concept.label,
+                "children": self._concept_tree_to_json(node.children),
+            }
+            for node in nodes
+        ]
+
     def _ontology_to_dict(self, entities: "ExtractedEntities") -> dict[str, Any]:
         """Convert ontology info to a dictionary.
 
@@ -259,6 +370,8 @@ class JSONRenderer:
                 "annotation_properties": len(entities.annotation_properties),
                 "instances": len(entities.instances),
                 "shapes": len(entities.shapes),
+                "concepts": len(entities.concepts),
+                "concept_schemes": len(entities.concept_schemes),
             },
             "classes": [
                 {
@@ -314,6 +427,28 @@ class JSONRenderer:
                     "label": s.label,
                 }
                 for s in entities.shapes
+            ],
+            # Top-level concepts / concept_schemes arrays (#63). Breaking
+            # change from v0.5.x, in the same way the shapes array was in
+            # v0.5.0: SKOS entities used to appear in 'instances' and now
+            # have their own buckets.
+            "concepts": [
+                {
+                    "uri": str(c.uri),
+                    "qname": c.qname,
+                    "kinds": [str(k) for k in c.kinds],
+                    "label": c.label,
+                }
+                for c in entities.concepts
+            ],
+            "concept_schemes": [
+                {
+                    "uri": str(s.uri),
+                    "qname": s.qname,
+                    "kinds": [str(k) for k in s.kinds],
+                    "label": s.label,
+                }
+                for s in entities.concept_schemes
             ],
         }
 
@@ -472,6 +607,60 @@ class JSONRenderer:
         rel_path = entity_to_path(shape_info.qname, "shape", self.config, extension=".json")
         return self._write_json(self.config.output_dir / rel_path, data)
 
+    def render_concept(
+        self,
+        concept_info: "ConceptInfo",
+        entities: "ExtractedEntities",
+    ) -> Path:
+        """Render a SKOS concept as JSON.
+
+        Args:
+            concept_info: Concept to render.
+            entities: All extracted entities.
+
+        Returns:
+            Path to the rendered file.
+        """
+        data = self._concept_to_dict(concept_info)
+
+        from ..config import entity_to_path
+
+        rel_path = entity_to_path(
+            concept_info.qname, "skos_concept", self.config, extension=".json"
+        )
+        return self._write_json(self.config.output_dir / rel_path, data)
+
+    def render_concept_scheme(
+        self,
+        scheme_info: "ConceptSchemeInfo",
+        entities: "ExtractedEntities",
+    ) -> Path:
+        """Render a SKOS concept scheme as JSON.
+
+        The scheme's cycle-safe broader/narrower tree is included as
+        ``hierarchy`` so a consumer does not have to rebuild it.
+
+        Args:
+            scheme_info: Concept scheme to render.
+            entities: All extracted entities.
+
+        Returns:
+            Path to the rendered file.
+        """
+        from ..extractors import build_concept_tree
+
+        data = self._concept_scheme_to_dict(scheme_info)
+        data["hierarchy"] = self._concept_tree_to_json(
+            build_concept_tree(entities.concepts, scheme_info.uri)
+        )
+
+        from ..config import entity_to_path
+
+        rel_path = entity_to_path(
+            scheme_info.qname, "skos_concept_scheme", self.config, extension=".json"
+        )
+        return self._write_json(self.config.output_dir / rel_path, data)
+
     def render_namespaces(self, entities: "ExtractedEntities") -> Path:
         """Render namespaces as JSON.
 
@@ -511,6 +700,9 @@ class JSONRenderer:
             # extractor didn't filter them out. They now have their
             # own top-level array.
             "shapes": [self._shape_to_dict(s) for s in entities.shapes],
+            # SKOS entities left 'instances' for their own arrays in #63.
+            "concepts": [self._concept_to_dict(c) for c in entities.concepts],
+            "concept_schemes": [self._concept_scheme_to_dict(s) for s in entities.concept_schemes],
         }
 
         return self._write_json(self._get_output_path("ontology.json"), data)

--- a/src/rdf_construct/docs/renderers/markdown.py
+++ b/src/rdf_construct/docs/renderers/markdown.py
@@ -9,8 +9,13 @@ if TYPE_CHECKING:
     from ..config import DocsConfig
     from ..extractors import (
         ClassInfo,
+        ConceptInfo,
+        ConceptNode,
+        ConceptSchemeInfo,
         ExtractedEntities,
         InstanceInfo,
+        LabelGroup,
+        NoteValue,
         PropertyInfo,
         PropertyShapeInfo,
         ShapeInfo,
@@ -139,6 +144,10 @@ class MarkdownRenderer:
         lines.append(f"- **Annotation Properties:** {len(entities.annotation_properties)}")
         if entities.shapes and self.config.include_shapes:
             lines.append(f"- **Shapes:** {len(entities.shapes)}")
+        if entities.concepts and self.config.include_skos:
+            lines.append(f"- **Concepts:** {len(entities.concepts)}")
+        if entities.concept_schemes and self.config.include_skos:
+            lines.append(f"- **Concept Schemes:** {len(entities.concept_schemes)}")
         if entities.instances:
             lines.append(f"- **Instances:** {len(entities.instances)}")
         lines.append("")
@@ -195,6 +204,23 @@ class MarkdownRenderer:
                     lines.append(f"- {link} {kind_tags}")
                 else:
                     lines.append(f"- {link}")
+            lines.append("")
+
+        # SKOS vocabulary section (#63). Schemes first — they are the
+        # containers a reader navigates into.
+        if (entities.concepts or entities.concept_schemes) and self.config.include_skos:
+            lines.append("## SKOS Vocabulary")
+            lines.append("")
+            for scheme in entities.concept_schemes:
+                link = self._entity_link(
+                    scheme.qname, "skos_concept_scheme", scheme.label or scheme.qname
+                )
+                lines.append(f"- {link} `skos_concept_scheme`")
+            for concept in entities.concepts:
+                link = self._entity_link(
+                    concept.qname, "skos_concept", concept.label or concept.qname
+                )
+                lines.append(f"- {link} `skos_concept`")
             lines.append("")
 
         content = "\n".join(lines)
@@ -407,6 +433,19 @@ class MarkdownRenderer:
             if str(s.uri) == uri_str:
                 return self._entity_link(s.qname, "shape", s.label or s.qname)
 
+        # Check if it's a known SKOS concept or concept scheme (#63)
+        for concept in entities.concepts:
+            if str(concept.uri) == uri_str:
+                return self._entity_link(
+                    concept.qname, "skos_concept", concept.label or concept.qname
+                )
+
+        for scheme in entities.concept_schemes:
+            if str(scheme.uri) == uri_str:
+                return self._entity_link(
+                    scheme.qname, "skos_concept_scheme", scheme.label or scheme.qname
+                )
+
         # Fall back to extracting local name
         if "#" in uri_str:
             return f"`{uri_str.split('#')[-1]}`"
@@ -567,6 +606,284 @@ class MarkdownRenderer:
         from ..config import entity_to_path
 
         rel_path = entity_to_path(instance_info.qname, "instance", self.config, extension=".md")
+        return self._write_file(self.config.output_dir / rel_path, content)
+
+    def _render_label_table(self, labels: list["LabelGroup"]) -> list[str]:
+        """Render SKOS labels as a language-per-row Markdown table.
+
+        Returns the table's lines, or an empty list when there are no
+        labels (the caller adds surrounding blank lines).
+        """
+        if not labels:
+            return []
+
+        lines = [
+            "| Language | Preferred | Alternative | Hidden |",
+            "| --- | --- | --- | --- |",
+        ]
+        for group in labels:
+            language = group.language or "—"
+            lines.append(
+                f"| `{language}` | {', '.join(group.preferred)} "
+                f"| {', '.join(group.alternative)} | {', '.join(group.hidden)} |"
+            )
+        return lines
+
+    def _render_notes_table(self, notes: dict[str, list["NoteValue"]]) -> list[str]:
+        """Render the SKOS documentation properties as a Markdown table.
+
+        Language tags are kept alongside the value rather than discarded —
+        a French scope note and an English one are different content.
+        """
+        if not notes:
+            return []
+
+        lines = ["| Property | Value |", "| --- | --- |"]
+        for name, values in notes.items():
+            for value in values:
+                text = value.text.replace("|", "\\|")
+                tag = f" _({value.language})_" if value.language else ""
+                lines.append(f"| `skos:{name}` | {text}{tag} |")
+        return lines
+
+    def render_concept(
+        self,
+        concept_info: "ConceptInfo",
+        entities: "ExtractedEntities",
+    ) -> Path:
+        """Render a SKOS concept documentation page.
+
+        Args:
+            concept_info: Concept to render.
+            entities: All extracted entities.
+
+        Returns:
+            Path to the rendered file.
+        """
+        lines = []
+
+        lines.append(
+            self._frontmatter(
+                title=concept_info.label or concept_info.qname,
+                type="skos_concept",
+            )
+        )
+
+        lines.append(f"# {concept_info.label or concept_info.qname}")
+        lines.append("")
+        kind_labels = " ".join(f"`{kind}`" for kind in concept_info.kinds)
+        if kind_labels:
+            lines.append(f"**Kinds:** {kind_labels}")
+            lines.append("")
+        lines.append(f"**URI:** `{concept_info.uri}`")
+        lines.append("")
+
+        if concept_info.definition:
+            lines.append(concept_info.definition)
+            lines.append("")
+
+        label_table = self._render_label_table(concept_info.labels)
+        if label_table:
+            lines.append("## Labels")
+            lines.append("")
+            lines.extend(label_table)
+            lines.append("")
+
+        if concept_info.in_schemes or concept_info.top_concept_of:
+            lines.append("## Schemes")
+            lines.append("")
+            if concept_info.in_schemes:
+                joined = ", ".join(
+                    self._uri_to_display(uri, entities, "skos_concept_scheme")
+                    for uri in concept_info.in_schemes
+                )
+                lines.append(f"- **In scheme:** {joined}")
+            if concept_info.top_concept_of:
+                joined = ", ".join(
+                    self._uri_to_display(uri, entities, "skos_concept_scheme")
+                    for uri in concept_info.top_concept_of
+                )
+                lines.append(f"- **Top concept of:** {joined}")
+            lines.append("")
+
+        relations: list[tuple[str, list]] = []
+        if concept_info.broader:
+            relations.append(("Broader", concept_info.broader))
+        if concept_info.narrower:
+            relations.append(("Narrower", concept_info.narrower))
+        if concept_info.related:
+            relations.append(("Related", concept_info.related))
+        if relations:
+            lines.append("## Semantic Relations")
+            lines.append("")
+            for label, uris in relations:
+                joined = ", ".join(
+                    self._uri_to_display(uri, entities, "skos_concept") for uri in uris
+                )
+                lines.append(f"- **{label}:** {joined}")
+            lines.append("")
+
+        notes_table = self._render_notes_table(concept_info.notes)
+        if notes_table:
+            lines.append("## Notes")
+            lines.append("")
+            lines.extend(notes_table)
+            lines.append("")
+
+        if concept_info.types:
+            lines.append("## Types")
+            lines.append("")
+            for uri in concept_info.types:
+                lines.append(f"- {self._uri_to_display(uri, entities)}")
+            lines.append("")
+
+        # Mappings (skos:exactMatch and friends) and anything else asserted
+        # about the concept — visible rather than dropped.
+        if concept_info.properties:
+            lines.append("## Other Properties")
+            lines.append("")
+            for pred, values in concept_info.properties.items():
+                pred_name = (
+                    str(pred).split("#")[-1] if "#" in str(pred) else str(pred).split("/")[-1]
+                )
+                for value in values:
+                    if isinstance(value, str):
+                        lines.append(f"- **{pred_name}:** {value}")
+                    else:
+                        lines.append(f"- **{pred_name}:** {self._uri_to_display(value, entities)}")
+            lines.append("")
+
+        if concept_info.annotations:
+            lines.append("## Annotations")
+            lines.append("")
+            for name, values in concept_info.annotations.items():
+                for value in values:
+                    lines.append(f"- **{name}:** {value}")
+            lines.append("")
+
+        content = "\n".join(lines)
+        from ..config import entity_to_path
+
+        rel_path = entity_to_path(concept_info.qname, "skos_concept", self.config, extension=".md")
+        return self._write_file(self.config.output_dir / rel_path, content)
+
+    def render_concept_scheme(
+        self,
+        scheme_info: "ConceptSchemeInfo",
+        entities: "ExtractedEntities",
+    ) -> Path:
+        """Render a SKOS concept scheme documentation page.
+
+        Args:
+            scheme_info: Concept scheme to render.
+            entities: All extracted entities.
+
+        Returns:
+            Path to the rendered file.
+        """
+        from ..extractors import build_concept_tree
+
+        lines = []
+
+        lines.append(
+            self._frontmatter(
+                title=scheme_info.label or scheme_info.qname,
+                type="skos_concept_scheme",
+            )
+        )
+
+        lines.append(f"# {scheme_info.label or scheme_info.qname}")
+        lines.append("")
+        kind_labels = " ".join(f"`{kind}`" for kind in scheme_info.kinds)
+        if kind_labels:
+            lines.append(f"**Kinds:** {kind_labels}")
+            lines.append("")
+        lines.append(f"**URI:** `{scheme_info.uri}`")
+        lines.append("")
+
+        if scheme_info.definition:
+            lines.append(scheme_info.definition)
+            lines.append("")
+
+        label_table = self._render_label_table(scheme_info.labels)
+        if label_table:
+            lines.append("## Labels")
+            lines.append("")
+            lines.extend(label_table)
+            lines.append("")
+
+        if scheme_info.top_concepts:
+            lines.append("## Top Concepts")
+            lines.append("")
+            for uri in scheme_info.top_concepts:
+                lines.append(f"- {self._uri_to_display(uri, entities, 'skos_concept')}")
+            lines.append("")
+
+        tree = build_concept_tree(entities.concepts, scheme_info.uri)
+        if tree:
+            lines.append("## Concept Hierarchy")
+            lines.append("")
+
+            def render_tree(nodes: list["ConceptNode"], indent: int = 0) -> None:
+                prefix = "  " * indent
+                for node in nodes:
+                    link = self._entity_link(
+                        node.concept.qname,
+                        "skos_concept",
+                        node.concept.label or node.concept.qname,
+                    )
+                    lines.append(f"{prefix}- {link}")
+                    if node.children:
+                        render_tree(node.children, indent + 1)
+
+            render_tree(tree)
+            lines.append("")
+
+        if scheme_info.concepts:
+            lines.append("## Concepts in this Scheme")
+            lines.append("")
+            for uri in scheme_info.concepts:
+                lines.append(f"- {self._uri_to_display(uri, entities, 'skos_concept')}")
+            lines.append("")
+
+        notes_table = self._render_notes_table(scheme_info.notes)
+        if notes_table:
+            lines.append("## Notes")
+            lines.append("")
+            lines.extend(notes_table)
+            lines.append("")
+
+        if scheme_info.properties:
+            lines.append("## Other Properties")
+            lines.append("")
+            for pred, values in scheme_info.properties.items():
+                pred_name = (
+                    str(pred).split("#")[-1] if "#" in str(pred) else str(pred).split("/")[-1]
+                )
+                for value in values:
+                    if isinstance(value, str):
+                        lines.append(f"- **{pred_name}:** {value}")
+                    else:
+                        lines.append(f"- **{pred_name}:** {self._uri_to_display(value, entities)}")
+            lines.append("")
+
+        if scheme_info.annotations:
+            lines.append("## Annotations")
+            lines.append("")
+            for name, values in scheme_info.annotations.items():
+                for value in values:
+                    lines.append(f"- **{name}:** {value}")
+            lines.append("")
+
+        content = "\n".join(lines)
+        from ..config import entity_to_path
+
+        rel_path = entity_to_path(
+            scheme_info.qname,
+            "skos_concept_scheme",
+            self.config,
+            extension=".md",
+        )
         return self._write_file(self.config.output_dir / rel_path, content)
 
     def _render_property_shape_table(
@@ -835,6 +1152,8 @@ class MarkdownRenderer:
         lines.append("- [Datatype Properties](#datatype-properties)")
         if entities.shapes and self.config.include_shapes:
             lines.append("- [Shapes](#shapes)")
+        if (entities.concepts or entities.concept_schemes) and self.config.include_skos:
+            lines.append("- [SKOS Vocabulary](#skos-vocabulary)")
         lines.append("- [Namespaces](#namespaces)")
         lines.append("")
 
@@ -895,6 +1214,56 @@ class MarkdownRenderer:
                     lines.append("")
                 if "node_shape" in s.kinds and s.properties:
                     lines.append(f"**Property constraints:** {len(s.properties)}")
+                    lines.append("")
+
+        # SKOS vocabulary (#63)
+        if (entities.concepts or entities.concept_schemes) and self.config.include_skos:
+            lines.append("## SKOS Vocabulary")
+            lines.append("")
+            for scheme in entities.concept_schemes:
+                lines.append(f"### {scheme.label or scheme.qname}")
+                lines.append("")
+                lines.append("**Kinds:** `skos_concept_scheme`")
+                lines.append("")
+                lines.append(f"**URI:** `{scheme.uri}`")
+                lines.append("")
+                if scheme.definition:
+                    lines.append(scheme.definition)
+                    lines.append("")
+                if scheme.concepts:
+                    lines.append(f"**Concepts:** {len(scheme.concepts)}")
+                    lines.append("")
+            for concept in entities.concepts:
+                lines.append(f"### {concept.label or concept.qname}")
+                lines.append("")
+                kind_tags = " ".join(f"`{kind}`" for kind in concept.kinds)
+                lines.append(f"**Kinds:** {kind_tags}")
+                lines.append("")
+                lines.append(f"**URI:** `{concept.uri}`")
+                lines.append("")
+                if concept.definition:
+                    lines.append(concept.definition)
+                    lines.append("")
+                if concept.broader:
+                    joined = ", ".join(
+                        self._uri_to_display(uri, entities, "skos_concept")
+                        for uri in concept.broader
+                    )
+                    lines.append(f"**Broader:** {joined}")
+                    lines.append("")
+                if concept.narrower:
+                    joined = ", ".join(
+                        self._uri_to_display(uri, entities, "skos_concept")
+                        for uri in concept.narrower
+                    )
+                    lines.append(f"**Narrower:** {joined}")
+                    lines.append("")
+                if concept.in_schemes:
+                    joined = ", ".join(
+                        self._uri_to_display(uri, entities, "skos_concept_scheme")
+                        for uri in concept.in_schemes
+                    )
+                    lines.append(f"**In scheme:** {joined}")
                     lines.append("")
 
         # Namespaces

--- a/src/rdf_construct/docs/search.py
+++ b/src/rdf_construct/docs/search.py
@@ -12,6 +12,8 @@ if TYPE_CHECKING:
     from rdf_construct.docs.config import DocsConfig
     from rdf_construct.docs.extractors import (
         ClassInfo,
+        ConceptInfo,
+        ConceptSchemeInfo,
         ExtractedEntities,
         InstanceInfo,
         PropertyInfo,
@@ -36,7 +38,7 @@ class SearchEntry:
 
     uri: str
     qname: str
-    entity_type: str  # class, object_property, datatype_property, instance, shape
+    entity_type: str  # class, object_property, instance, shape, skos_concept, ...
     label: str
     keywords: list[str]
     url: str
@@ -359,6 +361,105 @@ def shape_to_search_entry(
     )
 
 
+def concept_to_search_entry(
+    concept_info: "ConceptInfo",
+    config: "DocsConfig",
+) -> SearchEntry:
+    """Convert a ConceptInfo to a SearchEntry.
+
+    Indexes every SKOS label — alternative and hidden labels included,
+    across all languages. Hidden labels exist precisely to catch
+    misspellings in search, so leaving them out would waste the one place
+    they earn their keep.
+
+    Args:
+        concept_info: Concept information.
+        config: Documentation configuration.
+
+    Returns:
+        SearchEntry for the concept.
+    """
+    keywords = []
+
+    if ":" in concept_info.qname:
+        prefix, local = concept_info.qname.split(":", 1)
+        keywords.extend(extract_keywords(local))
+        keywords.append(prefix.lower())
+
+    if concept_info.label:
+        keywords.extend(extract_keywords(concept_info.label))
+    if concept_info.definition:
+        keywords.extend(extract_keywords(concept_info.definition))
+
+    for group in concept_info.labels:
+        for value in group.preferred + group.alternative + group.hidden:
+            keywords.extend(extract_keywords(value))
+        if group.language:
+            keywords.append(group.language.lower())
+
+    keywords.append("concept")
+    keywords.append("skos")
+
+    from .config import entity_to_url
+
+    return SearchEntry(
+        uri=str(concept_info.uri),
+        qname=concept_info.qname,
+        entity_type="skos_concept",
+        label=concept_info.label or concept_info.qname,
+        keywords=list(set(keywords)),
+        url=entity_to_url(concept_info.qname, "skos_concept", config),
+        kinds=[str(k) for k in concept_info.kinds],
+    )
+
+
+def concept_scheme_to_search_entry(
+    scheme_info: "ConceptSchemeInfo",
+    config: "DocsConfig",
+) -> SearchEntry:
+    """Convert a ConceptSchemeInfo to a SearchEntry.
+
+    Args:
+        scheme_info: Concept scheme information.
+        config: Documentation configuration.
+
+    Returns:
+        SearchEntry for the concept scheme.
+    """
+    keywords = []
+
+    if ":" in scheme_info.qname:
+        prefix, local = scheme_info.qname.split(":", 1)
+        keywords.extend(extract_keywords(local))
+        keywords.append(prefix.lower())
+
+    if scheme_info.label:
+        keywords.extend(extract_keywords(scheme_info.label))
+    if scheme_info.definition:
+        keywords.extend(extract_keywords(scheme_info.definition))
+
+    for group in scheme_info.labels:
+        for value in group.preferred + group.alternative + group.hidden:
+            keywords.extend(extract_keywords(value))
+        if group.language:
+            keywords.append(group.language.lower())
+
+    keywords.append("scheme")
+    keywords.append("skos")
+
+    from .config import entity_to_url
+
+    return SearchEntry(
+        uri=str(scheme_info.uri),
+        qname=scheme_info.qname,
+        entity_type="skos_concept_scheme",
+        label=scheme_info.label or scheme_info.qname,
+        keywords=list(set(keywords)),
+        url=entity_to_url(scheme_info.qname, "skos_concept_scheme", config),
+        kinds=[str(k) for k in scheme_info.kinds],
+    )
+
+
 def generate_search_index(
     entities: "ExtractedEntities",
     config: "DocsConfig",
@@ -401,6 +502,13 @@ def generate_search_index(
     if config.include_shapes:
         for shape_info in entities.shapes:
             entries.append(shape_to_search_entry(shape_info, config))
+
+    # SKOS concepts and concept schemes (#63)
+    if config.include_skos:
+        for scheme_info in entities.concept_schemes:
+            entries.append(concept_scheme_to_search_entry(scheme_info, config))
+        for concept_info in entities.concepts:
+            entries.append(concept_to_search_entry(concept_info, config))
 
     return entries
 

--- a/src/rdf_construct/docs/templates/html/concept.html.jinja
+++ b/src/rdf_construct/docs/templates/html/concept.html.jinja
@@ -1,0 +1,176 @@
+{% extends "base.html.jinja" %}
+
+{% block title %}{{ concept_info.label or concept_info.qname }} - {{ ontology.title or "Documentation" }}{% endblock %}
+
+{# Render a list of resolved entity references (see HTMLRenderer._entity_reference).
+   References with no entity_type were never documented, so they render as plain
+   code rather than a link to a page that does not exist. #}
+{% macro reference_list(refs) %}
+{% for ref in refs %}
+{% if ref.entity_type %}<a href="{{ ref.qname | entity_url(ref.entity_type) }}">{{ ref.label }}</a>{% else %}<code>{{ ref.label }}</code>{% endif %}{% if not loop.last %}, {% endif %}
+{% endfor %}
+{% endmacro %}
+
+{% block content %}
+<article class="entity-card">
+    <h1>
+        {{ concept_info.label or concept_info.qname }}
+        {% for kind in concept_info.kinds %}
+        <span class="entity-type {{ kind }}">{{ kind | replace('_', ' ') }}</span>
+        {% endfor %}
+    </h1>
+    <p class="uri">{{ concept_info.uri }}</p>
+
+    {% if concept_info.definition %}
+    <p class="definition">{{ concept_info.definition }}</p>
+    {% endif %}
+
+    {# Labels grouped by language — one row per language tag. #}
+    {% if concept_info.labels %}
+    <section class="section">
+        <h3>Labels</h3>
+        <table>
+            <thead>
+                <tr>
+                    <th>Language</th>
+                    <th>Preferred</th>
+                    <th>Alternative</th>
+                    <th>Hidden</th>
+                </tr>
+            </thead>
+            <tbody>
+                {% for group in concept_info.labels %}
+                <tr>
+                    <td><code>{{ group.language or "—" }}</code></td>
+                    <td>{{ group.preferred | join(", ") }}</td>
+                    <td>{{ group.alternative | join(", ") }}</td>
+                    <td>{{ group.hidden | join(", ") }}</td>
+                </tr>
+                {% endfor %}
+            </tbody>
+        </table>
+    </section>
+    {% endif %}
+
+    {% if concept_info.in_schemes or concept_info.top_concept_of %}
+    <section class="section">
+        <h3>Schemes</h3>
+        <table>
+            <tbody>
+                {% if scheme_refs %}
+                <tr><th>In scheme</th><td>{{ reference_list(scheme_refs) }}</td></tr>
+                {% endif %}
+                {% if top_concept_of_refs %}
+                <tr><th>Top concept of</th><td>{{ reference_list(top_concept_of_refs) }}</td></tr>
+                {% endif %}
+            </tbody>
+        </table>
+    </section>
+    {% endif %}
+
+    {% if broader_refs or narrower_refs or related_refs %}
+    <section class="section">
+        <h3>Semantic Relations</h3>
+        <table>
+            <tbody>
+                {% if broader_refs %}
+                <tr><th>Broader</th><td>{{ reference_list(broader_refs) }}</td></tr>
+                {% endif %}
+                {% if narrower_refs %}
+                <tr><th>Narrower</th><td>{{ reference_list(narrower_refs) }}</td></tr>
+                {% endif %}
+                {% if related_refs %}
+                <tr><th>Related</th><td>{{ reference_list(related_refs) }}</td></tr>
+                {% endif %}
+            </tbody>
+        </table>
+    </section>
+    {% endif %}
+
+    {% if concept_info.notes %}
+    <section class="section">
+        <h3>Notes</h3>
+        <table>
+            <thead>
+                <tr>
+                    <th>Property</th>
+                    <th>Value</th>
+                </tr>
+            </thead>
+            <tbody>
+                {% for name, values in concept_info.notes.items() %}
+                {% for value in values %}
+                <tr>
+                    <td><code>skos:{{ name }}</code></td>
+                    <td>{{ value.text }}{% if value.language %}<span class="lang-tag">{{ value.language }}</span>{% endif %}</td>
+                </tr>
+                {% endfor %}
+                {% endfor %}
+            </tbody>
+        </table>
+    </section>
+    {% endif %}
+
+    {% if type_refs %}
+    <section class="section">
+        <h3>Types</h3>
+        <ul class="entity-list">
+            {% for ref in type_refs %}
+            <li>{% if ref.entity_type %}<a href="{{ ref.qname | entity_url(ref.entity_type) }}">{{ ref.label }}</a>{% else %}<code>{{ ref.label }}</code>{% endif %}</li>
+            {% endfor %}
+        </ul>
+    </section>
+    {% endif %}
+
+    {# Anything else asserted about the concept — mappings such as
+       skos:exactMatch land here as visible key-value rows rather than
+       being dropped. #}
+    {% if concept_info.properties %}
+    <section class="section">
+        <h3>Other Properties</h3>
+        <table>
+            <thead>
+                <tr>
+                    <th>Property</th>
+                    <th>Value</th>
+                </tr>
+            </thead>
+            <tbody>
+                {% for pred, values in concept_info.properties.items() %}
+                {% for value in values %}
+                <tr>
+                    <td><code>{{ pred }}</code></td>
+                    <td>{% if value is string %}{{ value }}{% else %}<code>{{ value }}</code>{% endif %}</td>
+                </tr>
+                {% endfor %}
+                {% endfor %}
+            </tbody>
+        </table>
+    </section>
+    {% endif %}
+
+    {% if concept_info.annotations %}
+    <section class="section">
+        <h3>Annotations</h3>
+        <table>
+            <thead>
+                <tr>
+                    <th>Property</th>
+                    <th>Value</th>
+                </tr>
+            </thead>
+            <tbody>
+                {% for name, values in concept_info.annotations.items() %}
+                {% for value in values %}
+                <tr>
+                    <td><code>{{ name }}</code></td>
+                    <td>{{ value }}</td>
+                </tr>
+                {% endfor %}
+                {% endfor %}
+            </tbody>
+        </table>
+    </section>
+    {% endif %}
+</article>
+{% endblock %}

--- a/src/rdf_construct/docs/templates/html/concept_scheme.html.jinja
+++ b/src/rdf_construct/docs/templates/html/concept_scheme.html.jinja
@@ -1,0 +1,164 @@
+{% extends "base.html.jinja" %}
+
+{% block title %}{{ scheme_info.label or scheme_info.qname }} - {{ ontology.title or "Documentation" }}{% endblock %}
+
+{% macro reference_list(refs) %}
+{% for ref in refs %}
+{% if ref.entity_type %}<a href="{{ ref.qname | entity_url(ref.entity_type) }}">{{ ref.label }}</a>{% else %}<code>{{ ref.label }}</code>{% endif %}{% if not loop.last %}, {% endif %}
+{% endfor %}
+{% endmacro %}
+
+{# The tree is built by build_concept_tree(), which is cycle-safe: a concept
+   already on the current path is not expanded again, so a broader cycle
+   renders once rather than recursing forever. #}
+{% macro concept_tree_nodes(nodes) %}
+<ul class="concept-tree">
+    {% for node in nodes %}
+    <li>
+        <a href="{{ node.concept.qname | entity_url('skos_concept') }}">{{ node.concept.label or node.concept.qname }}</a>
+        {% if node.children %}
+        {{ concept_tree_nodes(node.children) }}
+        {% endif %}
+    </li>
+    {% endfor %}
+</ul>
+{% endmacro %}
+
+{% block content %}
+<article class="entity-card">
+    <h1>
+        {{ scheme_info.label or scheme_info.qname }}
+        {% for kind in scheme_info.kinds %}
+        <span class="entity-type {{ kind }}">{{ kind | replace('_', ' ') }}</span>
+        {% endfor %}
+    </h1>
+    <p class="uri">{{ scheme_info.uri }}</p>
+
+    {% if scheme_info.definition %}
+    <p class="definition">{{ scheme_info.definition }}</p>
+    {% endif %}
+
+    {% if scheme_info.labels %}
+    <section class="section">
+        <h3>Labels</h3>
+        <table>
+            <thead>
+                <tr>
+                    <th>Language</th>
+                    <th>Preferred</th>
+                    <th>Alternative</th>
+                    <th>Hidden</th>
+                </tr>
+            </thead>
+            <tbody>
+                {% for group in scheme_info.labels %}
+                <tr>
+                    <td><code>{{ group.language or "—" }}</code></td>
+                    <td>{{ group.preferred | join(", ") }}</td>
+                    <td>{{ group.alternative | join(", ") }}</td>
+                    <td>{{ group.hidden | join(", ") }}</td>
+                </tr>
+                {% endfor %}
+            </tbody>
+        </table>
+    </section>
+    {% endif %}
+
+    {% if top_concept_refs %}
+    <section class="section">
+        <h3>Top Concepts</h3>
+        <p>{{ reference_list(top_concept_refs) }}</p>
+    </section>
+    {% endif %}
+
+    {% if concept_tree %}
+    <section class="section">
+        <h3>Concept Hierarchy</h3>
+        {{ concept_tree_nodes(concept_tree) }}
+    </section>
+    {% endif %}
+
+    {% if member_refs %}
+    <section class="section">
+        <h3>Concepts in this Scheme</h3>
+        <ul class="entity-list">
+            {% for ref in member_refs %}
+            <li>{% if ref.entity_type %}<a href="{{ ref.qname | entity_url(ref.entity_type) }}">{{ ref.label }}</a>{% else %}<code>{{ ref.label }}</code>{% endif %}</li>
+            {% endfor %}
+        </ul>
+    </section>
+    {% endif %}
+
+    {% if scheme_info.notes %}
+    <section class="section">
+        <h3>Notes</h3>
+        <table>
+            <thead>
+                <tr>
+                    <th>Property</th>
+                    <th>Value</th>
+                </tr>
+            </thead>
+            <tbody>
+                {% for name, values in scheme_info.notes.items() %}
+                {% for value in values %}
+                <tr>
+                    <td><code>skos:{{ name }}</code></td>
+                    <td>{{ value.text }}{% if value.language %}<span class="lang-tag">{{ value.language }}</span>{% endif %}</td>
+                </tr>
+                {% endfor %}
+                {% endfor %}
+            </tbody>
+        </table>
+    </section>
+    {% endif %}
+
+    {% if scheme_info.properties %}
+    <section class="section">
+        <h3>Other Properties</h3>
+        <table>
+            <thead>
+                <tr>
+                    <th>Property</th>
+                    <th>Value</th>
+                </tr>
+            </thead>
+            <tbody>
+                {% for pred, values in scheme_info.properties.items() %}
+                {% for value in values %}
+                <tr>
+                    <td><code>{{ pred }}</code></td>
+                    <td>{% if value is string %}{{ value }}{% else %}<code>{{ value }}</code>{% endif %}</td>
+                </tr>
+                {% endfor %}
+                {% endfor %}
+            </tbody>
+        </table>
+    </section>
+    {% endif %}
+
+    {% if scheme_info.annotations %}
+    <section class="section">
+        <h3>Annotations</h3>
+        <table>
+            <thead>
+                <tr>
+                    <th>Property</th>
+                    <th>Value</th>
+                </tr>
+            </thead>
+            <tbody>
+                {% for name, values in scheme_info.annotations.items() %}
+                {% for value in values %}
+                <tr>
+                    <td><code>{{ name }}</code></td>
+                    <td>{{ value }}</td>
+                </tr>
+                {% endfor %}
+                {% endfor %}
+            </tbody>
+        </table>
+    </section>
+    {% endif %}
+</article>
+{% endblock %}

--- a/src/rdf_construct/docs/templates/html/index.html.jinja
+++ b/src/rdf_construct/docs/templates/html/index.html.jinja
@@ -18,6 +18,12 @@
         <div class="label">Shapes</div>
     </div>
     {% endif %}
+    {% if concepts and config.include_skos %}
+    <div class="stat-card">
+        <div class="number">{{ concepts | length }}</div>
+        <div class="label">Concepts</div>
+    </div>
+    {% endif %}
     {% if instances %}
     <div class="stat-card">
         <div class="number">{{ total_instances }}</div>
@@ -114,6 +120,36 @@
             {% endfor %}
             {% if shape.definition %}
             <span class="definition">— {{ shape.definition[:80] }}{% if shape.definition|length > 80 %}...{% endif %}</span>
+            {% endif %}
+        </li>
+        {% endfor %}
+    </ul>
+</section>
+{% endif %}
+
+{% if (concepts or concept_schemes) and config.include_skos %}
+<section class="section">
+    <h2>SKOS Vocabulary</h2>
+    <ul class="entity-list">
+        {% for scheme in concept_schemes %}
+        <li>
+            <a href="{{ scheme.qname | entity_url('skos_concept_scheme') }}">
+                {{ scheme.label or scheme.qname }}
+            </a>
+            <span class="entity-type skos_concept_scheme">skos concept scheme</span>
+            {% if scheme.definition %}
+            <span class="definition">— {{ scheme.definition[:80] }}{% if scheme.definition|length > 80 %}...{% endif %}</span>
+            {% endif %}
+        </li>
+        {% endfor %}
+        {% for concept in concepts %}
+        <li>
+            <a href="{{ concept.qname | entity_url('skos_concept') }}">
+                {{ concept.label or concept.qname }}
+            </a>
+            <span class="entity-type skos_concept">skos concept</span>
+            {% if concept.definition %}
+            <span class="definition">— {{ concept.definition[:80] }}{% if concept.definition|length > 80 %}...{% endif %}</span>
             {% endif %}
         </li>
         {% endfor %}

--- a/src/rdf_construct/docs/templates/html/single_page.html.jinja
+++ b/src/rdf_construct/docs/templates/html/single_page.html.jinja
@@ -15,6 +15,9 @@
         {% if shapes and config.include_shapes %}
         <li><a href="#shapes">Shapes</a></li>
         {% endif %}
+        {% if (concepts or concept_schemes) and config.include_skos %}
+        <li><a href="#skos">SKOS Vocabulary</a></li>
+        {% endif %}
         {% if instances and config.include_instances %}
         <li><a href="#instances">Instances</a></li>
         {% endif %}
@@ -35,6 +38,12 @@
     <div class="stat-card">
         <div class="number">{{ shapes | length }}</div>
         <div class="label">Shapes</div>
+    </div>
+    {% endif %}
+    {% if concepts and config.include_skos %}
+    <div class="stat-card">
+        <div class="number">{{ concepts | length }}</div>
+        <div class="label">Concepts</div>
     </div>
     {% endif %}
     {% if instances %}
@@ -158,6 +167,56 @@
         {% endif %}
         {% if 'node_shape' in shape.kinds and shape.properties %}
         <p><strong>Property constraints:</strong> {{ shape.properties | length }}</p>
+        {% endif %}
+    </article>
+    {% endfor %}
+</section>
+{% endif %}
+
+{% if (concepts or concept_schemes) and config.include_skos %}
+<section id="skos">
+    <h2>SKOS Vocabulary</h2>
+    {% for scheme in concept_schemes %}
+    <article class="entity-card" id="scheme-{{ scheme.qname | qname_local }}">
+        <h3>
+            {{ scheme.label or scheme.qname }}
+            <span class="entity-type skos_concept_scheme">skos concept scheme</span>
+        </h3>
+        <p class="uri">{{ scheme.uri }}</p>
+        {% if scheme.definition %}
+        <p class="definition">{{ scheme.definition }}</p>
+        {% endif %}
+        {% if scheme.concepts %}
+        <p><strong>Concepts:</strong> {{ scheme.concepts | length }}</p>
+        {% endif %}
+    </article>
+    {% endfor %}
+    {% for concept in concepts %}
+    <article class="entity-card" id="concept-{{ concept.qname | qname_local }}">
+        <h3>
+            {{ concept.label or concept.qname }}
+            {% for kind in concept.kinds %}
+            <span class="entity-type {{ kind }}">{{ kind | replace('_', ' ') }}</span>
+            {% endfor %}
+        </h3>
+        <p class="uri">{{ concept.uri }}</p>
+        {% if concept.definition %}
+        <p class="definition">{{ concept.definition }}</p>
+        {% endif %}
+        {% if concept.broader %}
+        <p><strong>Broader:</strong>
+        {% for uri in concept.broader %}<code>{{ uri }}</code>{% if not loop.last %}, {% endif %}{% endfor %}
+        </p>
+        {% endif %}
+        {% if concept.narrower %}
+        <p><strong>Narrower:</strong>
+        {% for uri in concept.narrower %}<code>{{ uri }}</code>{% if not loop.last %}, {% endif %}{% endfor %}
+        </p>
+        {% endif %}
+        {% if concept.in_schemes %}
+        <p><strong>In scheme:</strong>
+        {% for uri in concept.in_schemes %}<code>{{ uri }}</code>{% if not loop.last %}, {% endif %}{% endfor %}
+        </p>
         {% endif %}
     </article>
     {% endfor %}

--- a/tests/fixtures/docs/skos_vocabulary.ttl
+++ b/tests/fixtures/docs/skos_vocabulary.ttl
@@ -1,0 +1,147 @@
+@prefix ex:    <http://example.org/vocab#> .
+@prefix owl:   <http://www.w3.org/2002/07/owl#> .
+@prefix rdfs:  <http://www.w3.org/2000/01/rdf-schema#> .
+@prefix skos:  <http://www.w3.org/2004/02/skos/core#> .
+@prefix xsd:   <http://www.w3.org/2001/XMLSchema#> .
+
+#
+# Test vocabulary for the docs command's SKOS support (issue #63).
+#
+# Deliberately not shipped under examples/ — it carries a broader cycle
+# (ex:Loop... below) that exists to prove the hierarchy walker terminates.
+# Copied into a real vocabulary it would be a modelling error, so it stays
+# test material.
+#
+# Exercises: a scheme with skos:hasTopConcept and the inverse
+# skos:topConceptOf; three levels of broader/narrower; a concept in two
+# schemes; a concept in no scheme at all; pref/alt/hidden labels across
+# two languages; all seven SKOS documentation properties; a concept that
+# is also owl:NamedIndividual; a concept that is also owl:Class (punning);
+# and a two-node broader cycle.
+#
+
+ex:BuildingVocabulary a owl:Ontology ;
+    rdfs:label "Building Classification Vocabulary"@en ;
+    rdfs:comment "A small controlled vocabulary used to test SKOS rendering."@en .
+
+#
+# Concept schemes
+#
+
+ex:BuildingScheme a skos:ConceptScheme ;
+    rdfs:label "Building Classification"@en ;
+    skos:prefLabel "Building Classification"@en ;
+    skos:prefLabel "Classification des bâtiments"@fr ;
+    skos:definition "Classification of buildings by primary function."@en ;
+    skos:hasTopConcept ex:Building ;
+    skos:note "Maintained by the example working group."@en .
+
+ex:HeritageScheme a skos:ConceptScheme ;
+    skos:prefLabel "Heritage Designations"@en ;
+    skos:definition "Designations applied to buildings of historic interest."@en .
+
+#
+# Top concept and its descendants — three levels deep.
+#
+
+ex:Building a skos:Concept , owl:NamedIndividual ;
+    skos:prefLabel "Building"@en ;
+    skos:prefLabel "Bâtiment"@fr ;
+    skos:altLabel "Structure"@en ;
+    skos:altLabel "Édifice"@fr ;
+    skos:hiddenLabel "buildin"@en ;
+    skos:definition "A permanent, roofed construction intended for occupation."@en ;
+    skos:definition "Construction permanente et couverte destinée à être occupée."@fr ;
+    skos:scopeNote "Excludes temporary structures such as marquees."@en ;
+    skos:example "An office block; a terraced house."@en ;
+    skos:note "The root of the building classification."@en ;
+    skos:historyNote "Added in the 2019 revision."@en ;
+    skos:editorialNote "Check alignment with the national classification."@en ;
+    skos:changeNote "Definition tightened in 2021 to exclude marquees."@en ;
+    skos:topConceptOf ex:BuildingScheme ;
+    skos:inScheme ex:BuildingScheme ;
+    skos:narrower ex:Dwelling .
+
+ex:Dwelling a skos:Concept ;
+    skos:prefLabel "Dwelling"@en ;
+    skos:prefLabel "Logement"@fr ;
+    skos:altLabel "Residence"@en ;
+    skos:definition "A building, or part of one, used as a private residence."@en ;
+    skos:broader ex:Building ;
+    skos:narrower ex:DetachedHouse ;
+    skos:inScheme ex:BuildingScheme .
+
+ex:DetachedHouse a skos:Concept ;
+    skos:prefLabel "Detached House"@en ;
+    skos:prefLabel "Maison individuelle"@fr ;
+    skos:altLabel "Standalone House"@en ;
+    skos:hiddenLabel "detatched house"@en ;
+    skos:definition "A dwelling that shares no wall with another dwelling."@en ;
+    skos:broader ex:Dwelling ;
+    skos:related ex:ListedBuilding ;
+    skos:inScheme ex:BuildingScheme .
+
+#
+# A concept in two schemes.
+#
+
+ex:ListedBuilding a skos:Concept ;
+    skos:prefLabel "Listed Building"@en ;
+    skos:prefLabel "Bâtiment classé"@fr ;
+    skos:definition "A building on a statutory list of buildings of special interest."@en ;
+    skos:broader ex:Building ;
+    skos:inScheme ex:BuildingScheme ;
+    skos:inScheme ex:HeritageScheme ;
+    skos:topConceptOf ex:HeritageScheme ;
+    skos:exactMatch <http://example.net/heritage#Listed> .
+
+#
+# A concept with no scheme membership at all — must still be documented.
+#
+
+ex:Outbuilding a skos:Concept ;
+    skos:prefLabel "Outbuilding"@en ;
+    skos:definition "A detached building subordinate to a main building."@en .
+
+#
+# Punning: also an owl:Class. Classes keep their class page; the concept
+# routing must not produce a second page for the same subject.
+#
+
+ex:Warehouse a skos:Concept , owl:Class ;
+    rdfs:label "Warehouse"@en ;
+    skos:prefLabel "Warehouse"@en ;
+    skos:definition "A building for storing goods."@en ;
+    skos:inScheme ex:BuildingScheme .
+
+#
+# A deliberate two-node broader cycle. SKOS does not promise acyclicity;
+# the hierarchy walker must terminate rather than recurse forever.
+#
+
+ex:LoopA a skos:Concept ;
+    skos:prefLabel "Loop A"@en ;
+    skos:broader ex:LoopB ;
+    skos:inScheme ex:BuildingScheme .
+
+ex:LoopB a skos:Concept ;
+    skos:prefLabel "Loop B"@en ;
+    skos:broader ex:LoopA ;
+    skos:inScheme ex:BuildingScheme .
+
+#
+# Non-SKOS context so the vocabulary exercises cross-referencing: a class,
+# a property and a plain instance that must stay in their own buckets.
+#
+
+ex:Site a owl:Class ;
+    rdfs:label "Site"@en .
+
+ex:hasClassification a owl:ObjectProperty ;
+    rdfs:label "has classification"@en ;
+    rdfs:domain ex:Site ;
+    rdfs:range ex:Building .
+
+ex:MainSite a ex:Site ;
+    rdfs:label "Main Site"@en ;
+    ex:hasClassification ex:Dwelling .

--- a/tests/test_docs.py
+++ b/tests/test_docs.py
@@ -9,12 +9,14 @@ from rdflib.namespace import OWL, SH, XSD
 
 from rdf_construct.docs import (
     ClassInfo,
+    ConceptInfo,
     DocsConfig,
     DocsGenerator,
     EntityKind,
     ExtractedEntities,
     PropertyInfo,
     ShapeInfo,
+    build_concept_tree,
     extract_all,
     generate_docs,
 )
@@ -646,7 +648,13 @@ class TestPathResolution:
             assert 'href="./assets/style.css"' not in html
             assert 'href="../assets/style.css"' not in html
 
-    def test_all_links_resolve_for_every_entity_kind(self, shape_ontology: Graph, output_dir: Path):
+    @pytest.mark.parametrize("fixture_name", ["shape_ontology", "skos_vocabulary"])
+    def test_all_links_resolve_for_every_entity_kind(
+        self,
+        fixture_name: str,
+        request: pytest.FixtureRequest,
+        output_dir: Path,
+    ):
         """Every page of every entity kind must have resolvable links.
 
         The sibling tests above run against ``simple_ontology``, which has
@@ -658,16 +666,19 @@ class TestPathResolution:
         This runs the same walk over an ontology carrying a class, an
         instance, a property and both shape kinds, so a new entity type
         added without going through ``_render_page()`` fails here rather
-        than shipping.
+        than shipping. It runs again over the SKOS vocabulary (#63) for
+        the same reason: a guard is only as general as its fixture.
         """
         import re
 
+        graph = request.getfixturevalue(fixture_name)
         config = DocsConfig(output_dir=output_dir, format="html")
-        DocsGenerator(config).generate(shape_ontology)
+        DocsGenerator(config).generate(graph)
 
         # The point of the test is lost if the fixture stops producing
         # pages at depth — assert the tree actually has them.
-        assert list(output_dir.glob("shapes/*.html")), "fixture generated no shape pages"
+        subdir = "shapes" if fixture_name == "shape_ontology" else "concepts"
+        assert list(output_dir.glob(f"{subdir}/*.html")), "fixture generated no pages at depth"
 
         broken: list[tuple[Path, str, Path]] = []
         ref_pat = re.compile(r'(?:href|src)="([^"#?]+)"')
@@ -1283,3 +1294,586 @@ class TestEntityKindEnum:
         assert "shape" in kinds
         assert EntityKind.SHAPE in kinds
         assert "instance" not in kinds
+
+
+# ---------------------------------------------------------------------------
+# SKOS support — issue #63 / milestone v0.6.0 stage 2
+# ---------------------------------------------------------------------------
+
+
+SKOS_FIXTURE = Path(__file__).parent / "fixtures" / "docs" / "skos_vocabulary.ttl"
+
+
+@pytest.fixture
+def skos_vocabulary() -> Graph:
+    """Load the tracked SKOS test vocabulary.
+
+    The repository had no SKOS structure at all before #63 — no
+    ``skos:Concept``, ``skos:ConceptScheme``, ``broader``, ``narrower`` or
+    ``inScheme`` anywhere — so this fixture is the material the acceptance
+    criteria are demonstrated against. See the file's own header for what
+    it exercises, including the deliberate ``skos:broader`` cycle.
+    """
+    g = Graph()
+    g.parse(SKOS_FIXTURE, format="turtle")
+    return g
+
+
+def _concept(entities: ExtractedEntities, local_name: str) -> ConceptInfo:
+    """Find a concept by the local part of its qname."""
+    return next(c for c in entities.concepts if c.qname.split(":")[-1] == local_name)
+
+
+class TestSKOSExtraction:
+    """Tests for ConceptInfo / ConceptSchemeInfo extraction."""
+
+    def test_concepts_extracted(self, skos_vocabulary: Graph):
+        """skos:Concept subjects land in the concepts bucket with the right kind."""
+        entities = extract_all(skos_vocabulary)
+        qnames = {c.qname for c in entities.concepts}
+        assert "ex:Building" in qnames
+        assert "ex:Dwelling" in qnames
+        for concept in entities.concepts:
+            assert EntityKind.SKOS_CONCEPT in concept.kinds
+
+    def test_concept_schemes_extracted(self, skos_vocabulary: Graph):
+        """skos:ConceptScheme subjects get their own bucket and kind."""
+        entities = extract_all(skos_vocabulary)
+        qnames = {s.qname for s in entities.concept_schemes}
+        assert qnames == {"ex:BuildingScheme", "ex:HeritageScheme"}
+        for scheme in entities.concept_schemes:
+            assert EntityKind.SKOS_CONCEPT_SCHEME in scheme.kinds
+
+    def test_concepts_excluded_from_instances(self, skos_vocabulary: Graph):
+        """The central #63 change: SKOS entities leave the Instances bucket."""
+        entities = extract_all(skos_vocabulary)
+        instance_qnames = {i.qname for i in entities.instances}
+        # The plain instance is still there
+        assert "ex:MainSite" in instance_qnames
+        # Concepts and schemes are not
+        assert "ex:Building" not in instance_qnames
+        assert "ex:BuildingScheme" not in instance_qnames
+        assert "ex:Outbuilding" not in instance_qnames
+
+    def test_concept_also_named_individual_routes_to_concepts(self, skos_vocabulary: Graph):
+        """A concept that is also owl:NamedIndividual is documented once, as a concept."""
+        entities = extract_all(skos_vocabulary)
+        building = _concept(entities, "Building")
+        assert str(OWL.NamedIndividual) in [str(t) for t in building.types]
+        assert "ex:Building" not in {i.qname for i in entities.instances}
+
+    def test_punned_class_keeps_its_class_page(self, skos_vocabulary: Graph):
+        """A subject typed both owl:Class and skos:Concept stays a class.
+
+        Classes outrank SKOS in the routing order, so ``ex:Warehouse`` gets
+        one page rather than two. It remains visible as a member of its
+        scheme, which cross-links to the class page.
+        """
+        entities = extract_all(skos_vocabulary)
+        assert "ex:Warehouse" in {c.qname for c in entities.classes}
+        assert "ex:Warehouse" not in {c.qname for c in entities.concepts}
+        scheme = next(s for s in entities.concept_schemes if s.qname == "ex:BuildingScheme")
+        assert any("Warehouse" in str(uri) for uri in scheme.concepts)
+
+    def test_labels_grouped_by_language(self, skos_vocabulary: Graph):
+        """pref/alt/hidden labels group into one row per language tag."""
+        entities = extract_all(skos_vocabulary)
+        building = _concept(entities, "Building")
+        by_lang = {group.language: group for group in building.labels}
+        assert set(by_lang) == {"en", "fr"}
+        assert by_lang["en"].preferred == ["Building"]
+        assert by_lang["en"].alternative == ["Structure"]
+        assert by_lang["en"].hidden == ["buildin"]
+        assert by_lang["fr"].preferred == ["Bâtiment"]
+        assert by_lang["fr"].alternative == ["Édifice"]
+        assert by_lang["fr"].hidden == []
+
+    def test_all_seven_note_types_extracted(self, skos_vocabulary: Graph):
+        """All seven SKOS documentation properties are captured, with languages."""
+        entities = extract_all(skos_vocabulary)
+        building = _concept(entities, "Building")
+        assert set(building.notes) == {
+            "definition",
+            "scopeNote",
+            "example",
+            "note",
+            "historyNote",
+            "editorialNote",
+            "changeNote",
+        }
+        languages = {value.language for value in building.notes["definition"]}
+        assert languages == {"en", "fr"}
+
+    def test_notes_not_duplicated_in_annotations(self, skos_vocabulary: Graph):
+        """SKOS notes render from `notes`, so get_annotations' copies are dropped."""
+        entities = extract_all(skos_vocabulary)
+        building = _concept(entities, "Building")
+        for name in ("note", "example", "scopeNote", "historyNote", "editorialNote"):
+            assert name not in building.annotations
+
+    def test_broader_materialises_the_inverse_of_narrower(self, skos_vocabulary: Graph):
+        """SKOS declares broader/narrower inverse, so one assertion gives both.
+
+        ``ex:ListedBuilding`` asserts ``skos:broader ex:Building`` and
+        nothing asserts the narrower direction — the concept still has to
+        appear under Building.
+        """
+        entities = extract_all(skos_vocabulary)
+        building = _concept(entities, "Building")
+        listed = _concept(entities, "ListedBuilding")
+        assert any("ListedBuilding" in str(uri) for uri in building.narrower)
+        assert any("Building" in str(uri) for uri in listed.broader)
+
+    def test_broader_and_narrower_deduplicated(self, skos_vocabulary: Graph):
+        """A relation asserted in both directions is not listed twice."""
+        entities = extract_all(skos_vocabulary)
+        dwelling = _concept(entities, "Dwelling")
+        assert len(dwelling.broader) == len(set(dwelling.broader))
+        assert sum("Building" in str(uri) for uri in dwelling.broader) == 1
+
+    def test_related_is_symmetric(self, skos_vocabulary: Graph):
+        """skos:related is symmetric, so both ends carry the relation."""
+        entities = extract_all(skos_vocabulary)
+        detached = _concept(entities, "DetachedHouse")
+        listed = _concept(entities, "ListedBuilding")
+        assert any("ListedBuilding" in str(uri) for uri in detached.related)
+        assert any("DetachedHouse" in str(uri) for uri in listed.related)
+
+    def test_concept_in_two_schemes(self, skos_vocabulary: Graph):
+        """Multiple skos:inScheme memberships are all kept."""
+        entities = extract_all(skos_vocabulary)
+        listed = _concept(entities, "ListedBuilding")
+        assert len(listed.in_schemes) == 2
+
+    def test_top_concept_of_implies_in_scheme(self, skos_vocabulary: Graph):
+        """skos:topConceptOf is a sub-property of skos:inScheme."""
+        entities = extract_all(skos_vocabulary)
+        listed = _concept(entities, "ListedBuilding")
+        heritage = next(s for s in entities.concept_schemes if s.qname == "ex:HeritageScheme")
+        # ListedBuilding declares topConceptOf HeritageScheme but no inScheme for it
+        assert heritage.uri in listed.in_schemes
+        assert heritage.uri in listed.top_concept_of
+
+    def test_scheme_members_and_top_concepts(self, skos_vocabulary: Graph):
+        """A scheme lists its members and its declared top concepts."""
+        entities = extract_all(skos_vocabulary)
+        scheme = next(s for s in entities.concept_schemes if s.qname == "ex:BuildingScheme")
+        member_names = {str(uri).split("#")[-1] for uri in scheme.concepts}
+        assert {"Building", "Dwelling", "DetachedHouse", "ListedBuilding"} <= member_names
+        assert [str(uri).split("#")[-1] for uri in scheme.top_concepts] == ["Building"]
+
+    def test_scheme_top_concept_from_inverse(self, skos_vocabulary: Graph):
+        """hasTopConcept and topConceptOf are inverses; either assertion counts."""
+        entities = extract_all(skos_vocabulary)
+        heritage = next(s for s in entities.concept_schemes if s.qname == "ex:HeritageScheme")
+        # Only ex:ListedBuilding skos:topConceptOf ex:HeritageScheme is asserted
+        assert [str(uri).split("#")[-1] for uri in heritage.top_concepts] == ["ListedBuilding"]
+
+    def test_concept_with_no_scheme_still_extracted(self, skos_vocabulary: Graph):
+        """An orphan concept is documented rather than lost."""
+        entities = extract_all(skos_vocabulary)
+        outbuilding = _concept(entities, "Outbuilding")
+        assert outbuilding.in_schemes == []
+
+    def test_mappings_land_in_other_properties(self, skos_vocabulary: Graph):
+        """skos:exactMatch gets no special treatment but stays visible."""
+        entities = extract_all(skos_vocabulary)
+        listed = _concept(entities, "ListedBuilding")
+        preds = {str(pred) for pred in listed.properties}
+        assert "http://www.w3.org/2004/02/skos/core#exactMatch" in preds
+
+    def test_structural_predicates_not_repeated_in_properties(self, skos_vocabulary: Graph):
+        """broader/narrower/inScheme render structurally, not as key-value rows."""
+        entities = extract_all(skos_vocabulary)
+        dwelling = _concept(entities, "Dwelling")
+        preds = {str(pred) for pred in dwelling.properties}
+        assert "http://www.w3.org/2004/02/skos/core#broader" not in preds
+        assert "http://www.w3.org/2004/02/skos/core#inScheme" not in preds
+        assert "http://www.w3.org/2004/02/skos/core#prefLabel" not in preds
+
+
+class TestSKOSHierarchy:
+    """Tests for build_concept_tree, including the cyclic case."""
+
+    def test_tree_nests_three_levels(self, skos_vocabulary: Graph):
+        """The broader/narrower tree nests to the depth the vocabulary declares."""
+        entities = extract_all(skos_vocabulary)
+        scheme = next(s for s in entities.concept_schemes if s.qname == "ex:BuildingScheme")
+        tree = build_concept_tree(entities.concepts, scheme.uri)
+
+        building = next(node for node in tree if node.concept.qname == "ex:Building")
+        dwelling = next(node for node in building.children if node.concept.qname == "ex:Dwelling")
+        assert [child.concept.qname for child in dwelling.children] == ["ex:DetachedHouse"]
+
+    def test_tree_is_rooted_at_declared_top_concepts(self, skos_vocabulary: Graph):
+        """Declared top concepts anchor the tree."""
+        entities = extract_all(skos_vocabulary)
+        scheme = next(s for s in entities.concept_schemes if s.qname == "ex:BuildingScheme")
+        tree = build_concept_tree(entities.concepts, scheme.uri)
+        assert tree[0].concept.qname == "ex:Building"
+
+    def test_cyclic_broader_terminates(self, skos_vocabulary: Graph):
+        """A broader cycle must not send the walker into infinite recursion.
+
+        SKOS does not promise acyclicity. ``ex:LoopA`` and ``ex:LoopB`` are
+        each other's broader concept; the walker has to stop and still
+        render both.
+        """
+        entities = extract_all(skos_vocabulary)
+        scheme = next(s for s in entities.concept_schemes if s.qname == "ex:BuildingScheme")
+        tree = build_concept_tree(entities.concepts, scheme.uri)
+
+        def walk(nodes, depth=0):
+            assert depth < 20, "concept tree recursed further than the vocabulary is deep"
+            names = []
+            for node in nodes:
+                names.append(node.concept.qname)
+                names.extend(walk(node.children, depth + 1))
+            return names
+
+        rendered = walk(tree)
+        assert "ex:LoopA" in rendered
+        assert "ex:LoopB" in rendered
+
+    def test_cycle_members_are_not_dropped(self, skos_vocabulary: Graph):
+        """Every member of the scheme appears in the tree, cycle or not."""
+        entities = extract_all(skos_vocabulary)
+        scheme = next(s for s in entities.concept_schemes if s.qname == "ex:BuildingScheme")
+        tree = build_concept_tree(entities.concepts, scheme.uri)
+
+        def collect(nodes):
+            found = set()
+            for node in nodes:
+                found.add(node.concept.qname)
+                found |= collect(node.children)
+            return found
+
+        member_concepts = {c.qname for c in entities.concepts if scheme.uri in c.in_schemes}
+        assert member_concepts <= collect(tree)
+
+    def test_tree_without_scheme_covers_every_concept(self, skos_vocabulary: Graph):
+        """Called with no scheme, the tree spans all concepts including orphans."""
+        entities = extract_all(skos_vocabulary)
+        tree = build_concept_tree(entities.concepts)
+
+        def collect(nodes):
+            found = set()
+            for node in nodes:
+                found.add(node.concept.qname)
+                found |= collect(node.children)
+            return found
+
+        assert {c.qname for c in entities.concepts} <= collect(tree)
+
+
+class TestSKOSRendering:
+    """Tests for concept and scheme pages in all three formats."""
+
+    def test_html_renders_concept_pages(self, skos_vocabulary: Graph, output_dir: Path):
+        config = DocsConfig(output_dir=output_dir, format="html")
+        DocsGenerator(config).generate(skos_vocabulary)
+
+        assert (output_dir / "concepts" / "Building.html").exists()
+        assert (output_dir / "concepts" / "BuildingScheme.html").exists()
+
+    def test_markdown_renders_concept_pages(self, skos_vocabulary: Graph, output_dir: Path):
+        config = DocsConfig(output_dir=output_dir, format="markdown")
+        DocsGenerator(config).generate(skos_vocabulary)
+
+        assert (output_dir / "concepts" / "Building.md").exists()
+        assert (output_dir / "concepts" / "BuildingScheme.md").exists()
+
+    def test_json_renders_concept_pages(self, skos_vocabulary: Graph, output_dir: Path):
+        config = DocsConfig(output_dir=output_dir, format="json")
+        DocsGenerator(config).generate(skos_vocabulary)
+
+        assert (output_dir / "concepts" / "Building.json").exists()
+        assert (output_dir / "concepts" / "BuildingScheme.json").exists()
+
+    def test_html_kind_badges(self, skos_vocabulary: Graph, output_dir: Path):
+        """Concept and scheme pages carry their kind badges."""
+        config = DocsConfig(output_dir=output_dir, format="html")
+        DocsGenerator(config).generate(skos_vocabulary)
+
+        concept_html = (output_dir / "concepts" / "Building.html").read_text()
+        assert 'class="entity-type skos_concept"' in concept_html
+
+        scheme_html = (output_dir / "concepts" / "BuildingScheme.html").read_text()
+        assert 'class="entity-type skos_concept_scheme"' in scheme_html
+
+    def test_html_badge_css_present(self, skos_vocabulary: Graph, output_dir: Path):
+        """The SKOS badge colours ship in the default stylesheet."""
+        config = DocsConfig(output_dir=output_dir, format="html")
+        DocsGenerator(config).generate(skos_vocabulary)
+
+        css = (output_dir / "assets" / "style.css").read_text()
+        assert ".entity-type.skos_concept { background: #1d4ed8; }" in css
+        assert ".entity-type.skos_concept_scheme { background: #1e3a8a; }" in css
+
+    def test_html_multilingual_label_table(self, skos_vocabulary: Graph, output_dir: Path):
+        """Labels render one row per language, not as duplicate triples."""
+        config = DocsConfig(output_dir=output_dir, format="html")
+        DocsGenerator(config).generate(skos_vocabulary)
+
+        html = (output_dir / "concepts" / "Building.html").read_text()
+        assert "<th>Preferred</th>" in html
+        assert "Bâtiment" in html
+        assert "Édifice" in html
+        assert "buildin" in html  # hidden label
+
+    def test_html_notes_carry_language_tags(self, skos_vocabulary: Graph, output_dir: Path):
+        config = DocsConfig(output_dir=output_dir, format="html")
+        DocsGenerator(config).generate(skos_vocabulary)
+
+        html = (output_dir / "concepts" / "Building.html").read_text()
+        assert "skos:scopeNote" in html
+        assert "skos:changeNote" in html
+        assert '<span class="lang-tag">fr</span>' in html
+
+    def test_html_scheme_page_has_hierarchy(self, skos_vocabulary: Graph, output_dir: Path):
+        """The scheme page carries the vocabulary tree."""
+        config = DocsConfig(output_dir=output_dir, format="html")
+        DocsGenerator(config).generate(skos_vocabulary)
+
+        html = (output_dir / "concepts" / "BuildingScheme.html").read_text()
+        assert "Concept Hierarchy" in html
+        assert 'class="concept-tree"' in html
+        assert "DetachedHouse.html" in html
+
+    def test_html_concept_cross_references(self, skos_vocabulary: Graph, output_dir: Path):
+        """inScheme and broader/narrower render as links, both ways."""
+        config = DocsConfig(output_dir=output_dir, format="html")
+        DocsGenerator(config).generate(skos_vocabulary)
+
+        html = (output_dir / "concepts" / "Dwelling.html").read_text()
+        assert "BuildingScheme.html" in html  # scheme link
+        assert "Building.html" in html  # broader link
+        assert "DetachedHouse.html" in html  # narrower link
+
+    def test_html_punned_class_member_links_to_class_page(
+        self, skos_vocabulary: Graph, output_dir: Path
+    ):
+        """A member that is documented as a class links to its class page."""
+        config = DocsConfig(output_dir=output_dir, format="html")
+        DocsGenerator(config).generate(skos_vocabulary)
+
+        html = (output_dir / "concepts" / "BuildingScheme.html").read_text()
+        assert "classes/Warehouse.html" in html
+        assert not (output_dir / "concepts" / "Warehouse.html").exists()
+
+    def test_markdown_kind_in_frontmatter(self, skos_vocabulary: Graph, output_dir: Path):
+        config = DocsConfig(output_dir=output_dir, format="markdown")
+        DocsGenerator(config).generate(skos_vocabulary)
+
+        concept_md = (output_dir / "concepts" / "Building.md").read_text()
+        assert "type: skos_concept" in concept_md
+
+        scheme_md = (output_dir / "concepts" / "BuildingScheme.md").read_text()
+        assert "type: skos_concept_scheme" in scheme_md
+
+    def test_markdown_label_and_note_tables(self, skos_vocabulary: Graph, output_dir: Path):
+        config = DocsConfig(output_dir=output_dir, format="markdown")
+        DocsGenerator(config).generate(skos_vocabulary)
+
+        md = (output_dir / "concepts" / "Building.md").read_text()
+        assert "| Language | Preferred | Alternative | Hidden |" in md
+        assert "| `fr` | Bâtiment | Édifice |  |" in md
+        assert "`skos:historyNote`" in md
+        assert "_(fr)_" in md
+
+    def test_markdown_scheme_hierarchy(self, skos_vocabulary: Graph, output_dir: Path):
+        """The Markdown scheme page renders the tree as an indented list."""
+        config = DocsConfig(output_dir=output_dir, format="markdown")
+        DocsGenerator(config).generate(skos_vocabulary)
+
+        md = (output_dir / "concepts" / "BuildingScheme.md").read_text()
+        assert "## Concept Hierarchy" in md
+        assert "  - [Dwelling]" in md
+        assert "    - [Detached House]" in md
+
+    def test_json_breaking_change_concepts_not_in_instances(
+        self, skos_vocabulary: Graph, output_dir: Path
+    ):
+        """JSON instances array no longer carries concepts or schemes."""
+        config = DocsConfig(output_dir=output_dir, format="json")
+        DocsGenerator(config).generate(skos_vocabulary)
+
+        data = json.loads((output_dir / "index.json").read_text())
+        instance_qnames = {i["qname"] for i in data["instances"]}
+        assert "ex:Building" not in instance_qnames
+        assert "ex:BuildingScheme" not in instance_qnames
+
+    def test_json_top_level_skos_arrays(self, skos_vocabulary: Graph, output_dir: Path):
+        config = DocsConfig(output_dir=output_dir, format="json")
+        DocsGenerator(config).generate(skos_vocabulary)
+
+        data = json.loads((output_dir / "index.json").read_text())
+        assert {c["qname"] for c in data["concepts"]} >= {"ex:Building", "ex:Dwelling"}
+        assert {s["qname"] for s in data["concept_schemes"]} == {
+            "ex:BuildingScheme",
+            "ex:HeritageScheme",
+        }
+        assert data["statistics"]["concepts"] == 7
+        assert data["statistics"]["concept_schemes"] == 2
+
+    def test_json_concept_schema(self, skos_vocabulary: Graph, output_dir: Path):
+        """The per-concept JSON keeps labels, notes and relations structured."""
+        config = DocsConfig(output_dir=output_dir, format="json")
+        DocsGenerator(config).generate(skos_vocabulary)
+
+        data = json.loads((output_dir / "concepts" / "Building.json").read_text())
+        assert data["kinds"] == ["skos_concept"]
+        assert {"labels", "notes", "broader", "narrower", "in_schemes"} <= set(data)
+
+        french = next(group for group in data["labels"] if group["language"] == "fr")
+        assert french["preferred"] == ["Bâtiment"]
+
+        definitions = data["notes"]["definition"]
+        assert {d["language"] for d in definitions} == {"en", "fr"}
+
+    def test_json_scheme_carries_hierarchy(self, skos_vocabulary: Graph, output_dir: Path):
+        """The scheme JSON ships the tree so consumers need not rebuild it."""
+        config = DocsConfig(output_dir=output_dir, format="json")
+        DocsGenerator(config).generate(skos_vocabulary)
+
+        data = json.loads((output_dir / "concepts" / "BuildingScheme.json").read_text())
+        roots = {node["qname"] for node in data["hierarchy"]}
+        assert "ex:Building" in roots
+        building = next(n for n in data["hierarchy"] if n["qname"] == "ex:Building")
+        assert {child["qname"] for child in building["children"]} == {
+            "ex:Dwelling",
+            "ex:ListedBuilding",
+        }
+
+    def test_json_single_page_has_skos_arrays(self, skos_vocabulary: Graph, output_dir: Path):
+        config = DocsConfig(output_dir=output_dir, format="json", single_page=True)
+        DocsGenerator(config).generate(skos_vocabulary)
+
+        data = json.loads((output_dir / "ontology.json").read_text())
+        assert len(data["concepts"]) == 7
+        assert len(data["concept_schemes"]) == 2
+
+
+class TestSKOSIndexAndSinglePage:
+    """Tests for the SKOS section on index and single-page output."""
+
+    def test_html_index_has_skos_section(self, skos_vocabulary: Graph, output_dir: Path):
+        config = DocsConfig(output_dir=output_dir, format="html")
+        DocsGenerator(config).generate(skos_vocabulary)
+
+        html = (output_dir / "index.html").read_text()
+        assert "SKOS Vocabulary" in html
+        assert "concepts/Building.html" in html
+        assert "concepts/BuildingScheme.html" in html
+
+    def test_markdown_index_has_skos_section(self, skos_vocabulary: Graph, output_dir: Path):
+        config = DocsConfig(output_dir=output_dir, format="markdown")
+        DocsGenerator(config).generate(skos_vocabulary)
+
+        md = (output_dir / "index.md").read_text()
+        assert "## SKOS Vocabulary" in md
+        assert "`skos_concept`" in md
+        assert "`skos_concept_scheme`" in md
+
+    def test_html_single_page_has_skos(self, skos_vocabulary: Graph, output_dir: Path):
+        config = DocsConfig(output_dir=output_dir, format="html", single_page=True)
+        DocsGenerator(config).generate(skos_vocabulary)
+
+        html = (output_dir / "index.html").read_text()
+        assert 'id="skos"' in html
+        assert "Loop A" in html
+
+    def test_markdown_single_page_has_skos(self, skos_vocabulary: Graph, output_dir: Path):
+        config = DocsConfig(output_dir=output_dir, format="markdown", single_page=True)
+        DocsGenerator(config).generate(skos_vocabulary)
+
+        md = (output_dir / "index.md").read_text()
+        assert "## SKOS Vocabulary" in md
+        assert "- [SKOS Vocabulary](#skos-vocabulary)" in md
+
+
+class TestSKOSSearchIndex:
+    """Tests for SKOS entries in the search index."""
+
+    def test_concepts_appear_in_search_index(self, skos_vocabulary: Graph):
+        entities = extract_all(skos_vocabulary)
+        config = DocsConfig()
+        entries = generate_search_index(entities, config)
+
+        by_type = {e.entity_type for e in entries}
+        assert "skos_concept" in by_type
+        assert "skos_concept_scheme" in by_type
+
+    def test_search_entry_kinds_and_url(self, skos_vocabulary: Graph):
+        entities = extract_all(skos_vocabulary)
+        entries = generate_search_index(entities, DocsConfig())
+
+        entry = next(e for e in entries if e.qname == "ex:Building")
+        assert entry.kinds == ["skos_concept"]
+        assert entry.url == "concepts/Building.html"
+
+    def test_alt_and_hidden_labels_indexed(self, skos_vocabulary: Graph):
+        """Hidden labels exist to catch misspellings — they must be searchable."""
+        entities = extract_all(skos_vocabulary)
+        entries = generate_search_index(entities, DocsConfig())
+
+        detached = next(e for e in entries if e.qname == "ex:DetachedHouse")
+        assert "detatched" in detached.keywords  # skos:hiddenLabel
+        assert "standalone" in detached.keywords  # skos:altLabel
+
+
+class TestIncludeSkosFlag:
+    """Tests for the include_skos configuration flag."""
+
+    def test_default_include_skos_true(self):
+        assert DocsConfig().include_skos is True
+
+    def test_include_skos_from_dict(self):
+        config = DocsConfig.from_dict({"include_skos": False})
+        assert config.include_skos is False
+
+    def test_include_skos_false_excludes_pages(self, skos_vocabulary: Graph, output_dir: Path):
+        config = DocsConfig(output_dir=output_dir, format="html", include_skos=False)
+        DocsGenerator(config).generate(skos_vocabulary)
+
+        assert not (output_dir / "concepts").exists()
+        html = (output_dir / "index.html").read_text()
+        assert "SKOS Vocabulary" not in html
+
+    def test_include_skos_false_excludes_from_search(self, skos_vocabulary: Graph):
+        entities = extract_all(skos_vocabulary)
+        entries = generate_search_index(entities, DocsConfig(include_skos=False))
+
+        assert not [e for e in entries if e.entity_type.startswith("skos_")]
+
+    def test_include_skos_false_does_not_leak_into_instances(
+        self, skos_vocabulary: Graph, output_dir: Path
+    ):
+        """Excluded means excluded — concepts do not fall back to Instances."""
+        config = DocsConfig(output_dir=output_dir, format="json", include_skos=False)
+        DocsGenerator(config).generate(skos_vocabulary)
+
+        data = json.loads((output_dir / "index.json").read_text())
+        assert "ex:Building" not in {i["qname"] for i in data["instances"]}
+
+
+class TestSKOSRouting:
+    """Tests for SKOS URL/path generation."""
+
+    def test_concept_path_under_concepts_directory(self):
+        config = DocsConfig(format="html")
+        assert entity_to_path("ex:Building", "skos_concept", config) == Path(
+            "concepts/Building.html"
+        )
+
+    def test_scheme_shares_the_concepts_directory(self):
+        config = DocsConfig(format="html")
+        assert entity_to_path("ex:BuildingScheme", "skos_concept_scheme", config) == Path(
+            "concepts/BuildingScheme.html"
+        )
+
+    def test_concept_path_with_entity_kind_enum(self):
+        config = DocsConfig(format="html")
+        assert entity_to_path("ex:Building", EntityKind.SKOS_CONCEPT, config) == Path(
+            "concepts/Building.html"
+        )


### PR DESCRIPTION
## What

Stage 2 of the v0.6.0 entity-type taxonomy: `skos:Concept` and `skos:ConceptScheme` become a first-class entity type in `docs`, alongside Classes, Properties, Instances and Shapes.

Concepts and schemes route to `concepts/`, sharing the directory and told apart by kind badges — the arrangement stage 1 (#60) gave NodeShapes and PropertyShapes in `shapes/`. Each concept page carries labels grouped by language, `broader`/`narrower`/`related` as cross-links, scheme membership rendered both ways, and all seven SKOS documentation properties with their language tags. The scheme page carries the vocabulary tree.

Closes #63.

## Task zero: there was no SKOS material at all

The issue claimed `ies-building-classification.ttl` exercised vocabulary structure. It does not — it has two `skos:note` triples and is untracked besides. Searching the whole tree, tracked and untracked, for `skos:Concept`, `skos:ConceptScheme`, `skos:broader`, `skos:narrower` or `skos:inScheme` returned nothing; the only SKOS present was `skos:definition` used as a plain annotation.

So `tests/fixtures/docs/skos_vocabulary.ttl` is part of this change. It exercises a scheme with `hasTopConcept` and the inverse `topConceptOf`, three levels of hierarchy, a concept in two schemes, a concept in **no** scheme, pref/alt/hidden labels in two languages, all seven note types, a concept that is also `owl:NamedIndividual`, a concept punned as `owl:Class`, and a deliberate two-node `broader` cycle.

**It is a fixture, not a shipped `examples/` file, and that is deliberate**: the cycle exists to prove the walker terminates. Copied out of a shipped example into a real vocabulary it would be a modelling error, and shipped examples get used as real input (#84 was a data-loss bug found in one). Happy to add a clean shipped example separately if you want one.

## Design decisions

Panel review follows in a comment. The decisions that shaped the code:

| Question | Decision |
|---|---|
| Scheme in its own directory? | No — shared `concepts/`, kind badges differentiate. Stage 1 precedent. |
| Hierarchy rendering | Both: tree on the scheme page, inline neighbours on each concept page. Not on `hierarchy.html`, which is the *class* hierarchy — `skos:broader` is not `rdfs:subClassOf`. |
| Label rendering | Grouped by language, one row per tag. |
| Note types | All **seven**, not the six the issue lists. `skos:changeNote` is defined alongside the others and `get_annotations()` was already collecting it; dropping it while capturing the rest would have lost data. |
| `skos:Collection`, SKOS-XL | Deferred, as the issue proposed. |
| **Does #63 introduce `EntityKind.NAMED_INDIVIDUAL`?** | **No — #64 survives as its own stage.** See below. |
| Palette | Blue family, measured. See below. |

### The fold/no-fold question (#63 question 3, and #64 question 1)

**#64 stays a separate stage.** This PR adds `SKOS_CONCEPT` and `SKOS_CONCEPT_SCHEME` and nothing else; there is still no `NAMED_INDIVIDUAL` member.

The two stages sit on different axes. Routing is single-valued and needs a priority — this PR establishes `class/property/shape > SKOS > instance`. Badging is multi-valued and additive. #64 is badging only: it adds the kind at extraction time, and every renderer here already loops `kinds` to emit badges, so stage 3 lands additively on concepts, schemes and instances alike without touching routing. Introducing the rung here would have bought nothing and coupled the two.

The fixture's `ex:Building` (a concept that is also `owl:NamedIndividual`) currently carries `["skos_concept"]` and routes to `concepts/`. After #64 it gains the second badge, same page.

### Palette — measured, and the issue's candidate rejected

The issue proposed indigo (`#4f46e5`). Measured against the existing seven badges it is the *worst* option available: 11.3 CIEDE2000 units from the object-property violet `#8b5cf6`, and 10.7 under simulated deuteranopia. Too close to call apart.

Chosen instead, mirroring how the shape family shares red-rose with the container darker:

| Kind | Colour | Contrast vs white | Min ΔE2000 to existing badges (normal / deut / prot / trit) |
|---|---|---|---|
| `skos_concept` | `#1d4ed8` | **6.70:1** | 15.3 / 17.7 / 21.3 / 6.0 |
| `skos_concept_scheme` | `#1e3a8a` | **10.36:1** | 24.2 / 23.3 / 27.9 / 16.5 |

Both clear WCAG AA for normal text. The weak axis is tritanopia, where `#1d4ed8` falls to 6.0 against the instance emerald — still distinguishable, and the badge's text label carries the category regardless, which is the argument stage 1 made for its own family.

**Separately, and not touched here:** of the seven pre-existing badges only the three shape colours and (marginally) `object` pass AA against white — `datatype` is 2.43:1, `annotation` 2.15:1 and `instance` 2.54:1. That is a pre-existing accessibility bug in the v0.4.x palette, out of scope for this PR, and worth its own issue. Say the word and I will file it.

## What I did NOT claim, because the path underneath is broken

Two acceptance criteria cannot honestly be ticked, and the new pages inherit the defects rather than causing them:

- **#86** — `search.js` fetches `search.json` page-relatively and stores root-relative URLs, so the search overlay is inert on sub-folder pages. New `concepts/` pages are sub-folder pages. The search *index* is correct and tested (entries, `kinds`, URLs, hidden-label indexing); the *overlay* will not work from a concept page until #86 lands.
- **#87** — the Markdown renderer emits root-relative entity links. Verified in this branch's output: `concepts/Dwelling.md` links to `concepts/BuildingScheme.md` rather than `BuildingScheme.md`. Markdown cross-links between concepts are therefore broken in the same way every other Markdown cross-link already is.

Neither is fixed here, per the scope. #76 was also left alone.

## Verification

- `scripts/ci-local.sh` green: **687 passed** (630 before), black clean.
- 57 new tests across extraction, the cycle-safe hierarchy walker, all three renderers, index and single-page output, the search index, `include_skos=false`, and routing.
- `TestPathResolution::test_all_links_resolve_for_every_entity_kind` is now parametrised over the SKOS fixture as well as the shape one. This matters: stage 1 shipped `shapes/` pages where every reference 404'd because that walker only ran against a fixture with no shapes. A guard is only as general as its fixture. Every reference on every generated page resolves.
- ruff and mypy remain advisory. mypy errors in `docs/` went **down** (14 → 11): `BaseRenderer`'s signatures referenced `ClassInfo`, `ShapeInfo` and friends by name with an empty `TYPE_CHECKING` block, so my new annotations would have been unresolvable too — I added the imports rather than adding two more broken ones. New ruff findings in touched files are almost entirely `UP037` (quoted annotations), which is the existing convention in every one of those files.

## Breaking change

JSON output: concepts and schemes leave the `instances` array for top-level `concepts` and `concept_schemes` arrays, exactly as shapes did in v0.5.0. `statistics` gains both counts. Documented in the CHANGELOG under `Changed` and in DOCS_GUIDE.

## Not for release yet

Version unchanged; CHANGELOG `[Unreleased]` only. #63 and #64 go out together as v0.6.0 once stage 3 lands.
