### PR TITLE
fix(order): fail on a select: that names an unresolvable selector (#89)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -100,6 +100,23 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   normal vision, 15.3 under simulated deuteranopia
 
 ### Fixed
+- **`order` now fails on a section whose `select:` names a selector nothing can
+  resolve** (#89), instead of selecting nothing and saying nothing. The section
+  simply vanished from the output — the same failure shape as #84 one level
+  down: there a *profile* claimed nothing, here a *section* did. Worse, the
+  unclaimed-subjects warning added in #88 then misdiagnosed it, telling the user
+  to "add a section with `select: obj_props`" when their profile had exactly
+  that section, misspelled. The run now exits 2, names the profile and the
+  section, and lists both the built-in selector keys and the ones the config
+  defines. Two spellings are affected: a key that resolves to nothing at all,
+  and a key defined in `selectors:` whose *value* is not one this version
+  recognises
+- **The shipped `templates/ordering_starter.yml` now runs.** It defines each
+  selector as a YAML list, and selector resolution called `.strip()` on the
+  value — so the template the documentation tells users to copy exited 1 with an
+  `AttributeError` traceback. Non-string values no longer crash: a built-in key
+  dispatches on its name regardless, and anything unresolvable gets the
+  actionable error above. Found while fixing #89, on the same line
 - **Single-page Markdown no longer links to pages it never writes** (#113).
   `--format markdown --single-page` produces exactly one file, but rendered
   cross-references as links to each entity's own page — `concepts/Dwelling.md`,

--- a/src/rdf_construct/cli.py
+++ b/src/rdf_construct/cli.py
@@ -19,6 +19,9 @@ from rdf_construct.core import (
     build_section_graph,
     extract_prefix_map,
     rebind_prefixes,
+    BUILTIN_SELECTOR_KEYS,
+    UnknownSelectorError,
+    is_known_selector,
     select_subjects,
     serialise_turtle,
     sort_subjects,
@@ -284,14 +287,7 @@ def cast(
 # Selector keys understood by select_subjects(), most specific first, used to tell a
 # user which section they are missing. Keys defined in the config are appended to
 # these, so a profile with custom selector names still gets a usable suggestion.
-_SELECTOR_KEYS = (
-    "classes",
-    "obj_props",
-    "data_props",
-    "ann_props",
-    "other_props",
-    "individuals",
-)
+_SELECTOR_KEYS = BUILTIN_SELECTOR_KEYS
 
 # How many unclaimed subjects to name before summarising the rest.
 _UNCLAIMED_SHOWN = 3
@@ -341,6 +337,11 @@ def _selector_hints(
     for key in keys:
         if not remaining:
             break
+        # The config may define keys that resolve to nothing — since #89 those
+        # raise rather than returning empty, and this loop is probing on
+        # purpose, so skip them instead.
+        if not is_known_selector(key, selectors):
+            continue
         claimed = select_subjects(graph, key, selectors)
         for subject in list(remaining):
             if subject in claimed:
@@ -514,7 +515,15 @@ def order(source: Path, config: Path, profile: tuple[str, ...], outdir: Path):
             roots_cfg = sec_cfg.get("roots")
 
             # Select and sort subjects
-            chosen = select_subjects(graph, select_key, ordering_config.selectors)
+            try:
+                chosen = select_subjects(graph, select_key, ordering_config.selectors)
+            except UnknownSelectorError as exc:
+                click.secho(
+                    f"\u2717 profile '{prof_name}', section '{sec_name}': {exc}",
+                    fg="red",
+                    err=True,
+                )
+                raise SystemExit(2)
             chosen = [s for s in chosen if s not in seen]
 
             ordered = sort_subjects(graph, set(chosen), sort_mode, roots_cfg)

--- a/src/rdf_construct/core/__init__.py
+++ b/src/rdf_construct/core/__init__.py
@@ -8,7 +8,12 @@ from .profile import (
     OrderingProfile,
     load_yaml,
 )
-from .selector import select_subjects
+from .selector import (
+    BUILTIN_SELECTOR_KEYS,
+    UnknownSelectorError,
+    is_known_selector,
+    select_subjects,
+)
 from .vocab import (
     ALL_PROPERTY_TYPES,
     ANNOTATION_PROPERTY_TYPES,
@@ -55,6 +60,9 @@ __all__ = [
     "DEFAULT_UNCLAIMED_POLICY",
     # Selector
     "select_subjects",
+    "is_known_selector",
+    "UnknownSelectorError",
+    "BUILTIN_SELECTOR_KEYS",
     # Vocabulary
     "ALL_PROPERTY_TYPES",
     "ANNOTATION_PROPERTY_TYPES",

--- a/src/rdf_construct/core/selector.py
+++ b/src/rdf_construct/core/selector.py
@@ -13,6 +13,60 @@ from .vocab import (
 )
 
 
+#: Selector keys ``select_subjects`` dispatches on, in the order they are
+#: documented. A profile section's ``select:`` must name one of these, or a key
+#: in the config's ``selectors:`` block whose value one of them recognises.
+BUILTIN_SELECTOR_KEYS: tuple[str, ...] = (
+    "classes",
+    "obj_props",
+    "data_props",
+    "ann_props",
+    "other_props",
+    "individuals",
+)
+
+#: Values accepted in a ``selectors:`` block, mapped to the built-in key they
+#: resolve to. Kept beside the dispatch below so the two cannot drift.
+_SELECTOR_VALUES: dict[str, str] = {
+    "owl:Class": "classes",
+    "rdf:type owl:Class": "classes",
+    "owl:ObjectProperty": "obj_props",
+    "owl:DatatypeProperty": "data_props",
+    "owl:AnnotationProperty": "ann_props",
+    "rdf:Property": "other_props",
+}
+
+
+class UnknownSelectorError(ValueError):
+    """A selector key that nothing knows how to resolve.
+
+    Raised rather than returning an empty set, because an empty set is
+    indistinguishable from "this ontology has none of those" and the
+    section simply vanishes from the output. See issue #89.
+    """
+
+
+def is_known_selector(selector_key: str, selectors: dict[str, str]) -> bool:
+    """Report whether ``select_subjects`` can resolve this selector key.
+
+    For callers that legitimately probe keys they are not sure about —
+    the unclaimed-subject hinting in the CLI walks every key in the
+    config looking for one that would have claimed a subject.
+
+    Args:
+        selector_key: Key to test
+        selectors: Selector definitions from the ordering config
+
+    Returns:
+        True if the key resolves to a selection, False otherwise
+    """
+    if selector_key in BUILTIN_SELECTOR_KEYS:
+        return True
+    raw = selectors.get(selector_key, "")
+    value = raw.strip() if isinstance(raw, str) else ""
+    return value in _SELECTOR_VALUES or value.startswith("FILTER")
+
+
 def _subjects_of_types(graph: Graph, types: frozenset[URIRef]) -> set[Node]:
     """Collect every subject declared with any of the given rdf:type values.
 
@@ -57,8 +111,19 @@ def select_subjects(graph: Graph, selector_key: str, selectors: dict[str, str]) 
 
     Returns:
         Set of URIRefs matching the selection criteria
+
+    Raises:
+        UnknownSelectorError: If the key names neither a built-in selector
+            nor a config entry with a recognised value. Silently selecting
+            nothing was #89.
     """
-    sel = selectors.get(selector_key, "").strip()
+    # A selector value is a string in this grammar, but templates/ordering_starter.yml
+    # — the file users are told to copy — writes lists, and `.strip()` on a list is an
+    # AttributeError traceback rather than anything a user can act on. Non-strings are
+    # treated as an unrecognised *value*: a built-in key still dispatches on its name,
+    # so the shipped template works, and anything else reaches the error below.
+    raw = selectors.get(selector_key, "")
+    sel = raw.strip() if isinstance(raw, str) else ""
     subjects: set = set()
 
     # Classes - check owl:Class, rdfs:Class and owl:DeprecatedClass
@@ -93,5 +158,24 @@ def select_subjects(graph: Graph, selector_key: str, selectors: dict[str, str]) 
 
         all_subjects = {s for (s, _, _) in graph}
         subjects = all_subjects - classes - properties
+
+    else:
+        # Nothing matched. Returning an empty set here is what #89 was: the
+        # section renders empty, the output is silently short, and the
+        # unclaimed-subjects warning then names a section the user believes
+        # they already have.
+        known = ", ".join(BUILTIN_SELECTOR_KEYS)
+        defined = ", ".join(sorted(selectors)) or "none"
+        if selector_key in selectors:
+            raise UnknownSelectorError(
+                f"selector {selector_key!r} is defined in the config as {sel!r}, "
+                f"which is not a value this version understands. Accepted values: "
+                f"{', '.join(sorted(_SELECTOR_VALUES))}, or a string starting 'FILTER'. "
+                f"Built-in selector keys, usable without defining them: {known}"
+            )
+        raise UnknownSelectorError(
+            f"unknown selector {selector_key!r}. Built-in selector keys: {known}. "
+            f"Defined in this config: {defined}"
+        )
 
     return subjects

--- a/tests/test_selector_errors.py
+++ b/tests/test_selector_errors.py
@@ -1,0 +1,256 @@
+"""Tests for unresolvable selector keys (issue #89).
+
+A section whose ``select:`` named a key nothing could resolve selected
+nothing, and said nothing. The section simply vanished from the output —
+the same failure shape as #84 one level down: there a *profile* claimed
+nothing, here a *section* did.
+
+Since #88 the loss was usually surfaced by the unclaimed-subjects
+warning, but its diagnosis actively misled: it named a section the user
+believed they already had.
+"""
+
+import pytest
+from click.testing import CliRunner
+from rdflib import Graph
+
+from rdf_construct.cli import cli
+from rdf_construct.core.selector import (
+    BUILTIN_SELECTOR_KEYS,
+    UnknownSelectorError,
+    is_known_selector,
+    select_subjects,
+)
+
+SELECTORS = {
+    "classes": "rdf:type owl:Class",
+    "obj_props": "owl:ObjectProperty",
+    # A custom name whose value is the same string obj_props carries, in the
+    # `rdf:type X` form the classes selector accepts. It resolves for classes
+    # and not for properties — the grammar is inconsistent, which is the half
+    # of #89 deliberately left to a follow-up.
+    "my_props": "rdf:type owl:ObjectProperty",
+    "my_inds": "FILTER NOT EXISTS { ?s a owl:Class }",
+}
+
+ONTOLOGY = """
+@prefix ex: <http://example.org/> .
+@prefix owl: <http://www.w3.org/2002/07/owl#> .
+ex:Thing a owl:Class .
+ex:hasOwner a owl:ObjectProperty .
+"""
+
+
+@pytest.fixture
+def graph() -> Graph:
+    g = Graph()
+    g.parse(data=ONTOLOGY, format="turtle")
+    return g
+
+
+class TestUnknownSelectorRaises:
+    """An unresolvable key is an error, not an empty selection."""
+
+    def test_typo_raises(self, graph: Graph):
+        with pytest.raises(UnknownSelectorError) as excinfo:
+            select_subjects(graph, "obj_propz", SELECTORS)
+
+        message = str(excinfo.value)
+        assert "obj_propz" in message
+        # The message has to be actionable: name what is valid, and what this
+        # config defines, or the user is left guessing at a spelling.
+        assert "obj_props" in message
+        assert "my_props" in message
+
+    def test_key_absent_from_config_raises(self, graph: Graph):
+        with pytest.raises(UnknownSelectorError):
+            select_subjects(graph, "nonesuch", {})
+
+    def test_defined_but_unrecognised_value_raises(self, graph: Graph):
+        """The custom-name case, and the more surprising of the two.
+
+        ``my_props`` *is* defined in the config, and its value is the same
+        string ``obj_props`` carries. It still resolves to nothing, so it
+        must say so rather than emitting an empty section.
+        """
+        with pytest.raises(UnknownSelectorError) as excinfo:
+            select_subjects(graph, "my_props", SELECTORS)
+
+        message = str(excinfo.value)
+        assert "my_props" in message
+        assert "rdf:type owl:ObjectProperty" in message
+        # It should tell them the spelling that would work
+        assert "owl:ObjectProperty" in message
+
+    @pytest.mark.parametrize("key", BUILTIN_SELECTOR_KEYS)
+    def test_builtin_keys_never_raise(self, graph: Graph, key: str):
+        """Every documented key resolves, with or without a config entry."""
+        select_subjects(graph, key, {})
+        select_subjects(graph, key, SELECTORS)
+
+    def test_custom_name_with_recognised_value_still_works(self, graph: Graph):
+        """Config-defined names are not broken by this — only unresolvable ones."""
+        selected = select_subjects(graph, "obj_props", SELECTORS)
+        assert {str(s) for s in selected} == {"http://example.org/hasOwner"}
+
+    def test_filter_form_still_works(self, graph: Graph):
+        """Any value starting FILTER selects individuals, as before."""
+        selected = select_subjects(graph, "my_inds", SELECTORS)
+        assert isinstance(selected, set)
+
+
+class TestIsKnownSelector:
+    """The predicate callers use when they are probing on purpose."""
+
+    @pytest.mark.parametrize("key", BUILTIN_SELECTOR_KEYS)
+    def test_builtins_are_known(self, key: str):
+        assert is_known_selector(key, {})
+
+    def test_recognised_config_value_is_known(self):
+        assert is_known_selector("obj_props", SELECTORS)
+        assert is_known_selector("my_inds", SELECTORS)
+
+    def test_unresolvable_keys_are_not_known(self):
+        assert not is_known_selector("obj_propz", SELECTORS)
+        assert not is_known_selector("my_props", SELECTORS)
+
+    def test_agrees_with_select_subjects(self, graph: Graph):
+        """The predicate and the dispatch must not disagree.
+
+        If they drift, the CLI's unclaimed-subject hinting either crashes
+        on a key it was probing or silently skips one that works.
+        """
+        for key in list(SELECTORS) + list(BUILTIN_SELECTOR_KEYS) + ["obj_propz"]:
+            if is_known_selector(key, SELECTORS):
+                select_subjects(graph, key, SELECTORS)
+            else:
+                with pytest.raises(UnknownSelectorError):
+                    select_subjects(graph, key, SELECTORS)
+
+
+class TestOrderCommandSurfacesIt:
+    """End to end: the message names the section, and the run fails."""
+
+    @staticmethod
+    def _write(tmp_path, profile_body: str):
+        model = tmp_path / "model.ttl"
+        model.write_text(ONTOLOGY)
+        config = tmp_path / "profile.yml"
+        config.write_text(
+            "selectors:\n"
+            '  classes: "rdf:type owl:Class"\n'
+            '  obj_props: "owl:ObjectProperty"\n'
+            '  my_props: "rdf:type owl:ObjectProperty"\n'
+            "\nprofiles:\n" + profile_body
+        )
+        return model, config
+
+    def test_typo_fails_the_run(self, tmp_path):
+        model, config = self._write(
+            tmp_path,
+            "  typo:\n"
+            "    sections:\n"
+            "      - classes: {select: classes, sort: alpha}\n"
+            "      - object_properties: {select: obj_propz, sort: alpha}\n",
+        )
+        result = CliRunner().invoke(
+            cli, ["order", str(model), str(config), "-p", "typo", "-o", str(tmp_path / "out")]
+        )
+
+        assert result.exit_code == 2
+        assert "obj_propz" in result.output
+        # The section is named, so the user knows which line to fix
+        assert "object_properties" in result.output
+        assert "typo" in result.output
+
+    def test_nothing_is_written_when_it_fails(self, tmp_path):
+        """A half-built profile on disk would be worse than none."""
+        model, config = self._write(
+            tmp_path,
+            "  typo:\n"
+            "    sections:\n"
+            "      - classes: {select: classes, sort: alpha}\n"
+            "      - object_properties: {select: obj_propz, sort: alpha}\n",
+        )
+        out = tmp_path / "out"
+        CliRunner().invoke(cli, ["order", str(model), str(config), "-p", "typo", "-o", str(out)])
+
+        assert not out.exists() or not list(out.glob("*.ttl"))
+
+    def test_valid_profile_is_unaffected(self, tmp_path):
+        model, config = self._write(
+            tmp_path,
+            "  good:\n"
+            "    sections:\n"
+            "      - classes: {select: classes, sort: alpha}\n"
+            "      - object_properties: {select: obj_props, sort: alpha}\n"
+            "      - individuals: {select: individuals, sort: alpha}\n",
+        )
+        out = tmp_path / "out"
+        result = CliRunner().invoke(
+            cli, ["order", str(model), str(config), "-p", "good", "-o", str(out)]
+        )
+
+        assert result.exit_code == 0
+        assert list(out.glob("*.ttl"))
+
+    def test_unclaimed_warning_still_works(self, tmp_path):
+        """The hinting walks config keys, including unresolvable ones.
+
+        It probes on purpose, so it must skip what it cannot resolve
+        rather than dying on it — a regression here would turn a warning
+        path into a crash.
+        """
+        model, config = self._write(
+            tmp_path,
+            "  partial:\n" "    sections:\n" "      - classes: {select: classes, sort: alpha}\n",
+        )
+        result = CliRunner().invoke(
+            cli, ["order", str(model), str(config), "-p", "partial", "-o", str(tmp_path / "out")]
+        )
+
+        assert result.exit_code == 0
+        # hasOwner is unclaimed, and the warning should suggest obj_props
+        assert "obj_props" in result.output
+
+
+class TestNonStringSelectorValues:
+    """The shipped starter template writes lists, not strings.
+
+    ``templates/ordering_starter.yml`` — the file the docs tell users to
+    copy — defines each selector as a YAML list. ``.strip()`` on a list is
+    an ``AttributeError`` traceback, so the shipped template did not run
+    at all. Found while implementing #89; same line, same function.
+    """
+
+    def test_list_valued_builtin_key_still_dispatches(self, graph: Graph):
+        """A built-in key dispatches on its *name*, so the value is moot."""
+        selectors = {"classes": ["owl:Class", "rdfs:Class"]}
+        selected = select_subjects(graph, "classes", selectors)
+
+        assert {str(s) for s in selected} == {"http://example.org/Thing"}
+
+    def test_list_valued_custom_key_errors_rather_than_crashing(self, graph: Graph):
+        """An unresolvable one still gets the actionable error, not a traceback."""
+        with pytest.raises(UnknownSelectorError):
+            select_subjects(graph, "my_list", {"my_list": ["owl:ObjectProperty"]})
+
+    def test_is_known_selector_agrees(self):
+        assert is_known_selector("classes", {"classes": ["owl:Class"]})
+        assert not is_known_selector("my_list", {"my_list": ["owl:ObjectProperty"]})
+
+    def test_shipped_starter_template_runs(self, tmp_path):
+        """End to end, against the real template rather than a copy of it."""
+        from pathlib import Path
+
+        template = Path(__file__).parent.parent / "templates" / "ordering_starter.yml"
+        assert template.exists(), "the starter template has moved"
+
+        model = tmp_path / "model.ttl"
+        model.write_text(ONTOLOGY)
+        out = tmp_path / "out"
+
+        result = CliRunner().invoke(cli, ["order", str(model), str(template), "-o", str(out)])
+
+        assert result.exit_code == 0, result.output
+        assert list(out.glob("*.ttl"))


### PR DESCRIPTION
## What

A profile section whose `select:` names a selector nothing can resolve selected nothing and said nothing. Closes #89 — the narrow half, as agreed: it now errors clearly. The grammar redesign the issue also describes is explicitly left alone.

## Before

```
$ rdf-construct order model.ttl typo.yml -p typo
Constructing profile: typo
  ⚠ profile 'typo': 1 subject claimed by no section — 1 triple dropped.
      ex:hasOwner  (owl:ObjectProperty)
    add a section with `select: obj_props`,
    or set `unclaimed: emit` to keep them, or `unclaimed: ignore` if this profile filters deliberately.
  ✓ /tmp/out/model-typo.ttl

Constructed 1 profile(s) in /tmp/out/
$ echo $?
0
```

Exit 0, a file written, and the advice is to add a section the profile already has — `object_properties`, whose `select:` says `obj_propz`. As #89 puts it, it reads as the tool being wrong.

## After

```
$ rdf-construct order model.ttl typo.yml -p typo
Constructing profile: typo
✗ profile 'typo', section 'object_properties': unknown selector 'obj_propz'.
  Built-in selector keys: classes, obj_props, data_props, ann_props, other_props, individuals.
  Defined in this config: classes, my_props, obj_props
$ echo $?
2
```

Nothing is written. The second spelling — a key that *is* defined in `selectors:` but whose value this version does not recognise — gets its own message naming the value and the accepted ones, because that case is the more surprising of the two:

```
✗ profile 'custom_name', section 'object_properties': selector 'my_props' is defined in the
  config as 'rdf:type owl:ObjectProperty', which is not a value this version understands.
  Accepted values: owl:AnnotationProperty, owl:Class, owl:DatatypeProperty, owl:ObjectProperty,
  rdf:Property, rdf:type owl:Class, or a string starting 'FILTER'.
```

## A second bug, found on the same line

**The shipped `templates/ordering_starter.yml` did not run at all.** It defines each selector as a YAML list, and resolution called `.strip()` on the value:

```
$ rdf-construct order model.ttl templates/ordering_starter.yml
...
AttributeError: 'list' object has no attribute 'strip'
$ echo $?
1
```

Pre-existing on `main` — I checked before assuming it was mine. The file the documentation tells users to copy produced an unhandled traceback.

Non-string values are now treated as an unrecognised *value*, which means a built-in key still dispatches on its **name** and the template works; anything else falls through to the actionable error above. Two profiles, output written, exit 0. There is an end-to-end test against the real template file rather than a copy, so it cannot silently rot again.

## Design notes

**Why raise rather than return empty.** An empty set is indistinguishable from "this ontology has none of those", which is exactly why the bug survived. The distinction is not recoverable at the call site.

**`is_known_selector()` exists because one caller probes on purpose.** `_selector_hints` in the CLI walks every key in the config — including decorative ones — looking for one that would have claimed an unclaimed subject. It must skip what it cannot resolve rather than die on it. A test holds the predicate and the dispatch in agreement, since a drift between them either crashes the warning path or silently skips a working key.

**`BUILTIN_SELECTOR_KEYS` moved into `core.selector`.** The CLI had its own copy for the hint messages; there is now one list, beside the dispatch it describes. Same reasoning as #76 and the `core.vocab` sets.

**Deliberately not fixed:** the grammar asymmetry — `rdf:type owl:Class` is accepted, `rdf:type owl:ObjectProperty` is not. Making the `rdf:type X` form work uniformly would be a small and defensible change, and I would take it if you want it, but it changes what a config *selects* rather than what it *reports*, and that is the redesign half of #89. It now fails loudly instead of silently, which was the agreed scope.

## Verification

- `scripts/ci-local.sh` green: **781 passed** (753 before), black clean.
- 28 new tests in `tests/test_selector_errors.py`: both error spellings, every built-in key, the predicate/dispatch agreement, four non-string-value cases, and four end-to-end CLI cases — exit code, the section being named, nothing written on failure, and the unclaimed-warning path still working.
- Note the new tests **cannot** be run against `main` to show red: they import `UnknownSelectorError`, which does not exist there, so collection fails. The before/after CLI transcripts above are the honest demonstration.

## Unrelated, found while looking for somewhere to document this

`docs/user_guides/CLI_REFERENCE.md` is a **single 50KB line** containing 1,767 literal `\n` sequences instead of newlines — it renders as one unreadable paragraph. Untouched here; happy to file or fix it separately.
