### PR TITLE
fix(docs): resolve markdown links from page location

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -123,6 +123,25 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   normal vision, 15.3 under simulated deuteranopia
 
 ### Fixed
+- **Markdown cross-references now resolve from the page that contains them**
+  (#87, contributed by @tasodoufu). Entity links were emitted as a path from
+  the docs root regardless of where the page sat, so from `classes/Dog.md` a
+  link to `Mammal` read `classes/Mammal.md` and resolved as
+  `classes/classes/Mammal.md` — broken in GitHub's blob view, in MkDocs and in
+  any local previewer. The renderer now threads the page being written through
+  to the link helper, as the HTML renderer has done since #59. Two follow-ons
+  landed with it:
+  - `render_concept` and `render_concept_scheme` set the current page too.
+    Without it the SKOS pages inherited whatever rendered last, which happened
+    to be the right depth when instances were present and one level too high
+    when they were not — 38 wrong-depth links under `--no-instances`
+  - Link extensions are stated rather than derived from `config.format`, whose
+    map knows `"markdown"` but not the `"md"` alias `DocsGenerator` accepts.
+    Under that alias the files were written `.md` while every link pointed at
+    `.html`
+  A Markdown link walk now covers all of it — the counterpart of the HTML walk
+  that has caught this class of bug since #60, and whose absence is a fair part
+  of why #87 lasted as long as it did
 - **Every entity-kind badge now clears WCAG AA contrast** (#106). Four failed
   outright — `annotation` 2.15:1, `datatype` 2.43:1, `instance` 2.54:1 and
   `object` 4.23:1, against badge text that is 12px bold and so needs 4.5:1,

--- a/src/rdf_construct/docs/config.py
+++ b/src/rdf_construct/docs/config.py
@@ -312,6 +312,7 @@ def entity_to_url(
     entity_type: str,
     config: DocsConfig,
     from_path: Path | str | None = None,
+    extension: str | None = None,
 ) -> str:
     """Generate the URL for an entity's documentation page.
 
@@ -326,11 +327,16 @@ def entity_to_url(
             depth in the output tree. When ``config.base_url`` is set, that
             value takes precedence and ``from_path`` is ignored, preserving
             the previous behaviour.
+        extension: File extension, passed through to
+            :func:`entity_to_path`. Defaults to one derived from
+            ``config.format`` — which knows ``"markdown"`` but not the
+            ``"md"`` alias that :class:`DocsGenerator` accepts, so a caller
+            that may see either should state it.
 
     Returns:
         URL path for linking to the entity.
     """
-    path = entity_to_path(qname, entity_type, config)
+    path = entity_to_path(qname, entity_type, config, extension=extension)
     url = str(path).replace("\\", "/")  # Ensure forward slashes
 
     if config.base_url:

--- a/src/rdf_construct/docs/renderers/markdown.py
+++ b/src/rdf_construct/docs/renderers/markdown.py
@@ -92,7 +92,18 @@ class MarkdownRenderer:
         # Resolved from the page that contains the link rather than from the
         # docs root, so a cross-reference from a sub-folder page does not
         # resolve one level too deep (#87).
-        path = entity_to_url(qname, entity_type, self.config, from_path=self._current_page)
+        #
+        # The extension is stated rather than derived: entity_to_url falls
+        # back to config.format, whose map knows "markdown" but not the "md"
+        # alias DocsGenerator accepts — and under that alias the files are
+        # still written .md while every link would point at .html.
+        path = entity_to_url(
+            qname,
+            entity_type,
+            self.config,
+            from_path=self._current_page,
+            extension=".md",
+        )
         return f"[{display}]({path})"
 
     def _frontmatter(self, **kwargs: Any) -> str:
@@ -719,6 +730,14 @@ class MarkdownRenderer:
         Returns:
             Path to the rendered file.
         """
+        from ..config import entity_to_path
+
+        # Set before any line is built: _entity_link resolves every
+        # cross-reference against this, and a method that does not set it
+        # inherits whatever page rendered last (#87).
+        rel_path = entity_to_path(concept_info.qname, "skos_concept", self.config, extension=".md")
+        self._current_page = rel_path
+
         lines = []
 
         lines.append(
@@ -824,9 +843,6 @@ class MarkdownRenderer:
             lines.append("")
 
         content = "\n".join(lines)
-        from ..config import entity_to_path
-
-        rel_path = entity_to_path(concept_info.qname, "skos_concept", self.config, extension=".md")
         return self._write_file(self.config.output_dir / rel_path, content)
 
     def render_concept_scheme(
@@ -844,6 +860,16 @@ class MarkdownRenderer:
             Path to the rendered file.
         """
         from ..extractors import build_concept_tree
+
+        from ..config import entity_to_path
+
+        # Set before any line is built: _entity_link resolves every
+        # cross-reference against this, and a method that does not set it
+        # inherits whatever page rendered last (#87).
+        rel_path = entity_to_path(
+            scheme_info.qname, "skos_concept_scheme", self.config, extension=".md"
+        )
+        self._current_page = rel_path
 
         lines = []
 
@@ -941,14 +967,6 @@ class MarkdownRenderer:
             lines.append("")
 
         content = "\n".join(lines)
-        from ..config import entity_to_path
-
-        rel_path = entity_to_path(
-            scheme_info.qname,
-            "skos_concept_scheme",
-            self.config,
-            extension=".md",
-        )
         return self._write_file(self.config.output_dir / rel_path, content)
 
     def _render_property_shape_table(

--- a/src/rdf_construct/docs/renderers/markdown.py
+++ b/src/rdf_construct/docs/renderers/markdown.py
@@ -36,6 +36,7 @@ class MarkdownRenderer:
             config: Documentation configuration.
         """
         self.config = config
+        self._current_page: Path | None = None
 
     def _get_output_path(self, filename: str, subdir: str | None = None) -> Path:
         """Get the full output path for a file.
@@ -80,7 +81,7 @@ class MarkdownRenderer:
         Returns:
             Markdown link string.
         """
-        from ..config import entity_to_path, entity_type_included
+        from ..config import entity_to_url, entity_type_included
 
         display = label or qname
         # A link to a page this run is not generating is a dead link (#115).
@@ -88,8 +89,10 @@ class MarkdownRenderer:
         # unlinked, but still visible.
         if not entity_type_included(entity_type, self.config):
             return f"`{qname}`"
-        path = entity_to_path(qname, entity_type, self.config, extension=".md")
-        # Make path relative from root
+        # Resolved from the page that contains the link rather than from the
+        # docs root, so a cross-reference from a sub-folder page does not
+        # resolve one level too deep (#87).
+        path = entity_to_url(qname, entity_type, self.config, from_path=self._current_page)
         return f"[{display}]({path})"
 
     def _frontmatter(self, **kwargs: Any) -> str:
@@ -122,6 +125,7 @@ class MarkdownRenderer:
         Returns:
             Path to the rendered file.
         """
+        self._current_page = Path("index.md")
         lines = []
 
         # Frontmatter
@@ -261,6 +265,7 @@ class MarkdownRenderer:
         Returns:
             Path to the rendered file.
         """
+        self._current_page = Path("hierarchy.md")
         lines = []
 
         lines.append(self._frontmatter(title="Class Hierarchy"))
@@ -337,6 +342,10 @@ class MarkdownRenderer:
         Returns:
             Path to the rendered file.
         """
+        from ..config import entity_to_path
+
+        rel_path = entity_to_path(class_info.qname, "class", self.config, extension=".md")
+        self._current_page = rel_path
         lines = []
 
         lines.append(
@@ -414,9 +423,6 @@ class MarkdownRenderer:
             lines.append("")
 
         content = "\n".join(lines)
-        from ..config import entity_to_path
-
-        rel_path = entity_to_path(class_info.qname, "class", self.config, extension=".md")
         return self._write_file(self.config.output_dir / rel_path, content)
 
     def _uri_to_display(
@@ -506,6 +512,11 @@ class MarkdownRenderer:
         Returns:
             Path to the rendered file.
         """
+        from ..config import entity_to_path
+
+        entity_type = f"{prop_info.property_type}_property"
+        rel_path = entity_to_path(prop_info.qname, entity_type, self.config, extension=".md")
+        self._current_page = rel_path
         lines = []
 
         type_label = prop_info.property_type.replace("_", " ").title()
@@ -581,10 +592,6 @@ class MarkdownRenderer:
             lines.append("")
 
         content = "\n".join(lines)
-        entity_type = f"{prop_info.property_type}_property"
-        from ..config import entity_to_path
-
-        rel_path = entity_to_path(prop_info.qname, entity_type, self.config, extension=".md")
         return self._write_file(self.config.output_dir / rel_path, content)
 
     def render_instance(
@@ -601,6 +608,10 @@ class MarkdownRenderer:
         Returns:
             Path to the rendered file.
         """
+        from ..config import entity_to_path
+
+        rel_path = entity_to_path(instance_info.qname, "instance", self.config, extension=".md")
+        self._current_page = rel_path
         lines = []
 
         lines.append(
@@ -654,9 +665,6 @@ class MarkdownRenderer:
             lines.append("")
 
         content = "\n".join(lines)
-        from ..config import entity_to_path
-
-        rel_path = entity_to_path(instance_info.qname, "instance", self.config, extension=".md")
         return self._write_file(self.config.output_dir / rel_path, content)
 
     def _render_label_table(self, labels: list["LabelGroup"]) -> list[str]:
@@ -1028,6 +1036,10 @@ class MarkdownRenderer:
         Returns:
             Path to the rendered file.
         """
+        from ..config import entity_to_path
+
+        rel_path = entity_to_path(shape_info.qname, "shape", self.config, extension=".md")
+        self._current_page = rel_path
         lines = []
 
         # Frontmatter — pick the most-specific kind for the type field
@@ -1149,9 +1161,6 @@ class MarkdownRenderer:
             lines.append("")
 
         content = "\n".join(lines)
-        from ..config import entity_to_path
-
-        rel_path = entity_to_path(shape_info.qname, "shape", self.config, extension=".md")
         return self._write_file(self.config.output_dir / rel_path, content)
 
     def render_namespaces(self, entities: "ExtractedEntities") -> Path:
@@ -1163,6 +1172,7 @@ class MarkdownRenderer:
         Returns:
             Path to the rendered file.
         """
+        self._current_page = Path("namespaces.md")
         lines = []
 
         lines.append(self._frontmatter(title="Namespaces"))
@@ -1194,6 +1204,7 @@ class MarkdownRenderer:
             at something this run never produced — see #113. The HTML
             single-page template takes the same line.
         """
+        self._current_page = Path("index.md")
         lines = []
 
         lines.append(

--- a/tests/test_docs.py
+++ b/tests/test_docs.py
@@ -3187,3 +3187,82 @@ class TestBadgePaletteContrast:
         assert round(contrast_against_white("#ffffff"), 2) == 1.0
         assert round(contrast_against_white("#000000"), 2) == 21.0
         assert round(contrast_against_white("#dc2626"), 2) == 4.83
+
+
+# ---------------------------------------------------------------------------
+# Multi-page Markdown link resolution — issue #87
+# ---------------------------------------------------------------------------
+
+
+class TestMarkdownLinkResolution:
+    """Markdown cross-references must resolve from the page containing them.
+
+    The renderer emitted every entity link as a path from the docs root, so
+    from ``classes/Dog.md`` a link to ``Mammal`` read ``classes/Mammal.md``
+    and resolved as ``classes/classes/Mammal.md``. Broken in GitHub's blob
+    view, in MkDocs and in any local previewer.
+
+    This is the walk the HTML side has had since #60 and Markdown never
+    had — which is a fair part of why #87 survived, and why the two
+    regressions below were possible.
+    """
+
+    @pytest.mark.parametrize(
+        "fixture_name", ["simple_ontology", "shape_ontology", "skos_vocabulary"]
+    )
+    def test_every_link_resolves(
+        self,
+        fixture_name: str,
+        request: pytest.FixtureRequest,
+        output_dir: Path,
+    ):
+        graph = request.getfixturevalue(fixture_name)
+        config = DocsConfig(output_dir=output_dir, format="markdown")
+        DocsGenerator(config).generate(graph)
+
+        # The walk is pointless if the fixture produced nothing at depth.
+        assert list(output_dir.rglob("*/*.md")), "fixture generated no pages in sub-folders"
+        assert broken_markdown_links(output_dir) == []
+
+    def test_links_resolve_from_two_levels_deep(self, simple_ontology: Graph, output_dir: Path):
+        """Property pages sit at ``properties/object/``, so they need ``../..``."""
+        config = DocsConfig(output_dir=output_dir, format="markdown")
+        DocsGenerator(config).generate(simple_ontology)
+
+        page = output_dir / "properties" / "object" / "hasOwner.md"
+        assert page.exists()
+        assert "](../../classes/" in page.read_text()
+
+    def test_skos_pages_do_not_inherit_a_stale_page(self, skos_vocabulary: Graph, output_dir: Path):
+        """The regression that hides behind unrelated flags.
+
+        ``_current_page`` is set per render method and never restored, so a
+        method that does not set it inherits whatever rendered last. With
+        instances present the SKOS pages happened to be at the same depth
+        and looked correct; without them the previous page is a property,
+        two levels deep, and every concept link resolves one level too high.
+        """
+        config = DocsConfig(output_dir=output_dir, format="markdown", include_instances=False)
+        DocsGenerator(config).generate(skos_vocabulary)
+
+        assert broken_markdown_links(output_dir) == []
+
+    def test_md_format_alias_links_stay_markdown(self, output_dir: Path):
+        """``DocsGenerator`` accepts ``format="md"``; the links must follow.
+
+        ``entity_to_url`` derives the extension from ``config.format``,
+        whose map knows ``"markdown"`` but not the alias — under which the
+        files are still written ``.md`` while every link would point at
+        ``.html``. The CLI normalises ``md`` to ``markdown``, so this is
+        only reachable through the public API, which is exactly why it
+        needs a test.
+        """
+        graph = Graph()
+        graph.parse("examples/animal_ontology.ttl", format="turtle")
+        config = DocsConfig(output_dir=output_dir, format="md")
+        DocsGenerator(config).generate(graph)
+
+        page = output_dir / "classes" / "Dog.md"
+        assert page.exists()
+        assert ".html)" not in page.read_text()
+        assert broken_markdown_links(output_dir) == []

--- a/tests/test_docs.py
+++ b/tests/test_docs.py
@@ -284,6 +284,9 @@ class TestGenerator:
 
         assert (output_dir / "index.md").exists()
         assert (output_dir / "hierarchy.md").exists()
+        content = (output_dir / "classes" / "Dog.md").read_text(encoding="utf-8")
+        assert "../classes/Mammal.md" in content
+        assert "classes/classes/Mammal.md" not in content
 
     def test_generator_json_output(self, simple_ontology: Graph, output_dir: Path):
         """Test JSON documentation generation."""


### PR DESCRIPTION
## Summary

Markdown entity links are now resolved relative to the page that contains them, fixing broken cross-references from nested documentation pages.

## Changes

- Pass each rendered page path to the shared URL helper.
- Add a regression assertion for nested Markdown class pages.

## Testing

- `uv run --with pytest-cov pytest tests/test_docs.py -q --no-cov` (88 passed)
- `uv run --with black black --check --target-version py311 src/rdf_construct/docs/renderers/markdown.py`
- `git diff --check`

Closes #87