### PR TITLE
fix(docs): stop single-page Markdown linking to pages it never writes (#113)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -100,6 +100,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   normal vision, 15.3 under simulated deuteranopia
 
 ### Fixed
+- **Single-page Markdown no longer links to pages it never writes** (#113).
+  `--format markdown --single-page` produces exactly one file, but rendered
+  cross-references as links to each entity's own page — `concepts/Dwelling.md`,
+  `classes/Person.md` — every one of them dead. Both the SKOS section and the
+  Shapes section were affected; the latter since v0.5.0. References now render
+  as the entity's qname in code formatting, which stays greppable within the
+  single document and matches what the HTML single-page template already did.
+  Multi-page Markdown output is unchanged, byte for byte
 - **`docs` output is now byte-reproducible between runs** (#107). Keyword lists
   in `search.json` were built with `list(set(...))`, and Python randomises
   string hashing per process, so two runs over identical input produced a

--- a/src/rdf_construct/docs/renderers/markdown.py
+++ b/src/rdf_construct/docs/renderers/markdown.py
@@ -412,56 +412,66 @@ class MarkdownRenderer:
         uri: Any,
         entities: "ExtractedEntities",
         default_type: str = "class",
+        *,
+        link: bool = True,
     ) -> str:
         """Convert a URI to a display string, linking if possible.
 
-        Searches classes, properties, instances, and shapes (in that
-        order — most specific match wins). Falls back to the URI's
-        local name in code formatting when no entity matches.
+        Searches classes, properties, instances, shapes and SKOS entities
+        (in that order — most specific match wins). Falls back to the
+        URI's local name in code formatting when no entity matches.
 
         Args:
             uri: URI to convert.
             entities: All entities for lookups.
             default_type: Entity type if not found.
+            link: Whether to emit a Markdown link. Pass ``False`` when the
+                target has no page of its own to link to — single-page
+                output writes one file, so a link to an entity's own page
+                would be a dead reference (#113). The qname is rendered in
+                code formatting instead, which stays greppable within the
+                single document.
 
         Returns:
-            Display string with link if available.
+            Display string, linked when ``link`` is true and the entity
+            is one this run documents.
         """
         uri_str = str(uri)
+
+        def render(qname: str, label: str | None, entity_type: str) -> str:
+            """Format one resolved match, with or without a link."""
+            if not link:
+                return f"`{qname}`"
+            return self._entity_link(qname, entity_type, label or qname)
 
         # Check if it's a known class
         for c in entities.classes:
             if str(c.uri) == uri_str:
-                return self._entity_link(c.qname, "class", c.label or c.qname)
+                return render(c.qname, c.label, "class")
 
         # Check if it's a known property
         for p in entities.properties:
             if str(p.uri) == uri_str:
-                entity_type = f"{p.property_type}_property"
-                return self._entity_link(p.qname, entity_type, p.label or p.qname)
+                return render(p.qname, p.label, f"{p.property_type}_property")
 
         # Check if it's a known instance
         for i in entities.instances:
             if str(i.uri) == uri_str:
-                return self._entity_link(i.qname, "instance", i.label or i.qname)
+                return render(i.qname, i.label, "instance")
 
         # Check if it's a known shape
         for s in entities.shapes:
             if str(s.uri) == uri_str:
-                return self._entity_link(s.qname, "shape", s.label or s.qname)
+                return render(s.qname, s.label, "shape")
 
         # Check if it's a known SKOS concept or concept scheme (#63)
         for concept in entities.concepts:
             if str(concept.uri) == uri_str:
-                return self._entity_link(
-                    concept.qname, "skos_concept", concept.label or concept.qname
-                )
+                return render(concept.qname, concept.label, "skos_concept")
 
         for scheme in entities.concept_schemes:
             if str(scheme.uri) == uri_str:
-                return self._entity_link(
-                    scheme.qname, "skos_concept_scheme", scheme.label or scheme.qname
-                )
+                return render(scheme.qname, scheme.label, "skos_concept_scheme")
 
         # Fall back to extracting local name
         if "#" in uri_str:
@@ -1150,6 +1160,12 @@ class MarkdownRenderer:
 
         Returns:
             Path to the rendered file.
+
+        Note:
+            Cross-references are rendered unlinked. Single-page output
+            writes one file, so a link to an entity's own page would point
+            at something this run never produced — see #113. The HTML
+            single-page template takes the same line.
         """
         lines = []
 
@@ -1247,7 +1263,9 @@ class MarkdownRenderer:
                     lines.append(s.definition)
                     lines.append("")
                 if s.target_classes:
-                    joined = ", ".join(self._uri_to_display(u, entities) for u in s.target_classes)
+                    joined = ", ".join(
+                        self._uri_to_display(u, entities, link=False) for u in s.target_classes
+                    )
                     lines.append(f"**Target classes:** {joined}")
                     lines.append("")
                 if "node_shape" in s.kinds and s.properties:
@@ -1284,21 +1302,21 @@ class MarkdownRenderer:
                     lines.append("")
                 if concept.broader:
                     joined = ", ".join(
-                        self._uri_to_display(uri, entities, "skos_concept")
+                        self._uri_to_display(uri, entities, "skos_concept", link=False)
                         for uri in concept.broader
                     )
                     lines.append(f"**Broader:** {joined}")
                     lines.append("")
                 if concept.narrower:
                     joined = ", ".join(
-                        self._uri_to_display(uri, entities, "skos_concept")
+                        self._uri_to_display(uri, entities, "skos_concept", link=False)
                         for uri in concept.narrower
                     )
                     lines.append(f"**Narrower:** {joined}")
                     lines.append("")
                 if concept.in_schemes:
                     joined = ", ".join(
-                        self._uri_to_display(uri, entities, "skos_concept_scheme")
+                        self._uri_to_display(uri, entities, "skos_concept_scheme", link=False)
                         for uri in concept.in_schemes
                     )
                     lines.append(f"**In scheme:** {joined}")

--- a/tests/test_docs.py
+++ b/tests/test_docs.py
@@ -1,6 +1,7 @@
 """Tests for the documentation generation module."""
 
 import json
+import re
 from pathlib import Path
 
 import pytest
@@ -2546,3 +2547,142 @@ class TestSearchIndexDeterminism:
             if (first / rel).read_bytes() != (second / rel).read_bytes()
         ]
         assert not differing, f"output differs between runs: {differing}"
+
+
+# ---------------------------------------------------------------------------
+# Markdown link resolution — issue #113, and the helper #87 needs
+# ---------------------------------------------------------------------------
+
+
+MARKDOWN_LINK = re.compile(r"\]\(([^)]+)\)")
+MARKDOWN_HEADING = re.compile(r"^#{1,6}\s+(.*?)\s*$", re.MULTILINE)
+
+
+def _heading_slug(text: str) -> str:
+    """Slugify a heading the way GitHub and MkDocs both do.
+
+    Lowercase, drop anything that is not alphanumeric, space or hyphen,
+    then spaces to hyphens. The two differ on collisions and on some
+    punctuation; this covers the headings this project emits.
+    """
+    cleaned = re.sub(r"[^a-z0-9 \-]", "", text.lower())
+    return re.sub(r"\s+", "-", cleaned.strip())
+
+
+def broken_markdown_links(root: Path) -> list[tuple[str, str]]:
+    """Find Markdown links that do not resolve, anywhere under ``root``.
+
+    The Markdown counterpart of
+    ``TestPathResolution::test_all_links_resolve_for_every_entity_kind``.
+    There was no equivalent for Markdown, which is a fair part of why
+    #87, #105 and #113 all survived as long as they did — a renderer
+    with no link walk over its own output has nothing holding it to
+    account.
+
+    Two kinds of link are checked:
+
+    - **File links** resolve against the directory of the file that
+      contains them, which is what every Markdown consumer does and what
+      makes a root-relative link from a sub-folder page wrong (#87).
+    - **Anchor links** (``#section``) must match a heading in the same
+      file, slugified — that is what single-page output relies on.
+
+    External links (``http``, ``https``, ``mailto``) are skipped.
+
+    Args:
+        root: Directory of generated Markdown to walk.
+
+    Returns:
+        ``(file, link)`` pairs, one per unresolved link, sorted.
+    """
+    broken: list[tuple[str, str]] = []
+
+    for page in sorted(root.rglob("*.md")):
+        text = page.read_text(encoding="utf-8")
+        slugs = {_heading_slug(h) for h in MARKDOWN_HEADING.findall(text)}
+
+        for target in MARKDOWN_LINK.findall(text):
+            if target.startswith(("http://", "https://", "mailto:")):
+                continue
+            if target.startswith("#"):
+                if target[1:] not in slugs:
+                    broken.append((str(page.relative_to(root)), target))
+                continue
+            path_part = target.split("#", 1)[0]
+            if not (page.parent / path_part).resolve().exists():
+                broken.append((str(page.relative_to(root)), target))
+
+    return broken
+
+
+class TestSinglePageMarkdownLinks:
+    """Single-page Markdown must not link to pages it never writes.
+
+    Single-page output produces exactly one file. Cross-references were
+    rendered as links to each entity's own page — `concepts/Dwelling.md`,
+    `classes/Person.md` — none of which exist in that mode. Every one was
+    a dead link (#113).
+    """
+
+    @pytest.mark.parametrize(
+        "fixture_name", ["skos_vocabulary", "shape_ontology", "simple_ontology"]
+    )
+    def test_no_dead_links_in_single_page_output(
+        self,
+        fixture_name: str,
+        request: pytest.FixtureRequest,
+        output_dir: Path,
+    ):
+        graph = request.getfixturevalue(fixture_name)
+        config = DocsConfig(output_dir=output_dir, format="markdown", single_page=True)
+        DocsGenerator(config).generate(graph)
+
+        assert (output_dir / "index.md").exists()
+        assert broken_markdown_links(output_dir) == []
+
+    def test_single_page_writes_exactly_one_file(self, skos_vocabulary: Graph, output_dir: Path):
+        """The premise of the bug: there is nowhere for a link to point."""
+        config = DocsConfig(output_dir=output_dir, format="markdown", single_page=True)
+        DocsGenerator(config).generate(skos_vocabulary)
+
+        assert [p.name for p in output_dir.rglob("*.md")] == ["index.md"]
+
+    def test_references_stay_visible_as_qnames(self, skos_vocabulary: Graph, output_dir: Path):
+        """Unlinked does not mean dropped — the reference is still readable.
+
+        A qname in code formatting is greppable within the single
+        document, which is the navigation story once a link is not
+        available.
+        """
+        config = DocsConfig(output_dir=output_dir, format="markdown", single_page=True)
+        DocsGenerator(config).generate(skos_vocabulary)
+
+        content = (output_dir / "index.md").read_text()
+        assert "**Broader:** `ex:Dwelling`" in content
+        assert "**In scheme:** `ex:BuildingScheme`" in content
+
+    def test_shape_targets_too(self, shape_ontology: Graph, output_dir: Path):
+        """The Shapes section had the same defect, and predates the SKOS one."""
+        config = DocsConfig(output_dir=output_dir, format="markdown", single_page=True)
+        DocsGenerator(config).generate(shape_ontology)
+
+        content = (output_dir / "index.md").read_text()
+        assert "**Target classes:** `ex:Person`" in content
+
+    def test_table_of_contents_anchors_resolve(self, skos_vocabulary: Graph, output_dir: Path):
+        """The anchors single-page output does rely on must actually exist."""
+        config = DocsConfig(output_dir=output_dir, format="markdown", single_page=True)
+        DocsGenerator(config).generate(skos_vocabulary)
+
+        content = (output_dir / "index.md").read_text()
+        assert "- [SKOS Vocabulary](#skos-vocabulary)" in content
+        assert "## SKOS Vocabulary" in content
+
+    def test_multi_page_links_are_still_links(self, skos_vocabulary: Graph, output_dir: Path):
+        """Only single-page output drops the links; multi-page keeps them."""
+        config = DocsConfig(output_dir=output_dir, format="markdown")
+        DocsGenerator(config).generate(skos_vocabulary)
+
+        content = (output_dir / "concepts" / "Dwelling.md").read_text()
+        assert "](" in content
+        assert "Building.md" in content


### PR DESCRIPTION
## What

`--format markdown --single-page` writes exactly one file and filled it with links to files it never writes. Closes #113.

```
$ rdf-construct docs tests/fixtures/docs/skos_vocabulary.ttl -f markdown --single-page -o out
$ ls out
index.md
$ grep -o '](concepts/[^)]*)' out/index.md | sort -u | head -3
](concepts/Building.md)
](concepts/BuildingScheme.md)
](concepts/DetachedHouse.md)
```

Eight dead links on that fixture, and every one of them looks like a working cross-reference until clicked.

## Wider than the issue said

I filed #113 against the SKOS section, which I introduced in #63 two days ago. Checking before fixing, **the Shapes section has the same defect and has had it since v0.5.0** — a shape's target classes render as links to `classes/*.md`:

```
$ # single-page markdown, ontology with one NodeShape
$ grep -o '](\S*)' out/index.md
](classes/Person.md)
```

Both are fixed here. Issue updated.

## The fix, and the fork I did not take

`_uri_to_display` gains a keyword-only `link` toggle; `render_single_page` passes `link=False`. References render as the entity's qname in code formatting:

```
**Broader:** `ex:Dwelling`
**In scheme:** `ex:BuildingScheme`
**Target classes:** `ex:Person`
```

The issue offered two options and I have taken the second — **plain text, matching what `single_page.html.jinja` already does** — rather than same-document anchors. The reasoning, since the issue left it open:

- **Anchors can silently go to the wrong entity.** Single-page output emits `### Dwelling` from the entity's *label*, and labels are not unique across buckets — a class and a concept can both be labelled "Building". GitHub disambiguates duplicate headings as `#building` and `#building-1` by document order, so an anchor generated from a label would resolve to whichever happened to render first. A link to the wrong entity is worse than no link, and it fails silently.
- **Consumers disagree about anchor slugs.** GitHub, MkDocs and Jekyll do not generate them identically, so an anchor correct in one is broken in another — which is precisely the trap #87 warns about for Markdown links generally.
- **It makes the two renderers agree.** HTML single-page already renders these as `<code>`.

The cost is that a reader loses in-document navigation. The mitigation is that a qname is greppable — `ex:Dwelling` is a unique token in the document, which a bare label is not. If you would rather have anchors, it is a clean follow-up on top of this, and it would want stable ids minted from qnames rather than labels.

## The other half: a Markdown link walk

`broken_markdown_links()` is the Markdown counterpart of `TestPathResolution::test_all_links_resolve_for_every_entity_kind`, which has been catching this class of bug on the HTML side since #60. It resolves file links against the containing file, and anchor links against the headings in it.

**Markdown had no such walk**, and that is a fair part of why #87, #105 and #113 all survived — a renderer with no walk over its own output has nothing holding it to account.

It is wired to the single-page case here. **The multi-page case belongs to #87** and would fail on `main` today (43 broken links on the SKOS fixture), so it is not asserted here; the helper is written to be reused there, and I have said so on #105 so @tasodoufu does not build a second one.

## Verification

- `scripts/ci-local.sh` green: **753 passed** (745 before), black clean.
- 8 new tests. 4 of them fail on unfixed code — checked by reverting `markdown.py` with the tests in place. The other 4 are controls (an ontology with neither shapes nor concepts has no dead links either way, and the multi-page case must keep its links).
- **Multi-page Markdown output is byte-identical**, verified over both the SKOS fixture and `examples/animal_ontology.ttl` — the `_uri_to_display` refactor changes nothing when `link` is left true.
