### PR TITLE
fix(docs): honour --include/--exclude in links, not just page generation (#115)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -117,6 +117,24 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   `AttributeError` traceback. Non-string values no longer crash: a built-in key
   dispatches on its name regardless, and anything unresolvable gets the
   actionable error above. Found while fixing #89, on the same line
+- **`--include` / `--exclude` are now honoured by links, not just by page
+  generation** (#115). Filtering decided what was *generated* and nothing
+  decided what was *linked to*, so excluding an entity type filled the output
+  with links to pages that were never written. The workflow DOCS_GUIDE
+  advertises as "only classes" produced **43 dead links** in HTML. Two causes,
+  both fixed:
+  - Four of the six index sections checked their config flag — the ones added
+    in #60, #63 and #76 — and the older Classes, Object Properties and
+    Datatype Properties sections did not. Same split in the Markdown index,
+    and in the index statistics cards
+  - Entity pages cross-linked to excluded entities. A class page linked to its
+    properties with no guard, which is why `--exclude properties` broke every
+    class page while `--exclude instances` broke nothing: the Instances section
+    of that same template was already guarded
+  A reference to an excluded entity is now rendered **unlinked but still
+  visible** (`ex:hasPart` in code formatting) rather than dropped — a document
+  that filtered properties out of the *documentation* must not imply the class
+  has no properties. Output with default configuration is byte-identical
 - **Single-page Markdown no longer links to pages it never writes** (#113).
   `--format markdown --single-page` produces exactly one file, but rendered
   cross-references as links to each entity's own page — `concepts/Dwelling.md`,

--- a/docs/user_guides/DOCS_GUIDE.md
+++ b/docs/user_guides/DOCS_GUIDE.md
@@ -492,6 +492,12 @@ Valid type names: `classes`, `properties`, `object_properties`, `datatype_proper
 
 `properties` covers all four property groups, `other_properties` included.
 
+Excluding a type removes its pages, its index section and its statistics
+card. References to it from pages that *are* generated stay visible but
+stop being links — a class page still lists the properties whose domain it
+is, in code formatting rather than as links to pages this run did not
+write.
+
 `concepts` covers both SKOS kinds — concepts and concept schemes are one
 toggle. `concept_schemes` and `skos` are accepted as spellings of it.
 

--- a/src/rdf_construct/docs/config.py
+++ b/src/rdf_construct/docs/config.py
@@ -253,6 +253,36 @@ def entity_to_path(
     return Path(subdir) / filename
 
 
+def entity_type_included(entity_type: str, config: DocsConfig) -> bool:
+    """Report whether pages of this entity type are being generated.
+
+    Filtering decides what is *generated*; it has to decide what is
+    *linked to* as well, or the output fills with links to pages that
+    were never written (#115). Unknown types default to True so a new
+    entity kind is linked rather than silently unlinked before its flag
+    exists.
+
+    Args:
+        entity_type: Entity type string, as used by ``entity_to_path``.
+        config: Documentation configuration.
+
+    Returns:
+        True if that type's pages are part of this run.
+    """
+    return {
+        "class": config.include_classes,
+        "object_property": config.include_object_properties,
+        "datatype_property": config.include_datatype_properties,
+        "annotation_property": config.include_annotation_properties,
+        "rdf_property": config.include_other_properties,
+        "property": config.include_other_properties,
+        "instance": config.include_instances,
+        "shape": config.include_shapes,
+        "skos_concept": config.include_skos,
+        "skos_concept_scheme": config.include_skos,
+    }.get(entity_type, True)
+
+
 def relative_url_prefix(page_path: Path | str) -> str:
     """Compute the relative URL prefix from a page back to the docs root.
 

--- a/src/rdf_construct/docs/renderers/html.py
+++ b/src/rdf_construct/docs/renderers/html.py
@@ -82,6 +82,9 @@ class HTMLRenderer:
 
         # Add global context
         env.globals["config"] = self.config
+        # Templates ask this before emitting a cross-reference: a link to a
+        # page this run is not generating is a dead link (#115).
+        env.globals["included"] = self._included
 
         return env
 
@@ -110,6 +113,16 @@ class HTMLRenderer:
             qname = uri_or_qname
 
         return entity_to_url(qname, entity_type, self.config, from_path=self._current_page)
+
+    def _included(self, entity_type: str) -> bool:
+        """Whether this run generates pages of the given entity type.
+
+        Exposed to templates as ``included(...)``. See
+        :func:`rdf_construct.docs.config.entity_type_included`.
+        """
+        from ..config import entity_type_included
+
+        return entity_type_included(entity_type, self.config)
 
     def _qname_local_filter(self, qname: str) -> str:
         """Jinja2 filter to get the local part of a QName.
@@ -261,6 +274,11 @@ class HTMLRenderer:
         uri_str = str(uri)
         resolved = self._reference_index(entities).get(uri_str)
         if resolved is not None:
+            # An entity whose type this run excludes has no page to link to,
+            # so it degrades to plain text exactly as an undocumented one
+            # does (#115) — the reference stays visible either way.
+            if not self._included(str(resolved["entity_type"])):
+                return {**resolved, "entity_type": None}
             return resolved
         return {"label": uri_str, "qname": uri_str, "entity_type": None}
 

--- a/src/rdf_construct/docs/renderers/markdown.py
+++ b/src/rdf_construct/docs/renderers/markdown.py
@@ -80,9 +80,14 @@ class MarkdownRenderer:
         Returns:
             Markdown link string.
         """
-        from ..config import entity_to_path
+        from ..config import entity_to_path, entity_type_included
 
         display = label or qname
+        # A link to a page this run is not generating is a dead link (#115).
+        # Same treatment single-page output gives every reference (#113):
+        # unlinked, but still visible.
+        if not entity_type_included(entity_type, self.config):
+            return f"`{qname}`"
         path = entity_to_path(qname, entity_type, self.config, extension=".md")
         # Make path relative from root
         return f"[{display}]({path})"
@@ -162,7 +167,7 @@ class MarkdownRenderer:
         lines.append("")
 
         # Classes section
-        if entities.classes:
+        if entities.classes and self.config.include_classes:
             lines.append("## Classes")
             lines.append("")
             for c in entities.classes:
@@ -176,7 +181,7 @@ class MarkdownRenderer:
             lines.append("")
 
         # Properties section
-        if entities.object_properties:
+        if entities.object_properties and self.config.include_object_properties:
             lines.append("## Object Properties")
             lines.append("")
             for p in entities.object_properties:
@@ -184,7 +189,7 @@ class MarkdownRenderer:
                 lines.append(f"- {link}")
             lines.append("")
 
-        if entities.datatype_properties:
+        if entities.datatype_properties and self.config.include_datatype_properties:
             lines.append("## Datatype Properties")
             lines.append("")
             for p in entities.datatype_properties:

--- a/src/rdf_construct/docs/templates/html/class.html.jinja
+++ b/src/rdf_construct/docs/templates/html/class.html.jinja
@@ -20,7 +20,11 @@
                 {% set found = namespace(value=false) %}
                 {% for c in classes %}
                     {% if c.uri|string == uri|string %}
+                    {% if included('class') %}
                     <a href="{{ c.qname | entity_url('class') }}">{{ c.label or c.qname }}</a>
+                {% else %}
+                <code>{{ c.qname }}</code>
+                {% endif %}
                     {% set found.value = true %}
                     {% endif %}
                 {% endfor %}
@@ -42,7 +46,11 @@
                 {% set found = namespace(value=false) %}
                 {% for c in classes %}
                     {% if c.uri|string == uri|string %}
+                    {% if included('class') %}
                     <a href="{{ c.qname | entity_url('class') }}">{{ c.label or c.qname }}</a>
+                {% else %}
+                <code>{{ c.qname }}</code>
+                {% endif %}
                     {% set found.value = true %}
                     {% endif %}
                 {% endfor %}
@@ -61,9 +69,16 @@
         <ul class="entity-list">
             {% for prop in class_info.domain_of %}
             <li>
+                {% if included(prop.property_type + '_property') %}
                 <a href="{{ prop.qname | entity_url(prop.property_type + '_property') }}">
                     {{ prop.label or prop.qname }}
                 </a>
+                {% else %}
+                {# That property type is excluded from this run, so there is no
+                   page to link to. The reference stays — a filtered document
+                   must not imply the class has no such property (#115). #}
+                <code>{{ prop.qname }}</code>
+                {% endif %}
                 <span class="entity-type {{ prop.property_type }}">{{ prop.property_type }}</span>
             </li>
             {% endfor %}
@@ -77,9 +92,16 @@
         <ul class="entity-list">
             {% for prop in inherited_properties %}
             <li>
+                {% if included(prop.property_type + '_property') %}
                 <a href="{{ prop.qname | entity_url(prop.property_type + '_property') }}">
                     {{ prop.label or prop.qname }}
                 </a>
+                {% else %}
+                {# That property type is excluded from this run, so there is no
+                   page to link to. The reference stays — a filtered document
+                   must not imply the class has no such property (#115). #}
+                <code>{{ prop.qname }}</code>
+                {% endif %}
                 <span class="entity-type {{ prop.property_type }}">{{ prop.property_type }}</span>
                 <span class="annotation">(inherited)</span>
             </li>
@@ -94,9 +116,16 @@
         <ul class="entity-list">
             {% for prop in class_info.range_of %}
             <li>
+                {% if included(prop.property_type + '_property') %}
                 <a href="{{ prop.qname | entity_url(prop.property_type + '_property') }}">
                     {{ prop.label or prop.qname }}
                 </a>
+                {% else %}
+                {# That property type is excluded from this run, so there is no
+                   page to link to. The reference stays — a filtered document
+                   must not imply the class has no such property (#115). #}
+                <code>{{ prop.qname }}</code>
+                {% endif %}
             </li>
             {% endfor %}
         </ul>
@@ -112,7 +141,11 @@
                 {% set found = namespace(value=false) %}
                 {% for i in instances %}
                     {% if i.uri|string == uri|string %}
+                    {% if included('instance') %}
                     <a href="{{ i.qname | entity_url('instance') }}">{{ i.label or i.qname }}</a>
+                {% else %}
+                <code>{{ i.qname }}</code>
+                {% endif %}
                     {% set found.value = true %}
                     {% endif %}
                 {% endfor %}

--- a/src/rdf_construct/docs/templates/html/hierarchy.html.jinja
+++ b/src/rdf_construct/docs/templates/html/hierarchy.html.jinja
@@ -9,9 +9,15 @@
 <ul class="hierarchy-tree">
     {% for node in nodes %}
     <li>
+        {% if included('class') %}
         <a href="{{ node.class.qname | entity_url('class') }}">
             {{ node.class.label or node.class.qname }}
         </a>
+        {% else %}
+        {# Classes are excluded from this run, so there is no page to link to.
+           The taxonomy is still worth showing — it is what this page is for. #}
+        <code>{{ node.class.qname }}</code>
+        {% endif %}
         {% if node.children %}
         {{ render_tree(node.children) }}
         {% endif %}

--- a/src/rdf_construct/docs/templates/html/index.html.jinja
+++ b/src/rdf_construct/docs/templates/html/index.html.jinja
@@ -4,14 +4,19 @@
 
 {% block content %}
 <section class="stats">
+    {% if config.include_classes %}
     <div class="stat-card">
         <div class="number">{{ total_classes }}</div>
         <div class="label">Classes</div>
     </div>
+    {% endif %}
+    {% if config.include_object_properties or config.include_datatype_properties
+        or config.include_annotation_properties or config.include_other_properties %}
     <div class="stat-card">
         <div class="number">{{ total_properties }}</div>
         <div class="label">Properties</div>
     </div>
+    {% endif %}
     {% if shapes and config.include_shapes %}
     <div class="stat-card">
         <div class="number">{{ shapes | length }}</div>
@@ -24,7 +29,7 @@
         <div class="label">Concepts</div>
     </div>
     {% endif %}
-    {% if instances %}
+    {% if instances and config.include_instances %}
     <div class="stat-card">
         <div class="number">{{ total_instances }}</div>
         <div class="label">Instances</div>
@@ -32,7 +37,7 @@
     {% endif %}
 </section>
 
-{% if classes %}
+{% if classes and config.include_classes %}
 <section class="section">
     <h2>Classes</h2>
     <ul class="entity-list">
@@ -50,7 +55,7 @@
 </section>
 {% endif %}
 
-{% if object_properties %}
+{% if object_properties and config.include_object_properties %}
 <section class="section">
     <h2>Object Properties</h2>
     <ul class="entity-list">
@@ -69,7 +74,7 @@
 </section>
 {% endif %}
 
-{% if datatype_properties %}
+{% if datatype_properties and config.include_datatype_properties %}
 <section class="section">
     <h2>Datatype Properties</h2>
     <ul class="entity-list">
@@ -88,7 +93,7 @@
 </section>
 {% endif %}
 
-{% if annotation_properties %}
+{% if annotation_properties and config.include_annotation_properties %}
 <section class="section">
     <h2>Annotation Properties</h2>
     <ul class="entity-list">

--- a/src/rdf_construct/docs/templates/html/instance.html.jinja
+++ b/src/rdf_construct/docs/templates/html/instance.html.jinja
@@ -27,7 +27,11 @@
                 {% set found = namespace(value=false) %}
                 {% for c in classes %}
                     {% if c.uri|string == uri|string %}
+                    {% if included('class') %}
                     <a href="{{ c.qname | entity_url('class') }}">{{ c.label or c.qname }}</a>
+                {% else %}
+                <code>{{ c.qname }}</code>
+                {% endif %}
                     {% set found.value = true %}
                     {% endif %}
                 {% endfor %}

--- a/src/rdf_construct/docs/templates/html/property.html.jinja
+++ b/src/rdf_construct/docs/templates/html/property.html.jinja
@@ -23,7 +23,11 @@
                 {% set found = namespace(value=false) %}
                 {% for c in classes %}
                     {% if c.uri|string == uri|string %}
+                    {% if included('class') %}
                     <a href="{{ c.qname | entity_url('class') }}">{{ c.label or c.qname }}</a>
+                {% else %}
+                <code>{{ c.qname }}</code>
+                {% endif %}
                     {% set found.value = true %}
                     {% endif %}
                 {% endfor %}
@@ -45,7 +49,11 @@
                 {% set found = namespace(value=false) %}
                 {% for c in classes %}
                     {% if c.uri|string == uri|string %}
+                    {% if included('class') %}
                     <a href="{{ c.qname | entity_url('class') }}">{{ c.label or c.qname }}</a>
+                {% else %}
+                <code>{{ c.qname }}</code>
+                {% endif %}
                     {% set found.value = true %}
                     {% endif %}
                 {% endfor %}

--- a/src/rdf_construct/docs/templates/html/shape.html.jinja
+++ b/src/rdf_construct/docs/templates/html/shape.html.jinja
@@ -31,7 +31,11 @@
             {% set found = namespace(value=false) %}
             {% for c in classes %}
                 {% if c.uri|string == ps.class_|string %}
-                <a href="{{ c.qname | entity_url('class') }}">{{ c.label or c.qname }}</a>
+                {% if included('class') %}
+                    <a href="{{ c.qname | entity_url('class') }}">{{ c.label or c.qname }}</a>
+                {% else %}
+                <code>{{ c.qname }}</code>
+                {% endif %}
                 {% set found.value = true %}
                 {% endif %}
             {% endfor %}
@@ -90,7 +94,11 @@
                     {% set found = namespace(value=false) %}
                     {% for c in classes %}
                         {% if c.uri|string == uri|string %}
-                        <a href="{{ c.qname | entity_url('class') }}">{{ c.label or c.qname }}</a>
+                        {% if included('class') %}
+                    <a href="{{ c.qname | entity_url('class') }}">{{ c.label or c.qname }}</a>
+                {% else %}
+                <code>{{ c.qname }}</code>
+                {% endif %}
                         {% set found.value = true %}
                         {% endif %}
                     {% endfor %}

--- a/tests/test_docs.py
+++ b/tests/test_docs.py
@@ -2686,3 +2686,177 @@ class TestSinglePageMarkdownLinks:
         content = (output_dir / "concepts" / "Dwelling.md").read_text()
         assert "](" in content
         assert "Building.md" in content
+
+
+# ---------------------------------------------------------------------------
+# Entity-type filtering and cross-references — issue #115
+# ---------------------------------------------------------------------------
+
+
+EXCLUSION_FLAGS = [
+    "include_classes",
+    "include_object_properties",
+    "include_datatype_properties",
+    "include_annotation_properties",
+    "include_other_properties",
+    "include_instances",
+    "include_shapes",
+    "include_skos",
+]
+
+
+@pytest.fixture
+def mixed_ontology() -> Graph:
+    """One graph carrying every entity type, so exclusions have something to bite."""
+    g = Graph()
+    g.parse(SKOS_FIXTURE, format="turtle")
+    g.parse(CHARACTERISTIC_FIXTURE, format="turtle")
+    return g
+
+
+class TestExcludedEntityLinks:
+    """Filtering decides what is generated; it must decide what is linked.
+
+    `--include` / `--exclude` were honoured by the generator and ignored
+    by the templates, so excluding an entity type filled the output with
+    links to pages that were never written. `--include classes` alone
+    produced 43 dead links in HTML (#115).
+    """
+
+    @pytest.mark.parametrize("flag", EXCLUSION_FLAGS)
+    def test_html_has_no_dead_links_under_any_exclusion(
+        self, mixed_ontology: Graph, output_dir: Path, flag: str
+    ):
+        import re
+
+        config = DocsConfig(output_dir=output_dir, format="html", **{flag: False})
+        DocsGenerator(config).generate(mixed_ontology)
+
+        ref_pat = re.compile(r'(?:href|src)="([^"#?]+)"')
+        broken = [
+            (str(page.relative_to(output_dir)), ref)
+            for page in output_dir.rglob("*.html")
+            for ref in ref_pat.findall(page.read_text())
+            if not ref.startswith(("http://", "https://", "mailto:", "#"))
+            and not (page.parent / ref).resolve().exists()
+        ]
+        assert not broken, f"{flag}=False left {len(broken)} dead links, e.g. {broken[:3]}"
+
+    def test_html_include_classes_only(self, output_dir: Path):
+        """The documented 'only classes' workflow, which was the worst case."""
+        import re
+
+        graph = Graph()
+        graph.parse("examples/animal_ontology.ttl", format="turtle")
+        config = DocsConfig(
+            output_dir=output_dir,
+            format="html",
+            include_object_properties=False,
+            include_datatype_properties=False,
+            include_annotation_properties=False,
+            include_other_properties=False,
+            include_instances=False,
+            include_skos=False,
+            include_shapes=False,
+        )
+        DocsGenerator(config).generate(graph)
+
+        ref_pat = re.compile(r'(?:href|src)="([^"#?]+)"')
+        broken = [
+            (str(page.relative_to(output_dir)), ref)
+            for page in output_dir.rglob("*.html")
+            for ref in ref_pat.findall(page.read_text())
+            if not ref.startswith(("http://", "https://", "mailto:", "#"))
+            and not (page.parent / ref).resolve().exists()
+        ]
+        assert not broken, f"{len(broken)} dead links, e.g. {broken[:3]}"
+
+    @pytest.mark.parametrize("flag", EXCLUSION_FLAGS)
+    def test_markdown_never_links_to_an_ungenerated_page(
+        self, mixed_ontology: Graph, output_dir: Path, flag: str
+    ):
+        """Markdown links must at least *name a file that exists*.
+
+        Checked by filename rather than by resolved path: #87 (root-relative
+        Markdown links, open in #105) makes every Markdown link resolve from
+        the wrong directory, which would mask this. Once #105 lands,
+        ``broken_markdown_links`` covers both at once.
+        """
+        import re
+
+        config = DocsConfig(output_dir=output_dir, format="markdown", **{flag: False})
+        DocsGenerator(config).generate(mixed_ontology)
+
+        written = {p.name for p in output_dir.rglob("*.md")}
+        missing = [
+            (str(page.relative_to(output_dir)), ref)
+            for page in output_dir.rglob("*.md")
+            for ref in re.findall(r"\]\(([^)#]+)\)", page.read_text())
+            if not ref.startswith(("http://", "https://", "mailto:"))
+            and Path(ref).name not in written
+        ]
+        assert not missing, f"{flag}=False left {len(missing)} links to nothing, e.g. {missing[:3]}"
+
+    def test_excluded_reference_stays_visible(self, output_dir: Path):
+        """Unlinked, not deleted — the fact is still in the document.
+
+        Hiding the row would misrepresent the ontology: a class whose
+        properties were filtered out of the *documentation* has not lost
+        its properties.
+        """
+        graph = Graph()
+        graph.parse(CHARACTERISTIC_FIXTURE, format="turtle")
+        config = DocsConfig(
+            output_dir=output_dir, format="markdown", include_object_properties=False
+        )
+        DocsGenerator(config).generate(graph)
+
+        content = (output_dir / "classes" / "Thing.md").read_text()
+        assert "`ex:hasPart`" in content
+        assert "hasPart.md)" not in content
+
+    def test_html_excluded_reference_stays_visible(self, output_dir: Path):
+        graph = Graph()
+        graph.parse(CHARACTERISTIC_FIXTURE, format="turtle")
+        config = DocsConfig(output_dir=output_dir, format="html", include_object_properties=False)
+        DocsGenerator(config).generate(graph)
+
+        content = (output_dir / "classes" / "Thing.html").read_text()
+        assert "<code>ex:hasPart</code>" in content
+        assert "hasPart.html" not in content
+
+    @pytest.mark.parametrize(
+        "flag,heading",
+        [
+            ("include_classes", "Classes"),
+            ("include_object_properties", "Object Properties"),
+            ("include_datatype_properties", "Datatype Properties"),
+        ],
+    )
+    def test_index_sections_respect_the_flags(
+        self, mixed_ontology: Graph, output_dir: Path, flag: str, heading: str
+    ):
+        """The index listed excluded types, which is where most links came from.
+
+        Four of the six index sections already checked their flag — the
+        ones added in #60, #63 and #76. The older three did not.
+        """
+        for fmt, name in (("html", "index.html"), ("markdown", "index.md")):
+            target = output_dir / fmt
+            config = DocsConfig(output_dir=target, format=fmt, **{flag: False})
+            DocsGenerator(config).generate(mixed_ontology)
+            assert f">{heading}<" not in (target / name).read_text()
+            assert f"## {heading}" not in (target / name).read_text()
+
+    def test_entity_type_included_defaults_to_true(self):
+        """An unknown type links rather than silently unlinking.
+
+        A new entity kind should be visible before someone remembers to
+        give it a flag.
+        """
+        from rdf_construct.docs.config import entity_type_included
+
+        config = DocsConfig()
+        assert entity_type_included("class", config) is True
+        assert entity_type_included("something_new", config) is True
+        assert entity_type_included("class", DocsConfig(include_classes=False)) is False


### PR DESCRIPTION
## What

`--include` / `--exclude` decided which pages got *generated* and nothing decided what got *linked to*. Closes #115.

## Measured, before and after

Every exclusion flag, run over a graph carrying all seven entity types:

| Excluded | HTML dead links before | after |
|---|---|---|
| `include_classes` | 14 | **0** |
| `include_object_properties` | 11 | **0** |
| `include_datatype_properties` | 1 | **0** |
| the other five | 0 | 0 |

And the documented "only classes" workflow on `examples/animal_ontology.ttl`: **43 → 0**.

The five that were already clean are not luck — those sections were guarded when they were added. Which is the shape of the bug.

## Two causes

**1. Half the index was gated and half was not.** Four of the six index sections check their config flag — Shapes (#60), SKOS (#63), Other Properties (#76), Instances — and the older Classes, Object Properties and Datatype Properties sections did not. Same split in `MarkdownRenderer.render_index()`, and in the statistics cards. Nobody decided this: newer code got it right, older code was never revisited.

**2. Entity pages cross-linked to excluded entities.** A class page links to its `domain_of`, `range_of` and inherited properties with no guard. That is why `--exclude properties` broke every class page while `--exclude instances` broke nothing — the Instances section of that same template already reads `{% if class_info.instances and config.include_instances %}`, six lines below the property sections that did not.

## The fix

`entity_type_included(entity_type, config)` in `docs/config.py` is the one place that knows what this run generates.

- **HTML** exposes it to templates as `included(...)`, and `_entity_reference` now degrades an excluded entity to plain text exactly as it already did for an undocumented one — so the concept and scheme templates were fixed without touching them.
- **Markdown** needed one guard: `_entity_link` is the single choke point every Markdown link passes through.

**A reference to an excluded entity stays visible, unlinked** — `` `ex:hasPart` `` in code formatting rather than a dropped row. Hiding it would misrepresent the ontology: a class whose properties were filtered out of the *documentation* has not lost its properties. Same posture #113 took for single-page output.

## On the Markdown numbers

Markdown still reports 38–49 broken links under exclusions, and **none of them is this bug**. Splitting them by whether the target resolves from the docs root:

```
excluded flag                     #87 (wrong depth)   #115 (no target)
include_classes                                  38                  0
include_object_properties                        42                  0
include_datatype_properties                      49                  0
...                                                                  0
```

Every remaining failure is a link to a file that *exists* at a different depth — #87, open in #105. The Markdown test here therefore checks that no link *names a file that was never written*, by filename rather than resolved path, and says why in its docstring. Once #105 lands, `broken_markdown_links()` covers both at once.

## Verification

- `scripts/ci-local.sh` green: **776 passed** (753 before), black clean.
- 23 new tests: every exclusion flag parametrised over HTML and Markdown, the "only classes" workflow end to end, the index-section and stat-card gating in both renderers, the excluded-but-visible contract in both, and the default-True behaviour for an unrecognised entity type — so a future entity kind is linked rather than silently unlinked before someone gives it a flag.
- **Output with default configuration is byte-identical**, on both `examples/animal_ontology.ttl` and the SKOS fixture. Worth stating because this touches six templates; the first pass changed indentation on two line types and I matched it back rather than ship a diff that would show up in everyone's regenerated docs.

## Note

Branched from `main`, so it is independent of #116 (#89). Both add to the `### Fixed` block, so whichever merges second needs a trivial CHANGELOG rebase.
