### PR TITLE
feat(docs): surface owl:NamedIndividual as a distinct kind (#64)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -66,6 +66,38 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   simulated deuteranopia); blue keeps 15.3 / 17.7 / 21.3 (normal /
   deuteranopia / protanopia). Its weakest axis is tritanopia at 6.0 against
   the instance emerald, where the badge's text label carries the category
+- **`owl:NamedIndividual` surfaced as a distinct kind** (#64). An entity
+  explicitly typed `owl:NamedIndividual` now carries a `named individual`
+  badge in HTML and Markdown, and `"named_individual"` in its `kinds` array
+  in JSON:
+  - This is a refinement on an entity's existing kinds, **not** a new
+    bucket. Named individuals stay where they were routed — an individual
+    under `instances/`, a SKOS concept under `concepts/`, a NodeShape under
+    `shapes/`. No new directory, no new top-level JSON array, no CLI flag,
+    and nothing breaking
+  - The badge shows whenever the declaration is **asserted**, including when
+    it is redundant in OWL DL terms (an entity that already has a class
+    typing). `kinds` records what the source says rather than what a
+    reasoner could infer, consistently with every other kind — and the
+    redundancy is itself information: it says the author was explicit
+  - An entity typed *only* `owl:NamedIndividual`, with no class typing at
+    all, is documented as an instance carrying the kind — that declaration
+    is the only thing marking it as an individual
+  - No false positives: an entity typed only by its class carries just
+    `["instance"]`. Classes and properties never gain the kind
+  - Searchable — the kind joins the entity's search keywords, so a literal
+    search for `named_individual` finds them. The search `entity_type` is
+    unchanged, so named individuals are not a separate search bucket
+  - `rdfs:Datatype` and `owl:DeprecatedClass` / `owl:DeprecatedProperty`
+    remain out of scope. Deprecation is orthogonal to entity kind and needs
+    its own design
+- New `EntityKind` member `NAMED_INDIVIDUAL`, and a new tracked fixture
+  (`tests/fixtures/docs/named_individuals.ttl`) — the repository previously
+  contained no `owl:NamedIndividual` in any RDF file
+- Named-individual badge colour `#047857`, 5.48:1 against white (clears
+  WCAG AA), a deeper emerald than the `#10b981` instance badge it sits
+  beside so the two read as one family — 21.7 CIEDE2000 units apart in
+  normal vision, 15.3 under simulated deuteranopia
 
 ### Changed
 - **Breaking (JSON output):** `skos:Concept` and `skos:ConceptScheme` subjects

--- a/docs/user_guides/DOCS_GUIDE.md
+++ b/docs/user_guides/DOCS_GUIDE.md
@@ -143,10 +143,11 @@ their own pages; blank-node PropertyShapes attached to a NodeShape via
 `sh:property` are rendered inline on the parent shape's page.
 
 A NodeShape that is also typed as `owl:NamedIndividual` is treated as a
-shape (it appears in the Shapes section, not in Instances). The
-`kinds` field on each shape entry carries the full multi-kind list so
-JSON consumers can distinguish, for example, an
-`owl:NamedIndividual`-flagged NodeShape from a plain one.
+shape (it appears in the Shapes section, not in Instances) and carries
+the `named individual` badge as well. The `kinds` field on each shape
+entry carries the full multi-kind list so JSON consumers can
+distinguish, for example, an `owl:NamedIndividual`-flagged NodeShape
+from a plain one.
 
 Twenty-one SHACL constraints get explicit per-format rendering:
 
@@ -350,6 +351,42 @@ Schema notes:
 Not covered: `skos:Collection` / `skos:OrderedCollection` and SKOS-XL
 (`skosxl:Label`). Both fall through to their existing treatment; file an
 issue if a real vocabulary needs them.
+
+## Named Individuals
+
+An entity explicitly typed `owl:NamedIndividual` carries a
+`named individual` badge alongside whatever else it is, and its `kinds`
+list gains `"named_individual"`.
+
+This is a *refinement*, not a bucket: named individuals stay exactly
+where they were routed. An individual stays under `instances/`, a
+concept under `concepts/`, a shape under `shapes/`. There is no
+`named_individuals/` directory, no new top-level JSON array and no CLI
+flag — nothing about this stage is a breaking change.
+
+What the badge tells you is that the **source says so**. Three cases:
+
+| Source | Kinds | Why |
+|---|---|---|
+| `:alice a :Person, owl:NamedIndividual` | `["instance", "named_individual"]` | Declared, though the class typing already implies it |
+| `:bob a :Person` | `["instance"]` | Nothing declared — no badge |
+| `:carol a owl:NamedIndividual` | `["instance", "named_individual"]` | The declaration is the only thing saying Carol is an individual |
+
+The badge shows on `:alice` even though the declaration is **redundant**
+in OWL DL terms — `:Person` already makes her an individual, and a
+reasoner would infer the `owl:NamedIndividual` typing anyway. It is
+surfaced because `kinds` records what the source asserts rather than
+what could be inferred, which is the same policy every other kind
+follows. In practice the distinction tells you something real: tools
+like Protégé emit these declarations consistently, hand-written
+ontologies often omit them, and seeing which you have is useful when
+merging the two.
+
+Not covered: `rdfs:Datatype`, and the deprecation markers
+`owl:DeprecatedClass` / `owl:DeprecatedProperty`. Deprecation is
+orthogonal to entity kind — a deprecated class and a deprecated property
+want different visual treatment — so it needs its own design rather than
+another kind.
 
 ## Command Options
 

--- a/src/rdf_construct/docs/extractors.py
+++ b/src/rdf_construct/docs/extractors.py
@@ -58,6 +58,11 @@ class EntityKind(str, Enum):
     SKOS_CONCEPT = "skos_concept"
     SKOS_CONCEPT_SCHEME = "skos_concept_scheme"
 
+    # Explicit owl:NamedIndividual declaration (#64). A refinement on an
+    # entity's other kinds rather than a bucket of its own — named
+    # individuals stay wherever they were routed.
+    NAMED_INDIVIDUAL = "named_individual"
+
     def __str__(self) -> str:
         # Return the string value so f-strings and Jinja render
         # "shape" rather than "EntityKind.SHAPE". See class docstring.
@@ -583,6 +588,26 @@ def extract_ontology_info(graph: Graph) -> OntologyInfo:
     return info
 
 
+def _is_named_individual(graph: Graph, uri: URIRef) -> bool:
+    """Report whether ``owl:NamedIndividual`` is asserted on a subject.
+
+    The ``kinds`` list records what the source asserts rather than what a
+    reasoner could infer, so the answer is a plain lookup: no attempt is
+    made to decide whether the declaration is redundant. On an entity that
+    already has a class typing it *is* redundant in OWL DL terms — and
+    that redundancy is itself information, because it tells a reader the
+    author was explicit. See issue #64.
+
+    Args:
+        graph: RDF graph to query.
+        uri: Entity URI.
+
+    Returns:
+        True when the entity is explicitly typed ``owl:NamedIndividual``.
+    """
+    return (uri, RDF.type, OWL.NamedIndividual) in graph
+
+
 def extract_class_info(graph: Graph, uri: URIRef) -> ClassInfo:
     """Extract comprehensive information about a class.
 
@@ -743,6 +768,9 @@ def extract_instance_info(graph: Graph, uri: URIRef) -> InstanceInfo:
         definition=get_definition(graph, uri),
         annotations=get_annotations(graph, uri),
     )
+
+    if _is_named_individual(graph, uri):
+        info.kinds.append(EntityKind.NAMED_INDIVIDUAL)
 
     # Types
     for obj in graph.objects(uri, RDF.type):
@@ -957,6 +985,10 @@ def extract_shape_info(graph: Graph, uri: URIRef) -> ShapeInfo:
         info.kinds.append(EntityKind.NODE_SHAPE)
     if is_property_shape:
         info.kinds.append(EntityKind.PROPERTY_SHAPE)
+    # A shape can be declared an individual too — stage 1 routed such a
+    # shape to shapes/ but recorded nothing about the declaration (#64).
+    if _is_named_individual(graph, uri):
+        info.kinds.append(EntityKind.NAMED_INDIVIDUAL)
     # If neither (shouldn't happen since the caller only passes shape URIs)
     # we still mark it as a shape so renderers don't crash on missing kind.
 
@@ -1216,6 +1248,9 @@ def extract_concept_info(graph: Graph, uri: URIRef) -> ConceptInfo:
         annotations=get_annotations(graph, uri),
     )
 
+    if _is_named_individual(graph, uri):
+        info.kinds.append(EntityKind.NAMED_INDIVIDUAL)
+
     # The SKOS notes are rendered from `notes`, with their language tags.
     # Drop the copies get_annotations() collected so they render once.
     for _, name in SKOS_NOTE_PREDICATES:
@@ -1264,6 +1299,9 @@ def extract_concept_scheme_info(graph: Graph, uri: URIRef) -> ConceptSchemeInfo:
         notes=_skos_notes(graph, uri),
         annotations=get_annotations(graph, uri),
     )
+
+    if _is_named_individual(graph, uri):
+        info.kinds.append(EntityKind.NAMED_INDIVIDUAL)
 
     for _, name in SKOS_NOTE_PREDICATES:
         info.annotations.pop(name, None)

--- a/src/rdf_construct/docs/renderers/html.py
+++ b/src/rdf_construct/docs/renderers/html.py
@@ -856,6 +856,16 @@ h4 { font-size: 1.1rem; }
 .entity-type.skos_concept { background: #1d4ed8; }
 .entity-type.skos_concept_scheme { background: #1e3a8a; }
 
+/* Named-individual badge (#64). A darker, deeper emerald than the plain
+   instance badge it sits beside, so the two read as one family the way
+   NodeShape and PropertyShape share red-rose:
+     .instance         #10b981  (existing)
+     .named_individual #047857  5.48:1 — clears WCAG AA against white
+   It stays 21.7 CIEDE2000 units from the instance emerald in normal
+   vision and 15.3 under simulated deuteranopia — related, not confusable
+   — and is further still from every other badge in the palette. */
+.entity-type.named_individual { background: #047857; }
+
 /* Language tag beside a SKOS label or note value. */
 .lang-tag {
     font-family: 'SF Mono', Consolas, monospace;

--- a/src/rdf_construct/docs/renderers/markdown.py
+++ b/src/rdf_construct/docs/renderers/markdown.py
@@ -570,6 +570,12 @@ class MarkdownRenderer:
 
         lines.append(f"# {instance_info.label or instance_info.qname}")
         lines.append("")
+        # All kinds, mirroring the HTML badges — an explicit
+        # owl:NamedIndividual declaration is visible here too (#64).
+        kind_labels = " ".join(f"`{kind}`" for kind in instance_info.kinds)
+        if kind_labels:
+            lines.append(f"**Kinds:** {kind_labels}")
+            lines.append("")
         lines.append(f"**URI:** `{instance_info.uri}`")
         lines.append("")
 

--- a/src/rdf_construct/docs/search.py
+++ b/src/rdf_construct/docs/search.py
@@ -283,8 +283,11 @@ def instance_to_search_entry(
         elif "/" in str(uri):
             keywords.extend(extract_keywords(str(uri).split("/")[-1]))
 
-    # Add "instance" as a keyword
+    # Add "instance" as a keyword, plus any further kinds the entity
+    # carries so a literal search for "named_individual" works (#64).
     keywords.append("instance")
+    for kind in instance_info.kinds:
+        keywords.append(str(kind))
 
     from .config import entity_to_url
 

--- a/src/rdf_construct/docs/templates/html/index.html.jinja
+++ b/src/rdf_construct/docs/templates/html/index.html.jinja
@@ -166,7 +166,9 @@
             <a href="{{ inst.qname | entity_url('instance') }}">
                 {{ inst.label or inst.qname }}
             </a>
-            <span class="entity-type instance">Instance</span>
+            {% for kind in inst.kinds %}
+            <span class="entity-type {{ kind }}">{{ kind | replace('_', ' ') }}</span>
+            {% endfor %}
         </li>
         {% endfor %}
     </ul>

--- a/src/rdf_construct/docs/templates/html/instance.html.jinja
+++ b/src/rdf_construct/docs/templates/html/instance.html.jinja
@@ -4,7 +4,14 @@
 
 {% block content %}
 <article class="entity-card">
-    <h1>{{ instance_info.label or instance_info.qname }} <span class="entity-type instance">Instance</span></h1>
+    <h1>
+        {{ instance_info.label or instance_info.qname }}
+        {# Every kind, not just "instance": an explicit owl:NamedIndividual
+           declaration shows as its own badge (#64). #}
+        {% for kind in instance_info.kinds %}
+        <span class="entity-type {{ kind }}">{{ kind | replace('_', ' ') }}</span>
+        {% endfor %}
+    </h1>
     <p class="uri">{{ instance_info.uri }}</p>
 
     {% if instance_info.definition %}

--- a/src/rdf_construct/docs/templates/html/single_page.html.jinja
+++ b/src/rdf_construct/docs/templates/html/single_page.html.jinja
@@ -228,7 +228,12 @@
     <h2>Instances</h2>
     {% for inst in instances %}
     <article class="entity-card" id="inst-{{ inst.qname | qname_local }}">
-        <h3>{{ inst.label or inst.qname }} <span class="entity-type instance">Instance</span></h3>
+        <h3>
+            {{ inst.label or inst.qname }}
+            {% for kind in inst.kinds %}
+            <span class="entity-type {{ kind }}">{{ kind | replace('_', ' ') }}</span>
+            {% endfor %}
+        </h3>
         <p class="uri">{{ inst.uri }}</p>
         {% if inst.definition %}
         <p class="definition">{{ inst.definition }}</p>

--- a/tests/fixtures/docs/named_individuals.ttl
+++ b/tests/fixtures/docs/named_individuals.ttl
@@ -1,0 +1,46 @@
+@prefix ex:   <http://example.org/ni#> .
+@prefix owl:  <http://www.w3.org/2002/07/owl#> .
+@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
+
+#
+# Test material for owl:NamedIndividual badging (issue #64).
+#
+# No RDF file in this repository contained owl:NamedIndividual at all
+# before this, so these are the three cases the badge turns on:
+#
+#   ex:Alice   — class-typed *and* explicitly owl:NamedIndividual. The
+#                common Protégé-generated shape, and the case where the
+#                declaration is redundant in OWL DL terms.
+#   ex:Bob     — class-typed only. The false-positive guard: no badge.
+#   ex:Carol   — owl:NamedIndividual and nothing else. No class typing at
+#                all, so the declaration is the only thing saying this is
+#                an individual. Must still be documented.
+#
+# ex:Person and ex:knows are here so the individuals have somewhere to
+# point and so the extractor has classes and properties to keep separate.
+#
+
+ex:NamedIndividualDemo a owl:Ontology ;
+    rdfs:label "Named Individual Demo"@en ;
+    rdfs:comment "Exercises explicit owl:NamedIndividual declarations."@en .
+
+ex:Person a owl:Class ;
+    rdfs:label "Person"@en .
+
+ex:knows a owl:ObjectProperty ;
+    rdfs:label "knows"@en ;
+    rdfs:domain ex:Person ;
+    rdfs:range ex:Person .
+
+ex:Alice a ex:Person , owl:NamedIndividual ;
+    rdfs:label "Alice"@en ;
+    rdfs:comment "Typed both by her class and as a named individual."@en ;
+    ex:knows ex:Bob .
+
+ex:Bob a ex:Person ;
+    rdfs:label "Bob"@en ;
+    rdfs:comment "Typed only by his class — carries no named-individual kind."@en .
+
+ex:Carol a owl:NamedIndividual ;
+    rdfs:label "Carol"@en ;
+    rdfs:comment "Declared only as a named individual, with no class typing."@en .

--- a/tests/test_docs.py
+++ b/tests/test_docs.py
@@ -29,8 +29,9 @@ from rdf_construct.docs.config import (
 from rdf_construct.docs.search import extract_keywords, generate_search_index
 
 
-# Test namespace
+# Test namespaces
 EX = Namespace("http://example.org/")
+EX_NI = Namespace("http://example.org/ni#")
 
 
 @pytest.fixture
@@ -1722,7 +1723,8 @@ class TestSKOSRendering:
         DocsGenerator(config).generate(skos_vocabulary)
 
         data = json.loads((output_dir / "concepts" / "Building.json").read_text())
-        assert data["kinds"] == ["skos_concept"]
+        # ex:Building is also owl:NamedIndividual, so it carries both kinds (#64)
+        assert data["kinds"] == ["skos_concept", "named_individual"]
         assert {"labels", "notes", "broader", "narrower", "in_schemes"} <= set(data)
 
         french = next(group for group in data["labels"] if group["language"] == "fr")
@@ -1809,7 +1811,7 @@ class TestSKOSSearchIndex:
         entries = generate_search_index(entities, DocsConfig())
 
         entry = next(e for e in entries if e.qname == "ex:Building")
-        assert entry.kinds == ["skos_concept"]
+        assert entry.kinds == ["skos_concept", "named_individual"]
         assert entry.url == "concepts/Building.html"
 
     def test_alt_and_hidden_labels_indexed(self, skos_vocabulary: Graph):
@@ -1877,3 +1879,236 @@ class TestSKOSRouting:
         assert entity_to_path("ex:Building", EntityKind.SKOS_CONCEPT, config) == Path(
             "concepts/Building.html"
         )
+
+
+# ---------------------------------------------------------------------------
+# owl:NamedIndividual badging — issue #64 / milestone v0.6.0 stage 3
+# ---------------------------------------------------------------------------
+
+
+NAMED_INDIVIDUAL_FIXTURE = Path(__file__).parent / "fixtures" / "docs" / "named_individuals.ttl"
+
+
+@pytest.fixture
+def named_individual_ontology() -> Graph:
+    """Load the tracked owl:NamedIndividual test ontology.
+
+    No RDF file in the repository contained ``owl:NamedIndividual`` at all
+    before #64. The fixture carries the three cases the badge turns on:
+    class-typed *and* declared (``ex:Alice``), class-typed only
+    (``ex:Bob``, the false-positive guard) and declared with no class
+    typing at all (``ex:Carol``).
+    """
+    g = Graph()
+    g.parse(NAMED_INDIVIDUAL_FIXTURE, format="turtle")
+    return g
+
+
+def _instance(entities: ExtractedEntities, local_name: str):
+    """Find an instance by the local part of its qname."""
+    return next(i for i in entities.instances if i.qname.split(":")[-1] == local_name)
+
+
+class TestNamedIndividualExtraction:
+    """Tests for the NAMED_INDIVIDUAL kind."""
+
+    def test_explicit_declaration_carries_the_kind(self, named_individual_ontology: Graph):
+        """An entity typed both by its class and owl:NamedIndividual gets both kinds."""
+        entities = extract_all(named_individual_ontology)
+        alice = _instance(entities, "Alice")
+        assert alice.kinds == [EntityKind.INSTANCE, EntityKind.NAMED_INDIVIDUAL]
+
+    def test_redundant_declaration_still_shows(self, named_individual_ontology: Graph):
+        """The kind records what the source asserts, not what is inferable.
+
+        ``ex:Alice`` is already an individual by virtue of her ``ex:Person``
+        typing, so the ``owl:NamedIndividual`` triple is redundant in OWL DL
+        terms. It is surfaced anyway: the redundancy tells a reader the
+        author was explicit, which is the same policy ``kinds`` follows
+        everywhere else.
+        """
+        entities = extract_all(named_individual_ontology)
+        alice = _instance(entities, "Alice")
+        assert EntityKind.NAMED_INDIVIDUAL in alice.kinds
+        assert str(EX_NI.Person) in [str(t) for t in alice.types]
+
+    def test_class_typed_only_does_not_get_the_kind(self, named_individual_ontology: Graph):
+        """The false-positive guard: no declaration, no badge."""
+        entities = extract_all(named_individual_ontology)
+        bob = _instance(entities, "Bob")
+        assert bob.kinds == [EntityKind.INSTANCE]
+        assert EntityKind.NAMED_INDIVIDUAL not in bob.kinds
+
+    def test_declaration_alone_is_documented(self, named_individual_ontology: Graph):
+        """An entity typed *only* owl:NamedIndividual is still an instance.
+
+        With no class typing, the declaration is the only thing saying this
+        is an individual — so it must neither be dropped nor land in some
+        other bucket.
+        """
+        entities = extract_all(named_individual_ontology)
+        carol = _instance(entities, "Carol")
+        assert carol.kinds == [EntityKind.INSTANCE, EntityKind.NAMED_INDIVIDUAL]
+        assert [str(t) for t in carol.types] == [str(OWL.NamedIndividual)]
+
+    def test_classes_and_properties_do_not_get_the_kind(self, named_individual_ontology: Graph):
+        """Classes and properties are not individuals; nothing badges them."""
+        entities = extract_all(named_individual_ontology)
+        for class_info in entities.classes:
+            assert EntityKind.NAMED_INDIVIDUAL not in class_info.kinds
+        for prop in entities.properties:
+            assert EntityKind.NAMED_INDIVIDUAL not in prop.kinds
+
+    def test_shape_that_is_also_a_named_individual(self):
+        """Stage 1 routed such a shape to shapes/; it now records the declaration.
+
+        The routing is unchanged — the shape is documented once, under
+        Shapes, and does not appear in Instances.
+        """
+        g = Graph()
+        g.bind("ex", EX)
+        g.add((EX.MyShape, RDF.type, SH.NodeShape))
+        g.add((EX.MyShape, RDF.type, OWL.NamedIndividual))
+
+        entities = extract_all(g)
+        shape = next(s for s in entities.shapes if s.qname == "ex:MyShape")
+        assert shape.kinds == [
+            EntityKind.SHAPE,
+            EntityKind.NODE_SHAPE,
+            EntityKind.NAMED_INDIVIDUAL,
+        ]
+        assert "ex:MyShape" not in {i.qname for i in entities.instances}
+
+    def test_concept_that_is_also_a_named_individual(self, skos_vocabulary: Graph):
+        """The SKOS multi-kind case: badge added, routing unchanged."""
+        entities = extract_all(skos_vocabulary)
+        building = _concept(entities, "Building")
+        assert building.kinds == [EntityKind.SKOS_CONCEPT, EntityKind.NAMED_INDIVIDUAL]
+        assert "ex:Building" not in {i.qname for i in entities.instances}
+
+    def test_concept_without_the_declaration_is_unaffected(self, skos_vocabulary: Graph):
+        entities = extract_all(skos_vocabulary)
+        dwelling = _concept(entities, "Dwelling")
+        assert dwelling.kinds == [EntityKind.SKOS_CONCEPT]
+
+
+class TestNamedIndividualRendering:
+    """Tests for the badge in HTML, Markdown and JSON output."""
+
+    def test_html_instance_badge(self, named_individual_ontology: Graph, output_dir: Path):
+        config = DocsConfig(output_dir=output_dir, format="html")
+        DocsGenerator(config).generate(named_individual_ontology)
+
+        alice = (output_dir / "instances" / "Alice.html").read_text()
+        assert 'class="entity-type named_individual"' in alice
+        assert "named individual" in alice
+
+    def test_html_no_badge_without_declaration(
+        self, named_individual_ontology: Graph, output_dir: Path
+    ):
+        config = DocsConfig(output_dir=output_dir, format="html")
+        DocsGenerator(config).generate(named_individual_ontology)
+
+        bob = (output_dir / "instances" / "Bob.html").read_text()
+        assert 'class="entity-type named_individual"' not in bob
+        assert 'class="entity-type instance"' in bob
+
+    def test_html_badge_css_present(self, named_individual_ontology: Graph, output_dir: Path):
+        config = DocsConfig(output_dir=output_dir, format="html")
+        DocsGenerator(config).generate(named_individual_ontology)
+
+        css = (output_dir / "assets" / "style.css").read_text()
+        assert ".entity-type.named_individual { background: #047857; }" in css
+
+    def test_html_index_shows_the_badge(self, named_individual_ontology: Graph, output_dir: Path):
+        config = DocsConfig(output_dir=output_dir, format="html")
+        DocsGenerator(config).generate(named_individual_ontology)
+
+        html = (output_dir / "index.html").read_text()
+        assert 'class="entity-type named_individual"' in html
+
+    def test_html_single_page_shows_the_badge(
+        self, named_individual_ontology: Graph, output_dir: Path
+    ):
+        config = DocsConfig(output_dir=output_dir, format="html", single_page=True)
+        DocsGenerator(config).generate(named_individual_ontology)
+
+        html = (output_dir / "index.html").read_text()
+        assert 'class="entity-type named_individual"' in html
+
+    def test_markdown_kinds_line(self, named_individual_ontology: Graph, output_dir: Path):
+        config = DocsConfig(output_dir=output_dir, format="markdown")
+        DocsGenerator(config).generate(named_individual_ontology)
+
+        alice = (output_dir / "instances" / "Alice.md").read_text()
+        assert "**Kinds:** `instance` `named_individual`" in alice
+
+        bob = (output_dir / "instances" / "Bob.md").read_text()
+        assert "**Kinds:** `instance`" in bob
+        assert "named_individual" not in bob
+
+    def test_json_kinds_array(self, named_individual_ontology: Graph, output_dir: Path):
+        config = DocsConfig(output_dir=output_dir, format="json")
+        DocsGenerator(config).generate(named_individual_ontology)
+
+        alice = json.loads((output_dir / "instances" / "Alice.json").read_text())
+        assert alice["kinds"] == ["instance", "named_individual"]
+
+        bob = json.loads((output_dir / "instances" / "Bob.json").read_text())
+        assert bob["kinds"] == ["instance"]
+
+    def test_json_no_new_top_level_array(self, named_individual_ontology: Graph, output_dir: Path):
+        """Named individuals stay in `instances` — this stage is not breaking."""
+        config = DocsConfig(output_dir=output_dir, format="json")
+        DocsGenerator(config).generate(named_individual_ontology)
+
+        data = json.loads((output_dir / "index.json").read_text())
+        assert "named_individuals" not in data
+        assert {"ex:Alice", "ex:Bob", "ex:Carol"} <= {i["qname"] for i in data["instances"]}
+
+    def test_markdown_concept_shows_both_kinds(self, skos_vocabulary: Graph, output_dir: Path):
+        config = DocsConfig(output_dir=output_dir, format="markdown")
+        DocsGenerator(config).generate(skos_vocabulary)
+
+        md = (output_dir / "concepts" / "Building.md").read_text()
+        assert "**Kinds:** `skos_concept` `named_individual`" in md
+
+
+class TestNamedIndividualSearchIndex:
+    """Tests for the search index treatment."""
+
+    def test_kinds_field_populated(self, named_individual_ontology: Graph):
+        entities = extract_all(named_individual_ontology)
+        entries = generate_search_index(entities, DocsConfig())
+
+        alice = next(e for e in entries if e.qname == "ex:Alice")
+        assert alice.kinds == ["instance", "named_individual"]
+        assert alice.entity_type == "instance"
+
+    def test_kind_is_searchable(self, named_individual_ontology: Graph):
+        entities = extract_all(named_individual_ontology)
+        entries = generate_search_index(entities, DocsConfig())
+
+        alice = next(e for e in entries if e.qname == "ex:Alice")
+        assert "named_individual" in alice.keywords
+
+        bob = next(e for e in entries if e.qname == "ex:Bob")
+        assert "named_individual" not in bob.keywords
+
+    def test_no_new_entity_type(self, named_individual_ontology: Graph):
+        """Named individuals are not a separate search bucket."""
+        entities = extract_all(named_individual_ontology)
+        entries = generate_search_index(entities, DocsConfig())
+
+        assert not [e for e in entries if e.entity_type == "named_individual"]
+
+
+class TestNamedIndividualEnum:
+    """The new enum member follows the same str-mixin contract."""
+
+    def test_value_and_str(self):
+        assert EntityKind.NAMED_INDIVIDUAL == "named_individual"
+        assert str(EntityKind.NAMED_INDIVIDUAL) == "named_individual"
+
+    def test_json_serialises_as_plain_string(self):
+        assert json.dumps(EntityKind.NAMED_INDIVIDUAL) == '"named_individual"'


### PR DESCRIPTION
## What

Stage 3 of the v0.6.0 entity-type taxonomy: an entity explicitly typed `owl:NamedIndividual` now carries a `named individual` badge and `"named_individual"` in its `kinds` array.

Closes #64.

> **Stacked on #103.** Base is `dev/skos-entity-types-63`, not `main`, so this diff shows stage 3 alone. It needs stage 3's neighbour only because the SKOS extractor gains the same two lines; rebase onto `main` once #103 merges, or merge #103 first and this retargets cleanly.

## The enum member did not exist

The issue asserted twice that `EntityKind.NAMED_INDIVIDUAL` was already in stage 1's data model. It was not — the enum had ten members and none of them was this. That error was load-bearing: it sized the stage as "render a kind that is already extracted" rather than "introduce the kind, extract it, and render it". The issue has been corrected; this PR does all three.

Likewise there was no `owl:NamedIndividual` in any RDF file in the repository, tracked or untracked, so `tests/fixtures/docs/named_individuals.ttl` is part of the change. It carries the three cases the badge turns on:

| Fixture entity | Source | Kinds | Why it is there |
|---|---|---|---|
| `ex:Alice` | `a ex:Person, owl:NamedIndividual` | `["instance", "named_individual"]` | The common Protégé shape — and the redundant-declaration case question 3 turns on |
| `ex:Bob` | `a ex:Person` | `["instance"]` | The false-positive guard |
| `ex:Carol` | `a owl:NamedIndividual` | `["instance", "named_individual"]` | No class typing at all — the declaration is the only evidence, and the case most likely to be got wrong |

## Design decisions

**Question 1 — separate stage or fold into #63?** Resolved in #103's panel: **separate, and it held up.** Stage 2 does routing (single-valued, needs a priority); this does badging (multi-valued, additive). Because stage 2's templates loop `kinds` rather than hardcoding badges, this stage lands on concepts, schemes and shapes for free.

**Question 2 — other meta-classes?** Scoped narrowly to `owl:NamedIndividual`, as the issue's lean proposed. `rdfs:Datatype` and the deprecation markers are out. Deprecation is *orthogonal* to entity kind — a deprecated class wants different treatment from a deprecated property — so it is a cross-cutting indicator needing its own design, not an eleventh kind.

**Question 3 — does the badge show when the typing is redundant? This is the one with content.** In OWL DL, `owl:NamedIndividual` on an entity that already has a class typing is strictly inferable, and there is a real case that surfacing it is noise.

**Decision: always show.** Three reasons, in order of weight:

1. `kinds` records what the **source asserts**, not what a reasoner could infer. That is the policy stage 1 set and every kind follows; making this one kind mean something different would be the inconsistency.
2. The alternative — "show only when alone" — makes the badge mean *"this entity has no class typing"*, which is a stranger and less useful fact than "the author declared this".
3. The redundancy is information. Protégé-generated ontologies carry these declarations consistently and hand-written ones often do not; seeing which you have in front of you matters when merging the two.

**Question 4 — search index.** No schema change: `entity_type` stays `"instance"` so named individuals are not a separate search bucket. The kind does join the entity's keywords, so a literal search for `named_individual` finds them — one line, mirroring what `shape_to_search_entry` already does.

**Question 5 — palette.** Needed a green in the instance family, mirroring how the shape kinds share red-rose:

| Kind | Colour | Contrast vs white | ΔE2000 from the instance emerald (normal / deut / prot / trit) |
|---|---|---|---|
| `instance` | `#10b981` (existing) | 2.54:1 | — |
| `named_individual` | `#047857` | **5.48:1** | 21.7 / 15.3 / 17.9 / 19.9 |

Clears WCAG AA; visibly the same hue family as the badge beside it, and further still from every other badge in the palette. Note the existing `#10b981` instance badge is 2.54:1 and does **not** clear AA — pre-existing, out of scope here, flagged in #103's panel.

**Question 6 — release vehicle.** Superseded. Version untouched; CHANGELOG `[Unreleased]` only. #63 and #64 go out together as v0.6.0, on your approval and as a separate act.

## Scope note: shapes and concepts get the badge too

The issue's title says instance badges, but `owl:NamedIndividual` is asserted on shapes and concepts in the wild too, and v0.5.0's CHANGELOG explicitly anticipated this ("the `kinds` list is the extension point for it"). So the kind is added wherever the declaration appears on an entity that *is* an individual: instances, SKOS concepts, concept schemes and SHACL shapes.

**Routing is unchanged everywhere.** Stage 1's `test_multi_kind_node_shape_also_named_individual` case still routes to `shapes/` and still stays out of Instances — it now records the declaration as well.

Classes and properties never get the kind. `owl:NamedIndividual` on a class is OWL Full punning, which belongs with the deprecated/punning follow-up rather than here.

## Verification

- `scripts/ci-local.sh` green: **709 passed** (687 on the #63 branch), black clean.
- 22 new tests: all three fixture cases, the multi-kind interactions with SKOS and SHACL, the class/property negative case, all three renderers, index and single-page badges, CSS, the search index, and the enum's str-mixin contract.
- Two assertions from #103 updated rather than worked around: `ex:Building` in the SKOS fixture is a concept *and* an `owl:NamedIndividual`, so its kinds correctly went from `["skos_concept"]` to `["skos_concept", "named_individual"]`. That the SKOS tests noticed is the multi-kind model working.
- ruff and mypy unchanged from the #63 branch.

## Not breaking

Named individuals stay in `instances` (or `concepts`, or `shapes`). No new top-level JSON array, no new directory, no new CLI flag. A consumer that ignores `kinds` sees no difference.
