### PR TITLE
fix(docs): resolve search index and result links from the current page (#86)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -100,6 +100,24 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   normal vision, 15.3 under simulated deuteranopia
 
 ### Fixed
+- **The search overlay now works on every page, not just the three at the docs
+  root** (#86). `assets/search.js` made two root-relative assumptions that the
+  #59 fix did not reach, because that fix covered the Jinja templates only:
+  - It fetched `search.json` page-relatively, so from `classes/Dog.html` the
+    browser requested `classes/search.json`, got a 404, and the index never
+    loaded — typing in the box did nothing at all, with no error and no
+    empty-results message. On `examples/animal_ontology.ttl` the index was
+    unreachable from **16 of 19 pages**
+  - It injected the index's root-relative result URLs verbatim as hrefs, so a
+    result clicked from a sub-folder page resolved one level too deep —
+    **256 broken (page, result) pairs** on the same corpus
+  Both now resolve against a per-page `window.DOCS_ROOT`, set by
+  `base.html.jinja` from the same `link_root` every other link already uses, so
+  an explicit `base_url` keeps working unchanged
+- **The search box now says why it is unavailable under `file://`** instead of
+  rendering and silently doing nothing. `fetch` is CORS-blocked on `file://`
+  whatever the path, so search genuinely cannot work from a double-clicked
+  page; the input is disabled and explains itself
 - **`docs` no longer misfiles properties declared only by an OWL characteristic**
   (#76). A term declared solely `owl:TransitiveProperty`, `owl:SymmetricProperty`,
   `owl:AsymmetricProperty`, `owl:ReflexiveProperty`, `owl:IrreflexiveProperty`

--- a/docs/user_guides/DOCS_GUIDE.md
+++ b/docs/user_guides/DOCS_GUIDE.md
@@ -24,7 +24,7 @@ The default format produces a complete, navigable website with:
 - Index page with entity listings
 - Class hierarchy visualisation
 - Individual pages for each class, property, and instance
-- Client-side search functionality
+- Client-side search functionality (needs an HTTP server — see below)
 - Responsive CSS styling
 - Namespace reference page
 
@@ -138,6 +138,24 @@ Per-page files contain the complete entity record including all fields.
 > `concepts` and `concept_schemes` arrays; neither appears in
 > `instances` any more. See "SKOS Vocabularies" below for the per-page
 > schema.
+
+## Search
+
+HTML output ships a client-side search index (`search.json`) and a small
+overlay. It works from any page at any depth, and honours `base_url` when
+one is set.
+
+**It needs the docs to be served over HTTP.** Browsers block `fetch` on
+`file://` for security reasons regardless of the path, so search cannot
+work from a double-clicked `index.html`. The box disables itself and says
+so rather than appearing to work. Any static server will do:
+
+```bash
+poetry run rdf-construct docs ontology.ttl -o docs/
+cd docs && python3 -m http.server 8000
+```
+
+Disable the index entirely with `--no-search`.
 
 ## Properties Whose Kind the Source Does Not State
 

--- a/src/rdf_construct/docs/renderers/html.py
+++ b/src/rdf_construct/docs/renderers/html.py
@@ -1075,10 +1075,26 @@ document.addEventListener('DOMContentLoaded', function() {
 
     if (!searchInput || !resultsContainer) return;
 
+    // Where the docs root sits relative to THIS page. Set by base.html.jinja,
+    // which computes it per page (".", "..", "../.." or an absolute base_url).
+    // Falling back to "." keeps a hand-written page working at the root.
+    const docsRoot = (typeof window.DOCS_ROOT === 'string' && window.DOCS_ROOT)
+        ? window.DOCS_ROOT.replace(/\\/$/, '')
+        : '.';
+
+    // fetch() is blocked by CORS on file:// regardless of the path, so search
+    // cannot work from a double-clicked page. Say so rather than presenting a
+    // box that silently does nothing.
+    if (window.location.protocol === 'file:') {
+        searchInput.disabled = true;
+        searchInput.placeholder = 'Search needs an HTTP server (unavailable when opened as a file)';
+        return;
+    }
+
     let searchIndex = null;
 
-    // Load search index
-    fetch('search.json')
+    // Load search index, resolved from this page rather than assuming the root
+    fetch(docsRoot + '/search.json')
         .then(response => response.json())
         .then(data => {
             searchIndex = data.entities;
@@ -1121,8 +1137,11 @@ document.addEventListener('DOMContentLoaded', function() {
             return;
         }
 
+        // Entry URLs in search.json are stored relative to the docs root, so
+        // they have to be resolved against it — injected verbatim they
+        // resolve against the current page and 404 from any sub-folder.
         resultsContainer.innerHTML = results
-            .map(r => `<li><a href="${r.entity.url}">${r.entity.label}</a> <span class="entity-type ${r.entity.entity_type}">${r.entity.entity_type}</span></li>`)
+            .map(r => `<li><a href="${docsRoot}/${r.entity.url}">${r.entity.label}</a> <span class="entity-type ${r.entity.entity_type}">${r.entity.entity_type}</span></li>`)
             .join('');
     }
 

--- a/src/rdf_construct/docs/templates/html/base.html.jinja
+++ b/src/rdf_construct/docs/templates/html/base.html.jinja
@@ -43,6 +43,11 @@
     </footer>
 
     {% if config.include_search %}
+    {# search.js needs the same per-page root the templates use, for both the
+       index fetch and the result links. Without it the script has to assume
+       it is running at the docs root, which is only true of three pages —
+       see issue #86. Set before the script loads, not inside it. #}
+    <script>window.DOCS_ROOT = "{{ link_root }}";</script>
     <script src="{{ link_root }}/assets/search.js"></script>
     {% endif %}
     {% block scripts %}{% endblock %}

--- a/tests/test_docs.py
+++ b/tests/test_docs.py
@@ -2336,3 +2336,118 @@ class TestOtherPropertiesRendering:
         assert entity_to_path("ex:untyped", "property", config) == Path(
             "properties/other/untyped.html"
         )
+
+
+# ---------------------------------------------------------------------------
+# Search overlay path resolution — issue #86
+# ---------------------------------------------------------------------------
+
+
+class TestSearchOverlayPaths:
+    """The search overlay has to work from a page at any depth.
+
+    ``assets/search.js`` made two root-relative assumptions that #59 did
+    not reach, because #59 covered the Jinja templates only: it fetched
+    ``search.json`` page-relatively, and it injected the index's
+    root-relative result URLs verbatim as hrefs. On the animal-ontology
+    corpus that left the index unreachable from 16 of 19 pages and 256
+    (page, result) pairs pointing at files that do not exist.
+
+    These tests check the arithmetic the script performs rather than
+    driving a browser: the failure mode is a dead input and a 404, both
+    of which are decided entirely by these two path computations.
+    """
+
+    @staticmethod
+    def _docs_root(page: Path) -> str:
+        """Extract the per-page DOCS_ROOT the template declared."""
+        import re
+
+        match = re.search(r'window\.DOCS_ROOT = "([^"]*)"', page.read_text())
+        assert match is not None, f"{page} declares no DOCS_ROOT"
+        return match.group(1)
+
+    def test_docs_root_declared_on_every_page(self, shape_ontology: Graph, output_dir: Path):
+        """Every page states where the docs root is, relative to itself."""
+        config = DocsConfig(output_dir=output_dir, format="html")
+        DocsGenerator(config).generate(shape_ontology)
+
+        for page in output_dir.rglob("*.html"):
+            expected = relative_url_prefix(page.relative_to(output_dir))
+            assert self._docs_root(page) == expected
+
+    def test_index_fetch_resolves_from_every_page(self, shape_ontology: Graph, output_dir: Path):
+        """`fetch(docsRoot + '/search.json')` has to hit the real file.
+
+        This is the half that made the box inert: the request 404s, the
+        index never loads, and typing does nothing at all — no error, no
+        empty-results message.
+        """
+        config = DocsConfig(output_dir=output_dir, format="html")
+        DocsGenerator(config).generate(shape_ontology)
+
+        unreachable = [
+            str(page.relative_to(output_dir))
+            for page in output_dir.rglob("*.html")
+            if not (page.parent / f"{self._docs_root(page)}/search.json").resolve().exists()
+        ]
+        assert not unreachable, f"search.json unreachable from: {unreachable}"
+
+    def test_every_result_link_resolves_from_every_page(
+        self, skos_vocabulary: Graph, output_dir: Path
+    ):
+        """A result clicked from any page has to land on a real file.
+
+        Run over the SKOS fixture because its pages sit in a sub-folder,
+        which is precisely where the old behaviour broke.
+        """
+        config = DocsConfig(output_dir=output_dir, format="html")
+        DocsGenerator(config).generate(skos_vocabulary)
+
+        entries = json.loads((output_dir / "search.json").read_text())["entities"]
+        assert entries, "fixture produced an empty search index"
+
+        broken = [
+            (str(page.relative_to(output_dir)), entry["url"])
+            for page in output_dir.rglob("*.html")
+            for entry in entries
+            if not (page.parent / f"{self._docs_root(page)}/{entry['url']}").resolve().exists()
+        ]
+        assert not broken, f"{len(broken)} broken result links, e.g. {broken[:3]}"
+
+    def test_script_does_not_hardcode_the_root(self, simple_ontology: Graph, output_dir: Path):
+        """The old page-relative fetch must not come back."""
+        config = DocsConfig(output_dir=output_dir, format="html")
+        DocsGenerator(config).generate(simple_ontology)
+
+        js = (output_dir / "assets" / "search.js").read_text()
+        assert "fetch('search.json')" not in js
+        assert "docsRoot" in js
+
+    def test_explicit_base_url_is_used(self, simple_ontology: Graph, output_dir: Path):
+        """A configured base_url wins, as it does for every other link."""
+        config = DocsConfig(
+            output_dir=output_dir,
+            format="html",
+            base_url="https://example.com/docs",
+        )
+        DocsGenerator(config).generate(simple_ontology)
+
+        for rel in ("index.html", "classes/Dog.html"):
+            assert self._docs_root(output_dir / rel) == "https://example.com/docs"
+
+    def test_file_protocol_is_explained_not_silent(self, simple_ontology: Graph, output_dir: Path):
+        """Under file:// the box says why it cannot work.
+
+        `fetch` is CORS-blocked on file:// whatever the path, so search
+        genuinely cannot work from a double-clicked page. Rendering an
+        input that silently does nothing is the worst of the options
+        available.
+        """
+        config = DocsConfig(output_dir=output_dir, format="html")
+        DocsGenerator(config).generate(simple_ontology)
+
+        js = (output_dir / "assets" / "search.js").read_text()
+        assert "window.location.protocol === 'file:'" in js
+        assert "searchInput.disabled = true" in js
+        assert "placeholder" in js


### PR DESCRIPTION
## What

The search overlay worked on three pages out of nineteen. Closes #86.

## The bug, measured on `examples/animal_ontology.ttl`

Two independent root-relative assumptions in `assets/search.js`, both left behind by #59 — that fix covered the Jinja templates, and the script was never touched.

| | Before | After |
|---|---|---|
| Pages where the index fetch 404s | **16 of 19** | 0 |
| Broken (page, result) link pairs | **256** | 0 |

**The fetch.** `fetch('search.json')` is page-relative, so from `classes/Dog.html` the browser requests `classes/search.json`. It 404s, the index never loads, and typing in the box does nothing — no error, no empty-results message, just a dead input. That is the worst possible failure presentation, and it is why this survived: nothing about the page looks broken.

**The links.** `search.json` stores each URL relative to the docs root (`classes/Animal.html`) and the script injected it verbatim as an href. Clicked from `classes/Sparrow.html` that resolves to `classes/classes/Animal.html`.

## The fix

`base.html.jinja` sets `window.DOCS_ROOT` from `link_root` — the value every other link on the page already uses — and `search.js` resolves both the fetch and the result hrefs against it. That means an explicit `base_url` keeps working with no special case, and a page at any depth gets the right prefix, because `relative_url_prefix()` from #61 is doing the arithmetic rather than the script guessing.

**`file://` is handled honestly rather than silently.** `fetch` is CORS-blocked on `file://` whatever the path, so search genuinely cannot work from a double-clicked page — this fix makes it work over HTTP from any sub-path, which is the GitHub Pages case, and #86 asks for a decision on the rest. The box now disables itself with a placeholder saying it needs an HTTP server. Of the three options in the issue — hide, explain, or keep silently doing nothing — the current behaviour was the worst, and hiding it would leave a reader wondering whether the docs have search at all.

## On verification

I could not drive a real browser: the Chrome extension is not connected in this environment (`tabs_context_mcp` reports it unavailable), so this is **not** verified by clicking in Chrome.

What it is verified by is better suited to a repo with no hosted CI anyway. Both failure modes are decided entirely by two path computations, so the tests do that arithmetic against the real generated tree: parse the `DOCS_ROOT` each page declares, then assert `DOCS_ROOT + '/search.json'` resolves to the real index, and that `DOCS_ROOT + '/' + entry.url` resolves for **every entry from every page** — the 256-pair check, run over the SKOS fixture because its pages sit in a sub-folder.

All six new tests fail on `main` and pass here; I checked by reverting just the two source files with the tests in place. Happy to walk it in a browser if you want a second look — the docs serve fine with `python3 -m http.server`.

## Verification summary

- `scripts/ci-local.sh` green: **715 passed** (709 before), black clean.
- 6 new tests, including the `base_url` case and a guard that the old `fetch('search.json')` cannot come back.
- DOCS_GUIDE gains a short **Search** section saying it needs a server, with the one-liner to start one.

## Note on merge order

Branched from `main`, so it is independent of #109 (#76). Both add a `### Fixed` block to the same part of the CHANGELOG, so whichever merges second wants a trivial rebase there — nothing else overlaps.
