### PR TITLE
fix(docs): make search.json byte-reproducible between runs (#107)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -100,6 +100,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   normal vision, 15.3 under simulated deuteranopia
 
 ### Fixed
+- **`docs` output is now byte-reproducible between runs** (#107). Keyword lists
+  in `search.json` were built with `list(set(...))`, and Python randomises
+  string hashing per process, so two runs over identical input produced a
+  different key order every time — for every entity kind. Regenerating a
+  committed docs site showed a diff with no semantic change, and the project's
+  own verification technique (generate output at two commits and diff it) could
+  not be used on this command without pinning `PYTHONHASHSEED`. Keyword order
+  has never been meaningful to `search.js`, which substring-matches over the
+  whole list
 - **The search overlay now works on every page, not just the three at the docs
   root** (#86). `assets/search.js` made two root-relative assumptions that the
   #59 fix did not reach, because that fix covered the Jinja templates only:

--- a/src/rdf_construct/docs/search.py
+++ b/src/rdf_construct/docs/search.py
@@ -48,14 +48,15 @@ class SearchEntry:
 def extract_keywords(text: str | None) -> list[str]:
     """Extract searchable keywords from text.
 
-    Splits on whitespace and punctuation, lowercases, and removes
-    common stop words.
+    Splits on whitespace and punctuation, lowercases, removes common
+    stop words, and returns the result sorted so repeated builds of the
+    same ontology produce byte-identical output.
 
     Args:
         text: Text to extract keywords from.
 
     Returns:
-        List of keyword strings.
+        Sorted list of unique keyword strings.
     """
     if not text:
         return []
@@ -140,7 +141,12 @@ def extract_keywords(text: str | None) -> list[str]:
     }
 
     keywords = [w for w in words if w and len(w) > 2 and w not in stop_words]
-    return list(set(keywords))  # Remove duplicates
+    # Sorted, not just de-duplicated: Python randomises string hashing per
+    # process, so `list(set(...))` gives a different order on every run and
+    # search.json is never byte-identical between two builds of the same
+    # ontology. Keyword order has never been meaningful to search.js, which
+    # substring-matches over the whole list. See issue #107.
+    return sorted(set(keywords))
 
 
 def class_to_search_entry(
@@ -187,7 +193,7 @@ def class_to_search_entry(
         qname=class_info.qname,
         entity_type="class",
         label=class_info.label or class_info.qname,
-        keywords=list(set(keywords)),
+        keywords=sorted(set(keywords)),
         url=entity_to_url(class_info.qname, "class", config),
         kinds=[str(k) for k in class_info.kinds],
     )
@@ -241,7 +247,7 @@ def property_to_search_entry(
         qname=prop_info.qname,
         entity_type=entity_type,
         label=prop_info.label or prop_info.qname,
-        keywords=list(set(keywords)),
+        keywords=sorted(set(keywords)),
         url=entity_to_url(prop_info.qname, entity_type, config),
         kinds=[str(k) for k in prop_info.kinds],
     )
@@ -296,7 +302,7 @@ def instance_to_search_entry(
         qname=instance_info.qname,
         entity_type="instance",
         label=instance_info.label or instance_info.qname,
-        keywords=list(set(keywords)),
+        keywords=sorted(set(keywords)),
         url=entity_to_url(instance_info.qname, "instance", config),
         kinds=[str(k) for k in instance_info.kinds],
     )
@@ -358,7 +364,7 @@ def shape_to_search_entry(
         qname=shape_info.qname,
         entity_type="shape",
         label=shape_info.label or shape_info.qname,
-        keywords=list(set(keywords)),
+        keywords=sorted(set(keywords)),
         url=entity_to_url(shape_info.qname, "shape", config),
         kinds=[str(k) for k in shape_info.kinds],
     )
@@ -410,7 +416,7 @@ def concept_to_search_entry(
         qname=concept_info.qname,
         entity_type="skos_concept",
         label=concept_info.label or concept_info.qname,
-        keywords=list(set(keywords)),
+        keywords=sorted(set(keywords)),
         url=entity_to_url(concept_info.qname, "skos_concept", config),
         kinds=[str(k) for k in concept_info.kinds],
     )
@@ -457,7 +463,7 @@ def concept_scheme_to_search_entry(
         qname=scheme_info.qname,
         entity_type="skos_concept_scheme",
         label=scheme_info.label or scheme_info.qname,
-        keywords=list(set(keywords)),
+        keywords=sorted(set(keywords)),
         url=entity_to_url(scheme_info.qname, "skos_concept_scheme", config),
         kinds=[str(k) for k in scheme_info.kinds],
     )

--- a/tests/test_docs.py
+++ b/tests/test_docs.py
@@ -2451,3 +2451,98 @@ class TestSearchOverlayPaths:
         assert "window.location.protocol === 'file:'" in js
         assert "searchInput.disabled = true" in js
         assert "placeholder" in js
+
+
+# ---------------------------------------------------------------------------
+# Search index determinism — issue #107
+# ---------------------------------------------------------------------------
+
+
+class TestSearchIndexDeterminism:
+    """Generated output must be byte-identical between runs.
+
+    ``extract_keywords()`` and every ``*_to_search_entry`` ended with
+    ``list(set(...))``. Python randomises string hashing per process, so
+    the key order in ``search.json`` changed on every run over identical
+    input — for every entity kind. Regenerating a committed docs site
+    showed a diff with no semantic change, and the project's own
+    verification technique (generate at two commits, diff the output)
+    could not be used on this command without pinning the hash seed.
+    """
+
+    def test_keywords_are_sorted(self, skos_vocabulary: Graph):
+        """Every entry's keyword list is in a defined order."""
+        entities = extract_all(skos_vocabulary)
+        entries = generate_search_index(entities, DocsConfig())
+
+        assert entries
+        for entry in entries:
+            assert entry.keywords == sorted(entry.keywords)
+            assert len(entry.keywords) == len(set(entry.keywords))
+
+    def test_extract_keywords_returns_sorted(self):
+        """Enough words that a sorted result cannot be luck.
+
+        With three words there is a one-in-six chance an unsorted
+        implementation comes out sorted anyway under a given hash seed,
+        and pytest picks a fresh seed each session — so the input is
+        long enough to make that vanishingly unlikely.
+        """
+        text = "Zebra apple Mango apple Kiwi banana Cherry damson elder fig"
+        assert extract_keywords(text) == [
+            "apple",
+            "banana",
+            "cherry",
+            "damson",
+            "elder",
+            "fig",
+            "kiwi",
+            "mango",
+            "zebra",
+        ]
+
+    @pytest.mark.parametrize("output_format", ["html", "markdown", "json"])
+    def test_output_is_byte_identical_across_processes(self, tmp_path: Path, output_format: str):
+        """Two runs in separate processes produce identical bytes.
+
+        The second process is given a different ``PYTHONHASHSEED``, which
+        is what makes this a real test: within a single process,
+        ``list(set(...))`` iterates in a stable order, so generating twice
+        in-process passes even on the broken code.
+        """
+        import os
+        import subprocess
+        import sys
+
+        source = Path(__file__).parent / "fixtures" / "docs" / "skos_vocabulary.ttl"
+        runs = []
+
+        for index, hash_seed in enumerate(("1", "99999")):
+            out = tmp_path / f"run{index}"
+            script = (
+                "from pathlib import Path\n"
+                "from rdf_construct.docs import generate_docs\n"
+                f"generate_docs(Path({str(source)!r}), Path({str(out)!r}), "
+                f"None, {output_format!r})\n"
+            )
+            result = subprocess.run(
+                [sys.executable, "-c", script],
+                env={**os.environ, "PYTHONHASHSEED": hash_seed},
+                capture_output=True,
+                text=True,
+            )
+            assert result.returncode == 0, result.stderr
+            runs.append(out)
+
+        first, second = runs
+        first_files = sorted(p.relative_to(first) for p in first.rglob("*") if p.is_file())
+        second_files = sorted(p.relative_to(second) for p in second.rglob("*") if p.is_file())
+        assert first_files == second_files, "the two runs produced different file sets"
+        assert first_files, "no files generated"
+
+        differing = [
+            str(rel)
+            for rel in first_files
+            if (first / rel).read_bytes() != (second / rel).read_bytes()
+        ]
+        assert not differing, f"output differs between runs: {differing}"


### PR DESCRIPTION
## What

`docs --format html` produced a different `search.json` on every run over identical input. Closes #107.

`extract_keywords()` and each `*_to_search_entry` ended with `list(set(...))`. Python randomises string hashing per process, so key order changed run to run — for **every** entity kind, not just one.

```
$ poetry run python -c "print(list(set(['building','structure','edifice','permanent','roofed','occupation'])))"
['building', 'structure', 'occupation', 'roofed', 'edifice', 'permanent']
$ poetry run python -c "print(list(set(['building','structure','edifice','permanent','roofed','occupation'])))"
['permanent', 'occupation', 'roofed', 'structure', 'building', 'edifice']
```

Fix is `sorted(set(...))` in seven places. Keyword *order* has never meant anything to `assets/search.js`, which substring-matches over the whole list.

## Why it was worth fixing rather than living with

Two things, and the second is the one that bothered me:

- Anyone committing generated docs — GitHub Pages, a docs branch, a wiki — sees `search.json` modified on every rebuild with no semantic change.
- **It quietly disabled the project's own verification technique on this command.** "Generate real CLI output at both commits into the same absolute path and diff it" is how #77 was proved inert across 14 invocations and 130 files. On `docs` that method needs `PYTHONHASHSEED` pinned, and someone who does not know that reads the noise as a real change — or, worse, stops trusting the method. I hit exactly this twice in the last two days verifying #103 and #109 and had to explain the diff away both times.

## The test is the interesting part

**A naive version of this test passes on the broken code.** Within a single process, `list(set(...))` iterates in a stable order for the same strings, so "generate twice and compare" is worthless in-process:

```
$ poetry run python -c "ws=['building','structure','edifice','permanent','roofed','occupation']; print(list(set(ws))==list(set(ws)))"
True
```

So `test_output_is_byte_identical_across_processes` runs the second generation in a **subprocess with a different `PYTHONHASHSEED`**, and compares every file in both trees byte for byte. Parametrised over html, markdown and json.

Verified in both directions: with `search.py` reverted, 3 of the 5 new tests fail — consistently, across three separate pytest sessions — and the byte comparison names `search.json` specifically. All 5 pass with the fix.

One test needed strengthening after I checked it: `test_extract_keywords_returns_sorted` originally used three words, which gives a one-in-six chance of an unsorted implementation coming out sorted by luck under a given hash seed — and pytest picks a fresh seed each session. It now uses nine.

## Scope

`sorted(set(...))` in `docs/search.py` only. The whole `docs` tree is now byte-identical across runs and across hash seeds; verified on `examples/animal_ontology.ttl` with seeds forced to 1 and 99999.

**Not** #94. That is `shacl-gen`, and its cause is blank-node labelling, which `PYTHONHASHSEED=0` does not settle — different problem, same family. I have cross-posted the underlying question there: *is byte-reproducible output a guarantee this project makes?* If the answer is yes, both sites want a shared "generate twice, compare bytes" helper rather than two independent fixes, and the subprocess test here is a reasonable first draft of one.

## Verification

- `scripts/ci-local.sh` green: **714 passed** (709 before), black clean.
- Branched from `main`, independent of #109 and #110. All three touch the same `### Fixed` block in the CHANGELOG, so whichever merges last wants a trivial rebase there.
