### PR TITLE
docs(cli-reference): restore newlines, and document two missing flags

### DIFF
--- a/docs/user_guides/CLI_REFERENCE.md
+++ b/docs/user_guides/CLI_REFERENCE.md
@@ -1,1 +1,1770 @@
-# CLI Reference\n\nComplete command reference for rdf-construct.\n\n## Installation\n\n```bash\n# With pip (recommended)\npip install rdf-construct\n\n# With Poetry (for development)\ngit clone https://github.com/aigora-de/rdf-construct.git\ncd rdf-construct\npoetry install\n\n# From source\ngit clone https://github.com/aigora-de/rdf-construct.git\ncd rdf-construct\npip install -e .\n```\n\n> **Note**: If installed via Poetry, prefix commands with `poetry run` (e.g., `poetry run rdf-construct --help`). Once installed via pip, use `rdf-construct` directly.\n\n## Global Options\n\n```bash\nrdf-construct --version    # Show version\nrdf-construct --help       # Show help\n```\n\n## Commands\n\n### describe - Ontology Orientation\n\nProvide a quick orientation to an unfamiliar ontology file, showing metadata, metrics, profile, imports, and documentation coverage.\n\n```bash\nrdf-construct describe SOURCE [OPTIONS]\n```\n\n**Arguments**:\n- `SOURCE`: RDF ontology file to describe (.ttl, .rdf, .owl, etc.)\n\n**Options**:\n- `-o, --output PATH`: Write output to file instead of stdout\n- `-f, --format FORMAT`: Output format: `text` (default), `json`, `markdown`, `md`\n- `-b, --brief`: Quick overview (metadata + metrics + profile only)\n- `--no-resolve`: Skip import resolution (no network requests)\n- `--no-colour`: Disable ANSI colour codes\n\n**Output Sections**:\n\n| Section | Description |\n|---------|-------------|\n| Verdict | One-line summary: profile, scale, import status |\n| Metadata | Title, version, description, license, creators |\n| Metrics | Triples, classes, properties, individuals |\n| Profile | OWL expressiveness level (RDF, RDFS, OWL DL, OWL Full) |\n| Imports | owl:imports declarations and resolution status |\n| Namespaces | Local, standard, and external namespace usage |\n| Hierarchy | Root/leaf classes, depth, orphans, cycles |\n| Documentation | Label and comment coverage percentages |\n\n**Profile Detection**:\n\n| Profile | Description |\n|---------|-------------|\n| RDF | No schema vocabulary |\n| RDFS | Uses rdfs:Class, rdfs:subClassOf |\n| OWL 2 DL (simple) | Basic OWL constructs |\n| OWL 2 DL (expressive) | Complex restrictions, cardinality |\n| OWL 2 Full | Metaclasses, property punning |\n\n**Examples**:\n\n```bash\n# Describe an ontology file\nrdf-construct describe ontology.ttl\n\n# Quick overview (faster for large files)\nrdf-construct describe ontology.ttl --brief\n\n# Output as JSON for scripting\nrdf-construct describe ontology.ttl --format json -o description.json\n\n# Output as Markdown for documentation\nrdf-construct describe ontology.ttl --format markdown >> README.md\n\n# Skip import resolution (no network access)\nrdf-construct describe ontology.ttl --no-resolve\n\n# Disable coloured output\nrdf-construct describe ontology.ttl --no-colour\n```\n\n**Exit Codes**:\n- `0`: Success\n- `1`: Success with warnings (e.g., unresolvable imports)\n- `2`: Error (file not found, parse error)\n\n---\n\n### order - Reorder RDF Files\n\nReorder RDF Turtle files according to semantic profiles.\n\n```bash\nrdf-construct order SOURCE CONFIG [OPTIONS]\n```\n\n**Arguments**:\n- `SOURCE`: Input RDF Turtle file (.ttl)\n- `CONFIG`: YAML configuration file defining ordering profiles\n\n**Options**:\n- `-p, --profile NAME`: Profile(s) to generate (can specify multiple, default: all)\n- `-o, --outdir PATH`: Output directory (default: `src/ontology`)\n\n**Examples**:\n\n```bash\n# Generate all profiles defined in config\nrdf-construct order ontology.ttl order.yml\n\n# Generate specific profiles only\nrdf-construct order ontology.ttl order.yml -p alpha -p logical_topo\n\n# Custom output directory\nrdf-construct order ontology.ttl order.yml -o output/\n```\n\n---\n\n### profiles - List Ordering Profiles\n\nList available profiles in a configuration file.\n\n```bash\nrdf-construct profiles CONFIG\n```\n\n**Arguments**:\n- `CONFIG`: YAML configuration file to inspect\n\n**Example**:\n\n```bash\nrdf-construct profiles order.yml\n```\n\n---\n\n### uml - Generate UML Diagrams\n\nGenerate PlantUML class diagrams from RDF ontologies.\n\n```bash\nrdf-construct uml SOURCE [SOURCE...] -C CONFIG [OPTIONS]\n```\n\n**Arguments**:\n- `SOURCE`: One or more RDF files (.ttl, .rdf, .owl). First file is primary; additional files provide supporting definitions.\n- `-C, --config`: YAML configuration file defining contexts (required)\n\n**Options**:\n- `-c, --context NAME`: Generate specific context(s) (can specify multiple)\n- `-o, --outdir PATH`: Output directory (default: `diagrams`)\n- `--style-config PATH`: Path to style configuration YAML\n- `-s, --style NAME`: Style scheme name to use\n- `--layout-config PATH`: Path to layout configuration YAML\n- `-l, --layout NAME`: Layout name to use\n- `-r, --rendering-mode`: Rendering mode: `default` or `odm` (OMG ODM RDF Profile)\n\n**Examples**:\n\n```bash\n# Generate all contexts\nrdf-construct uml ontology.ttl -C config.yml\n\n# Specific context\nrdf-construct uml ontology.ttl -C config.yml -c animal_taxonomy\n\n# Multiple sources (primary + imports)\nrdf-construct uml domain.ttl imports/core.ttl -C config.yml\n\n# With styling and layout\nrdf-construct uml ontology.ttl -C config.yml \\\n  --style-config styles.yml --style default \\\n  --layout-config layouts.yml --layout hierarchy\n\n# ODM-compliant rendering\nrdf-construct uml ontology.ttl -C config.yml --rendering-mode odm\n```\n\n**Output**:\n- Creates `.puml` files in output directory\n- One file per context: `SOURCE-CONTEXT.puml`\n- Shows summary: number of classes, properties, instances\n\n---\n\n### contexts - List UML Contexts\n\nList available UML contexts in a configuration file.\n\n```bash\nrdf-construct contexts CONFIG\n```\n\n**Arguments**:\n- `CONFIG`: YAML configuration file to inspect\n\n**Example**:\n\n```bash\nrdf-construct contexts uml_contexts.yml\n```\n\n---\n\n### docs - Generate Documentation\n\nGenerate HTML, Markdown, or JSON documentation from RDF ontologies.\n\n```bash\nrdf-construct docs SOURCE [OPTIONS]\n```\n\n**Arguments**:\n- `SOURCE`: Input RDF ontology file (.ttl, .rdf, .owl, etc.)\n\n**Options**:\n- `-o, --output PATH`: Output directory (default: `docs`)\n- `-f, --format FORMAT`: Output format: `html`, `markdown`, `md`, `json` (default: html)\n- `-C, --config PATH`: YAML configuration file\n- `-t, --template PATH`: Path to custom Jinja2 templates directory\n- `--title TEXT`: Documentation title (default: from ontology or filename)\n- `--single-page`: Generate single-page documentation\n- `--no-search`: Disable search index generation (HTML only)\n- `--no-instances`: Exclude instances from documentation\n- `--include TYPES`: Include only these entity types (comma-separated: classes, properties, instances)\n- `--exclude TYPES`: Exclude these entity types\n\n**Examples**:\n\n```bash\n# Generate HTML documentation\nrdf-construct docs ontology.ttl -o api-docs/\n\n# Generate Markdown for GitHub wiki\nrdf-construct docs ontology.ttl --format markdown -o wiki/\n\n# Generate JSON for custom rendering\nrdf-construct docs ontology.ttl --format json -o data/\n\n# Single-page HTML with custom title\nrdf-construct docs ontology.ttl --single-page --title "My Ontology"\n\n# Use custom templates\nrdf-construct docs ontology.ttl --template my-templates/ -o docs/\n```\n\n**Output**:\n- HTML: Complete website with navigation, search, and styling\n- Markdown: Individual `.md` files per class/property\n- JSON: Structured data for programmatic use\n\n---\n\n### cast - Convert Between RDF Formats\n\nConvert an RDF source file to one or more serialisation formats. Designed to be Unix pipe-friendly: a single `--format` writes RDF to stdout, keeping stderr for diagnostics.\n\n```bash\nrdf-construct cast SOURCE [OPTIONS]\n```\n\n**Arguments**:\n- `SOURCE`: Input RDF file (any format rdflib can parse)\n\n**Options**:\n- `-f, --format FORMAT`: Output format, repeatable. Omit for all standard formats except source. Single format writes to stdout (pipe mode).\n- `-o, --output-dir PATH`: Output directory for files (default: same directory as source)\n- `--allow-flatten`: Merge all named graphs into the default graph when converting from a quad format (TriG, N-Quads) to a single-graph format\n\n**Supported format aliases** (case-insensitive):\n\n| Canonical | Aliases | Extension | Quad? |\n|-----------|---------|-----------|-------|\n| `turtle` | `ttl`, `turtle` | `.ttl` | No |\n| `xml` | `xml`, `rdf`, `rdfxml` | `.rdf` | No |\n| `json-ld` | `json-ld`, `jsonld` | `.jsonld` | No |\n| `nt` | `nt`, `ntriples` | `.nt` | No |\n| `n3` | `n3` | `.n3` | No |\n| `trig` | `trig` | `.trig` | Yes |\n| `nquads` | `nq`, `nquads` | `.nq` | Yes |\n\n**Pipe mode** (single `--format`, no `--output-dir`):\n\nRDF is written to stdout; all diagnostic messages go to stderr. This makes the output safe to pipe directly to other tools:\n\n```bash\nrdf-construct cast ontology.ttl --format n3 | grep rdf:type\nrdf-construct cast ontology.rdf --format ttl > converted.ttl\nrdf-construct cast ontology.ttl --format json-ld | jq \'.[\"@context\"]\'\n```\n\n**Default output set** (no `--format`):\n\nConverts to `turtle`, `xml`, and `json-ld`, excluding the source format. Writes one file per format to the output directory.\n\n**Quad format handling**:\n\nConverting a quad-format source (TriG, N-Quads) to a single-graph format is rejected by default with a clear error. Use `--allow-flatten` to merge all named graphs into the default graph:\n\n```bash\nrdf-construct cast dataset.trig --format ttl --allow-flatten\n```\n\n**Examples**:\n\n```bash\n# Pipe to grep (stdout is clean RDF)\nrdf-construct cast ontology.ttl --format n3 | grep rdf:type\n\n# Redirect to file\nrdf-construct cast ontology.rdf --format ttl > converted.ttl\n\n# Write multiple formats to files\nrdf-construct cast ontology.ttl --format xml --format json-ld\n\n# Default: write ttl + xml + json-ld (minus source) to source directory\nrdf-construct cast ontology.rdf\n\n# Custom output directory\nrdf-construct cast ontology.ttl --output-dir dist/\n\n# Flatten a multi-graph source\nrdf-construct cast dataset.trig --format turtle --allow-flatten\n\n# Pipe and validate\nrdf-construct cast ontology.rdf --format ttl | rdf-construct lint /dev/stdin\n```\n\n**Exit Codes**:\n- `0`: All conversions succeeded\n- `1`: Partial failure — some formats failed, at least one succeeded\n- `2`: Complete failure (parse error, or all formats failed)\n\n---\n\n### puml2rdf - Convert PlantUML to RDF\n\nConvert PlantUML class diagrams to RDF/OWL ontologies, enabling diagram-first ontology design.\n\n```bash\nrdf-construct puml2rdf SOURCE [OPTIONS]\n```\n\n**Arguments**:\n- `SOURCE`: PlantUML file (.puml or .plantuml)\n\n**Options**:\n- `-o, --output PATH`: Output file path (default: source name with .ttl extension)\n- `-f, --format FORMAT`: Output format: `turtle`, `ttl`, `xml`, `rdfxml`, `jsonld`, `json-ld`, `nt`, `ntriples` (default: turtle)\n- `-n, --namespace URI`: Default namespace URI for the ontology\n- `-C, --config PATH`: Path to YAML configuration file\n- `-m, --merge PATH`: Existing ontology file to merge with\n- `-v, --validate`: Validate only, don\'t generate output\n- `--strict`: Treat warnings as errors\n- `-l, --language TAG`: Language tag for labels/comments (default: en)\n- `--no-labels`: Don\'t auto-generate rdfs:label triples\n\n**Supported PlantUML Syntax**:\n- Classes: `class Building`, `class "Display Name" as pkg.Building`\n- Attributes: `floorArea : decimal`, `name : string`\n- Inheritance: `Building --|> Entity`, `Entity <|-- Building`\n- Associations: `Building --> Floor : hasFloor`\n- Packages: `package "http://example.org/building#" as bld { ... }`\n- Notes: `note right of Building : A physical structure`\n- Direction hints: `-u-|>`, `-d-|>`, `-l-|>`, `-r-|>` (up, down, left, right)\n\n**RDF Mapping**:\n\n| PlantUML | RDF |\n|----------|-----|\n| `class Building` | `Building rdf:type owl:Class` |\n| `floorArea : decimal` | `floorArea rdf:type owl:DatatypeProperty ; rdfs:range xsd:decimal` |\n| `Building --\\|> Entity` | `Building rdfs:subClassOf Entity` |\n| `Building --> Floor : hasFloor` | `hasFloor rdf:type owl:ObjectProperty ; rdfs:domain Building ; rdfs:range Floor` |\n| Note attached to class | `rdfs:comment` |\n\n**Examples**:\n\n```bash\n# Basic conversion\nrdf-construct puml2rdf design.puml\n\n# Custom output and namespace\nrdf-construct puml2rdf design.puml -o ontology.ttl -n http://example.org/ont#\n\n# Validate without generating\nrdf-construct puml2rdf design.puml --validate\n\n# Merge with existing ontology (preserves manual annotations)\nrdf-construct puml2rdf design.puml --merge existing.ttl\n\n# Use configuration file for namespace mappings\nrdf-construct puml2rdf design.puml -C puml-config.yml\n\n# Strict mode for CI\nrdf-construct puml2rdf design.puml --validate --strict\n```\n\n**Exit Codes**:\n- `0`: Success\n- `1`: Validation warnings (with --strict)\n- `2`: Parse or validation errors\n\n---\n\n### shacl-gen - Generate SHACL Shapes\n\nGenerate SHACL validation shapes from OWL ontology definitions.\n\n```bash\nrdf-construct shacl-gen SOURCE [OPTIONS]\n```\n\n**Arguments**:\n- `SOURCE`: Input RDF ontology file (.ttl, .rdf, .owl, etc.)\n\n**Options**:\n- `-o, --output PATH`: Output file path (default: `<source>-shapes.ttl`)\n- `-f, --format FORMAT`: Output format: `turtle`, `ttl`, `json-ld`, `jsonld` (default: turtle)\n- `-l, --level LEVEL`: Strictness level: `minimal`, `standard`, `strict` (default: standard)\n- `-C, --config PATH`: YAML configuration file\n- `--classes LIST`: Comma-separated list of classes to generate shapes for\n- `--closed`: Generate closed shapes (no extra properties allowed)\n- `--default-severity LEVEL`: Default severity: `violation`, `warning`, `info`\n- `--no-labels`: Don\'t include rdfs:label as sh:name\n- `--no-descriptions`: Don\'t include rdfs:comment as sh:description\n- `--no-inherit`: Don\'t inherit constraints from superclasses\n\n**Strictness Levels**:\n- `minimal`: Basic type constraints only (sh:class, sh:datatype)\n- `standard`: Adds cardinality and functional property constraints\n- `strict`: Maximum constraints including enumerations, closed shapes\n\n**Examples**:\n\n```bash\n# Basic generation\nrdf-construct shacl-gen ontology.ttl\n\n# Generate with strict constraints\nrdf-construct shacl-gen ontology.ttl --level strict --closed\n\n# Custom output path and format\nrdf-construct shacl-gen ontology.ttl -o shapes.ttl --format turtle\n\n# Focus on specific classes\nrdf-construct shacl-gen ontology.ttl --classes "ex:Building,ex:Floor"\n\n# Use configuration file\nrdf-construct shacl-gen ontology.ttl --config shacl-config.yml\n\n# Generate warnings instead of violations\nrdf-construct shacl-gen ontology.ttl --default-severity warning\n```\n\n**Output**:\n- Creates SHACL shapes file with NodeShapes for each class\n- Converts domain/range to sh:property constraints\n- Converts cardinality restrictions to sh:minCount/sh:maxCount\n- Converts functional properties to sh:maxCount 1\n\n---\n\n### diff - Compare RDF Files\n\nCompare two RDF files and show semantic differences.\n\n```bash\nrdf-construct diff OLD_FILE NEW_FILE [OPTIONS]\n```\n\n**Arguments**:\n- `OLD_FILE`: Original RDF file\n- `NEW_FILE`: Updated RDF file\n\n**Options**:\n- `-o, --output PATH`: Write output to file instead of stdout\n- `-f, --format FORMAT`: Output format: `text`, `markdown`, `md`, `json` (default: text)\n- `--show TYPES`: Show only these change types (comma-separated: added,removed,modified)\n- `--hide TYPES`: Hide these change types\n- `--entities TYPES`: Show only these entity types (comma-separated: classes,properties,instances)\n- `--ignore-predicates LIST`: Ignore these predicates in comparison (comma-separated CURIEs)\n\n**Examples**:\n\n```bash\n# Basic comparison\nrdf-construct diff v1.0.ttl v1.1.ttl\n\n# Generate markdown changelog\nrdf-construct diff v1.0.ttl v1.1.ttl --format markdown -o CHANGELOG.md\n\n# Show only added and removed (hide modified)\nrdf-construct diff old.ttl new.ttl --show added,removed\n\n# Focus on class changes only\nrdf-construct diff old.ttl new.ttl --entities classes\n\n# Ignore version predicates\nrdf-construct diff old.ttl new.ttl --ignore-predicates "owl:versionInfo,dct:modified"\n\n# JSON output for scripting\nrdf-construct diff old.ttl new.ttl --format json -o changes.json\n```\n\n**Exit Codes**:\n- `0`: Graphs are semantically identical\n- `1`: Differences were found\n- `2`: Error occurred\n\n---\n\n### lint - Check Ontology Quality\n\nCheck RDF ontologies for structural issues, missing documentation, and best practice violations.\n\n```bash\nrdf-construct lint SOURCE [SOURCE...] [OPTIONS]\n```\n\n**Arguments**:\n- `SOURCE`: One or more RDF files to check\n\n**Options**:\n- `-l, --level LEVEL`: Strictness level: `strict`, `standard`, `relaxed` (default: standard)\n- `-f, --format FORMAT`: Output format: `text`, `json` (default: text)\n- `-c, --config PATH`: Path to `.rdf-lint.yml` configuration file\n- `-e, --enable RULE`: Enable specific rules (can use multiple times)\n- `-d, --disable RULE`: Disable specific rules (can use multiple times)\n- `--no-colour`: Disable coloured output\n- `--list-rules`: List available rules and exit\n- `--init`: Generate a default `.rdf-lint.yml` config file and exit\n\n**Available Rules**:\n\n| Rule | Category | Severity | Description |\n|------|----------|----------|-------------|\n| `orphan-class` | Structural | error | Class with no superclass or subclasses |\n| `dangling-reference` | Structural | error | Reference to undefined entity |\n| `circular-subclass` | Structural | error | Circular subclass hierarchy |\n| `property-no-type` | Structural | error | Property without type declaration |\n| `empty-ontology` | Structural | error | Ontology with no classes or properties |\n| `missing-label` | Documentation | warning | Entity without rdfs:label |\n| `missing-comment` | Documentation | warning | Entity without rdfs:comment |\n| `redundant-subclass` | Best Practice | info | Redundant subclass declaration |\n| `property-no-domain` | Best Practice | info | Property without rdfs:domain |\n| `property-no-range` | Best Practice | info | Property without rdfs:range |\n| `inconsistent-naming` | Best Practice | info | Inconsistent naming conventions |\n\n**Examples**:\n\n```bash\n# Run all lint rules\nrdf-construct lint ontology.ttl\n\n# Strict checking\nrdf-construct lint ontology.ttl --level strict\n\n# Check multiple files\nrdf-construct lint domain.ttl foundation.ttl\n\n# JSON output for CI\nrdf-construct lint ontology.ttl --format json -o lint-results.json\n\n# Enable only specific rules\nrdf-construct lint ontology.ttl -e missing-label -e missing-comment\n\n# Disable specific rules\nrdf-construct lint ontology.ttl -d orphan-class\n\n# List all available rules\nrdf-construct lint --list-rules\n\n# Generate default config file\nrdf-construct lint --init\n```\n\n**Exit Codes**:\n- `0`: No issues found\n- `1`: Warnings found (with standard/strict level)\n- `2`: Errors found\n\n---\n\n### merge - Combine RDF Ontologies\n\nMerge multiple RDF ontology files with intelligent conflict detection and resolution.\n\n```bash\nrdf-construct merge [SOURCES...] -o OUTPUT [OPTIONS]\n```\n\n**Arguments**:\n- `SOURCES`: One or more RDF files to merge (.ttl, .rdf, .owl)\n\n**Options**:\n- `-o, --output PATH`: Output file for merged ontology (required)\n- `-c, --config PATH`: YAML configuration file\n- `-p, --priority INT`: Priority for each source (can specify multiple, higher wins conflicts)\n- `--strategy STRATEGY`: Conflict resolution: `priority`, `first`, `last`, `mark_all` (default: priority)\n- `-r, --report PATH`: Write conflict report to file\n- `--report-format FORMAT`: Report format: `text`, `markdown`, `md` (default: markdown)\n- `--imports STRATEGY`: owl:imports handling: `preserve`, `remove`, `merge` (default: preserve)\n- `--migrate-data PATH`: Data file(s) to migrate (can specify multiple)\n- `--migration-rules PATH`: YAML file with migration rules\n- `--data-output PATH`: Output path for migrated data\n- `--dry-run`: Show what would happen without writing files\n- `--no-colour`: Disable coloured output\n- `--init`: Generate a default merge configuration file\n\n**Conflict Resolution Strategies**:\n\n| Strategy | Description |\n|----------|-------------|\n| `priority` | Higher priority source wins (default) |\n| `first` | First source encountered wins |\n| `last` | Last source encountered wins |\n| `mark_all` | Mark all conflicts for manual review |\n\n**Examples**:\n\n```bash\n# Basic merge of two ontologies\nrdf-construct merge core.ttl extension.ttl -o merged.ttl\n\n# With priorities (extension wins conflicts)\nrdf-construct merge core.ttl extension.ttl -o merged.ttl -p 1 -p 2\n\n# Mark all conflicts for manual review\nrdf-construct merge core.ttl extension.ttl -o merged.ttl --strategy mark_all\n\n# Generate conflict report\nrdf-construct merge core.ttl extension.ttl -o merged.ttl --report conflicts.md\n\n# Dry run (preview without writing)\nrdf-construct merge core.ttl extension.ttl -o merged.ttl --dry-run\n\n# With data migration\nrdf-construct merge core.ttl extension.ttl -o merged.ttl \\\n    --migrate-data split_instances.ttl --data-output migrated.ttl\n\n# Using configuration file\nrdf-construct merge --config merge.yml -o merged.ttl\n\n# Generate default configuration\nrdf-construct merge --init\n```\n\n**Conflict Markers**:\n\nUnresolved conflicts are marked in the output file:\n\n```turtle\n# === CONFLICT: ex:Building rdfs:label ===\n# Source: core.ttl (priority 1): "Building"@en\n# Source: ext.ttl (priority 2): "Structure"@en\n# Resolution: UNRESOLVED - values differ, manual review required\nex:Building a owl:Class ;\n    rdfs:label "Building"@en ;\n    rdfs:label "Structure"@en .\n# === END CONFLICT ===\n```\n\nFind conflicts with: `grep -n "=== CONFLICT ===" merged.ttl`\n\n**Configuration File Format**:\n\n```yaml\nsources:\n  - path: core.ttl\n    priority: 1\n  - path: extension.ttl\n    priority: 2\n    namespace_remap:\n      "http://old.org/": "http://new.org/"\n\noutput:\n  path: merged.ttl\n  format: turtle\n\nconflicts:\n  strategy: priority\n  report: conflicts.md\n\nimports: preserve\n\nmigrate_data:\n  sources:\n    - split_instances.ttl\n  output: migrated.ttl\n  rules:\n    - type: rename\n      from: "http://old.org/Class"\n      to: "http://new.org/Class"\n```\n\n**Exit Codes**:\n- `0`: Merge successful, no unresolved conflicts\n- `1`: Merge successful, but unresolved conflicts marked in output\n- `2`: Error (file not found, parse error, etc.)\n\n---\n\n### split - Modularise Ontologies\n\nSplit a monolithic ontology into multiple modules.\n\n```bash\nrdf-construct split SOURCE [OPTIONS]\n```\n\n**Arguments**:\n- `SOURCE`: RDF ontology file to split (.ttl, .rdf, .owl)\n\n**Options**:\n- `-o, --output PATH`: Output directory for modules (default: `modules/`)\n- `-c, --config PATH`: YAML configuration file\n- `--by-namespace`: Auto-detect modules from namespaces\n- `--migrate-data PATH`: Data file(s) to split by instance type (can specify multiple)\n- `--data-output PATH`: Output directory for split data files\n- `--unmatched STRATEGY`: Strategy for unmatched entities: `common` or `error` (default: common)\n- `--common-name NAME`: Name for common module (default: `common`)\n- `--no-manifest`: Don\'t generate manifest.yml\n- `--dry-run`: Show what would happen without writing files\n- `--no-colour`: Disable coloured output\n- `--init`: Generate a default split configuration file\n\n**Examples**:\n\n```bash\n# Split by namespace (auto-detect modules)\nrdf-construct split large.ttl -o modules/ --by-namespace\n\n# Split using configuration file\nrdf-construct split large.ttl -o modules/ -c split.yml\n\n# With data migration\nrdf-construct split large.ttl -o modules/ -c split.yml \\\n    --migrate-data instances.ttl --data-output data/\n\n# Dry run (preview without writing)\nrdf-construct split large.ttl -o modules/ --by-namespace --dry-run\n\n# Generate default configuration\nrdf-construct split --init\n```\n\n**Configuration File Format**:\n\n```yaml\nsplit:\n  source: ontology/monolith.ttl\n  output_dir: modules/\n\n  modules:\n    # By explicit class/property list\n    - name: core\n      description: "Core concepts"\n      output: core.ttl\n      include:\n        classes:\n          - ex:Entity\n          - ex:Event\n        properties:\n          - ex:identifier\n      include_descendants: true\n\n    # By namespace\n    - name: organisation\n      output: organisation.ttl\n      namespaces:\n        - "http://example.org/ontology/org#"\n      auto_imports: true\n\n  unmatched:\n    strategy: common\n    module: common\n    output: common.ttl\n\n  generate_manifest: true\n```\n\n**Manifest Output** (`manifest.yml`):\n\n```yaml\nsource: ontology/monolith.ttl\noutput_dir: modules/\nmodules:\n  - name: core\n    file: core.ttl\n    classes: 5\n    properties: 3\n    triples: 42\n    imports: []\n    dependencies: []\n  - name: organisation\n    file: organisation.ttl\n    classes: 8\n    properties: 5\n    triples: 67\n    imports: [core.ttl]\n    dependencies: [core]\nsummary:\n  total_modules: 2\n  total_triples: 109\n  unmatched_entities: 0\n```\n\n**Exit Codes**:\n- `0`: Split successful\n- `1`: Split successful, unmatched entities placed in common module\n- `2`: Error (file not found, config invalid, etc.)\n\n---\n\n### refactor - Rename and Deprecate Entities\n\nRefactor ontologies by renaming URIs or marking entities as deprecated.\n\n```bash\nrdf-construct refactor <subcommand> [OPTIONS]\n```\n\n**Subcommands**:\n- `rename` - Rename URIs (single entity or bulk namespace)\n- `deprecate` - Mark entities as deprecated with OWL annotations\n\n---\n\n#### refactor rename\n\nRename URIs in ontology files.\n\n```bash\nrdf-construct refactor rename SOURCES [OPTIONS]\n```\n\n**Arguments**:\n- `SOURCES`: One or more RDF files to process (.ttl, .rdf, .owl)\n\n**Options**:\n- `--from URI`: Single URI to rename\n- `--to URI`: New URI for single rename\n- `--from-namespace NS`: Old namespace prefix for bulk rename\n- `--to-namespace NS`: New namespace prefix for bulk rename\n- `-c, --config PATH`: YAML configuration file with rename mappings\n- `-o, --output PATH`: Output file (single source) or directory (multiple sources)\n- `--migrate-data PATH`: Data file(s) to migrate (can specify multiple)\n- `--data-output PATH`: Output path for migrated data\n- `--dry-run`: Preview changes without writing files\n- `--no-colour`: Disable coloured output\n- `--init`: Generate a template rename configuration file\n\n**Examples**:\n\n```bash\n# Fix a single typo\nrdf-construct refactor rename ontology.ttl \\\n    --from "http://example.org/ont#Buiding" \\\n    --to "http://example.org/ont#Building" \\\n    -o fixed.ttl\n\n# Bulk namespace change\nrdf-construct refactor rename ontology.ttl \\\n    --from-namespace "http://old.example.org/" \\\n    --to-namespace "http://new.example.org/" \\\n    -o migrated.ttl\n\n# With data migration\nrdf-construct refactor rename ontology.ttl \\\n    --from "ex:OldClass" --to "ex:NewClass" \\\n    --migrate-data instances.ttl \\\n    --data-output updated-instances.ttl\n\n# From configuration file\nrdf-construct refactor rename --config renames.yml\n\n# Preview changes (dry run)\nrdf-construct refactor rename ontology.ttl \\\n    --from "ex:Old" --to "ex:New" --dry-run\n\n# Process multiple files\nrdf-construct refactor rename modules/*.ttl \\\n    --from-namespace "http://old/" --to-namespace "http://new/" \\\n    -o migrated/\n\n# Generate template config\nrdf-construct refactor rename --init\n```\n\n**Configuration File Format**:\n\n```yaml\nsource_files:\n  - ontology.ttl\n\noutput: renamed.ttl\n\nrename:\n  # Namespace mappings (applied first)\n  namespaces:\n    "http://old.example.org/v1#": "http://example.org/v2#"\n\n  # Individual entity renames (applied after namespace)\n  entities:\n    "http://example.org/v2#Buiding": "http://example.org/v2#Building"\n    "http://example.org/v2#hasAddres": "http://example.org/v2#hasAddress"\n\n# Optional data migration\nmigrate_data:\n  sources:\n    - data/*.ttl\n  output_dir: data/migrated/\n```\n\n---\n\n#### refactor deprecate\n\nMark ontology entities as deprecated with OWL annotations.\n\n```bash\nrdf-construct refactor deprecate SOURCES [OPTIONS]\n```\n\n**Arguments**:\n- `SOURCES`: One or more RDF files to process (.ttl, .rdf, .owl)\n\n**Options**:\n- `--entity URI`: URI of entity to deprecate\n- `--replaced-by URI`: URI of replacement entity (adds dcterms:isReplacedBy)\n- `-m, --message TEXT`: Deprecation message (added to rdfs:comment)\n- `--version VERSION`: Version when deprecated (included in message)\n- `-c, --config PATH`: YAML configuration file with deprecation specs\n- `-o, --output PATH`: Output file\n- `--dry-run`: Preview changes without writing files\n- `--no-colour`: Disable coloured output\n- `--init`: Generate a template deprecation configuration file\n\n**Examples**:\n\n```bash\n# Deprecate with replacement\nrdf-construct refactor deprecate ontology.ttl \\\n    --entity "http://example.org/ont#LegacyTerm" \\\n    --replaced-by "http://example.org/ont#NewTerm" \\\n    --message "Use NewTerm instead. Will be removed in v3.0." \\\n    -o updated.ttl\n\n# Deprecate without replacement\nrdf-construct refactor deprecate ontology.ttl \\\n    --entity "ex:ObsoleteThing" \\\n    --message "No longer needed." \\\n    -o updated.ttl\n\n# Bulk deprecation from config\nrdf-construct refactor deprecate ontology.ttl \\\n    -c deprecations.yml \\\n    -o updated.ttl\n\n# Preview changes (dry run)\nrdf-construct refactor deprecate ontology.ttl \\\n    --entity "ex:Legacy" --replaced-by "ex:Modern" --dry-run\n\n# Generate template config\nrdf-construct refactor deprecate --init\n```\n\n**Configuration File Format**:\n\n```yaml\nsource_files:\n  - ontology.ttl\n\noutput: deprecated.ttl\n\ndeprecations:\n  - entity: "http://example.org/ont#LegacyPerson"\n    replaced_by: "http://example.org/ont#Agent"\n    message: "Deprecated in v2.0. Use Agent for both people and organisations."\n    version: "2.0.0"\n\n  - entity: "http://example.org/ont#hasAddress"\n    replaced_by: "http://example.org/ont#locatedAt"\n    message: "Renamed for consistency with location vocabulary."\n\n  - entity: "http://example.org/ont#TemporaryClass"\n    # No replacement - just deprecated\n    message: "Experimental class removed. No replacement available."\n```\n\n**Deprecation Output**:\n\nWhen you deprecate an entity, the following triples are added:\n\n```turtle\nex:LegacyTerm\n    owl:deprecated true ;\n    dcterms:isReplacedBy ex:NewTerm ;\n    rdfs:comment "DEPRECATED (v2.0): Use NewTerm instead..."@en .\n```\n\n**Exit Codes**:\n- `0`: Success\n- `1`: Success with warnings (some entities not found)\n- `2`: Error (file not found, parse error, etc.)\n\n---\n\n### localise - Multi-Language Translation Management\n\nManage translations for multi-language ontology support.\n\n```bash\nrdf-construct localise <subcommand> [OPTIONS]\n```\n\n**Subcommands**:\n- `extract` - Extract translatable strings to YAML\n- `merge` - Merge translations back into ontology\n- `report` - Generate translation coverage report\n- `init` - Create empty translation file for new language\n- `config` - Generate default configuration\n\n---\n\n#### localise extract\n\nExtract translatable strings from an ontology to a YAML file.\n\n```bash\nrdf-construct localise extract SOURCE [OPTIONS]\n```\n\n**Arguments**:\n- `SOURCE`: RDF ontology file (.ttl, .rdf, .owl)\n\n**Options**:\n- `-l, --language CODE`: Target language code (required, e.g., de, fr, es)\n- `-o, --output PATH`: Output YAML file (default: {language}.yml)\n- `--source-language CODE`: Source language code (default: en)\n- `-p, --properties PROPS`: Comma-separated properties to extract (e.g., rdfs:label,rdfs:comment)\n- `--include-deprecated`: Include deprecated entities\n- `--missing-only`: Only extract strings missing in target language\n- `-c, --config PATH`: YAML configuration file\n\n**Examples**:\n\n```bash\n# Basic extraction for German\nrdf-construct localise extract ontology.ttl --language de -o translations/de.yml\n\n# Extract only labels\nrdf-construct localise extract ontology.ttl -l de -p rdfs:label,skos:prefLabel\n\n# Extract missing strings only (for updates)\nrdf-construct localise extract ontology.ttl -l de --missing-only -o de_update.yml\n\n# Include deprecated entities\nrdf-construct localise extract ontology.ttl -l fr --include-deprecated\n```\n\n---\n\n#### localise merge\n\nMerge translation files back into an ontology.\n\n```bash\nrdf-construct localise merge SOURCE TRANSLATIONS... [OPTIONS]\n```\n\n**Arguments**:\n- `SOURCE`: RDF ontology file\n- `TRANSLATIONS`: One or more translation YAML files\n\n**Options**:\n- `-o, --output PATH`: Output file for merged ontology (required)\n- `--status STATUS`: Minimum status to include (pending|needs_review|translated|approved, default: translated)\n- `--existing STRATEGY`: How to handle existing translations (preserve|overwrite, default: preserve)\n- `--dry-run`: Preview changes without writing files\n- `--no-colour`: Disable coloured output\n\n**Examples**:\n\n```bash\n# Merge single translation file\nrdf-construct localise merge ontology.ttl de.yml -o localised.ttl\n\n# Merge multiple languages\nrdf-construct localise merge ontology.ttl translations/*.yml -o multilingual.ttl\n\n# Merge only approved translations\nrdf-construct localise merge ontology.ttl de.yml --status approved -o localised.ttl\n\n# Overwrite existing translations\nrdf-construct localise merge ontology.ttl de.yml --existing overwrite -o updated.ttl\n\n# Preview changes\nrdf-construct localise merge ontology.ttl de.yml -o output.ttl --dry-run\n```\n\n---\n\n#### localise report\n\nGenerate translation coverage report.\n\n```bash\nrdf-construct localise report SOURCE [OPTIONS]\n```\n\n**Arguments**:\n- `SOURCE`: RDF ontology file\n\n**Options**:\n- `-l, --languages CODES`: Comma-separated language codes to check (required, e.g., en,de,fr)\n- `--source-language CODE`: Base language for translations (default: en)\n- `-p, --properties PROPS`: Comma-separated properties to check\n- `-o, --output PATH`: Output file for report\n- `-f, --format FORMAT`: Output format (text|markdown, default: text)\n- `-v, --verbose`: Show detailed missing translation list\n- `--no-colour`: Disable coloured output\n\n**Examples**:\n\n```bash\n# Basic coverage report\nrdf-construct localise report ontology.ttl --languages en,de,fr\n\n# Detailed report with missing entities\nrdf-construct localise report ontology.ttl -l en,de,fr --verbose\n\n# Markdown report to file\nrdf-construct localise report ontology.ttl -l en,de,fr -f markdown -o coverage.md\n\n# Check specific properties only\nrdf-construct localise report ontology.ttl -l en,de -p rdfs:label,skos:prefLabel\n```\n\n---\n\n#### localise init\n\nCreate empty translation file for a new language (equivalent to extract).\n\n```bash\nrdf-construct localise init SOURCE [OPTIONS]\n```\n\n**Arguments**:\n- `SOURCE`: RDF ontology file\n\n**Options**:\n- `-l, --language CODE`: Target language code (required)\n- `-o, --output PATH`: Output YAML file (default: {language}.yml)\n- `--source-language CODE`: Source language code (default: en)\n\n**Examples**:\n\n```bash\n# Initialise Japanese translation\nrdf-construct localise init ontology.ttl --language ja -o translations/ja.yml\n```\n\n---\n\n#### localise config\n\nGenerate or manage localise configuration.\n\n```bash\nrdf-construct localise config [OPTIONS]\n```\n\n**Options**:\n- `--init`: Generate a default localise configuration file\n\n**Examples**:\n\n```bash\n# Generate default config\nrdf-construct localise config --init\n```\n\n**Translation File Format**:\n\n```yaml\nmetadata:\n  source_file: ontology.ttl\n  source_language: en\n  target_language: de\n  generated: 2025-01-15T10:30:00\n  properties:\n    - rdfs:label\n    - rdfs:comment\n\nentities:\n  - uri: http://example.org/ont#Building\n    type: owl:Class\n    labels:\n      - property: rdfs:label\n        source: Building\n        translation: Gebäude\n        status: translated\n      - property: rdfs:comment\n        source: A permanent structure\n        translation: ""\n        status: pending\n\nsummary:\n  total_entities: 42\n  total_strings: 84\n  by_status:\n    pending: 40\n    translated: 44\n  coverage: "52.4%"\n```\n\n**Status Values**:\n- `pending`: Not yet translated (empty translation field)\n- `needs_review`: Translation uncertain, needs review\n- `translated`: Translation complete\n- `approved`: Translation reviewed and approved\n\n**Exit Codes**:\n- `0`: Success\n- `1`: Success with warnings\n- `2`: Error\n\n---\n\n### cq-test - Run Competency Question Tests\n\nValidate ontologies against SPARQL-based competency questions.\n\n```bash\nrdf-construct cq-test ONTOLOGY TEST_FILE [OPTIONS]\n```\n\n**Arguments**:\n- `ONTOLOGY`: RDF ontology file to test\n- `TEST_FILE`: YAML file containing competency question tests\n\n**Options**:\n- `-o, --output PATH`: Write output to file instead of stdout\n- `-f, --format FORMAT`: Output format: `text`, `json`, `junit` (default: text)\n- `-d, --data PATH`: Additional RDF data files (can specify multiple)\n- `-t, --tag TAG`: Run only tests with this tag (can specify multiple)\n- `-x, --exclude-tag TAG`: Skip tests with this tag (can specify multiple)\n- `--fail-fast`: Stop on first failure\n- `-v, --verbose`: Show query text and timing\n\n**Test File Format**:\n\n```yaml\nprefixes:\n  ex: http://example.org/\n\nquestions:\n  - name: "Animal hierarchy exists"\n    description: "Verify Animal is the root class"\n    query: |\n      ASK { ex:Animal a owl:Class }\n    expect: true\n    tags: [schema, required]\n\n  - name: "Dogs are mammals"\n    query: |\n      SELECT ?dog WHERE {\n        ?dog rdfs:subClassOf ex:Mammal\n      }\n    expect:\n      contains:\n        - dog: ex:Dog\n```\n\n**Examples**:\n\n```bash\n# Run all tests\nrdf-construct cq-test ontology.ttl tests.yml\n\n# Run tests with specific tag\nrdf-construct cq-test ontology.ttl tests.yml --tag schema\n\n# JUnit output for CI\nrdf-construct cq-test ontology.ttl tests.yml --format junit -o results.xml\n\n# Verbose output with timing\nrdf-construct cq-test ontology.ttl tests.yml --verbose\n\n# Stop on first failure\nrdf-construct cq-test ontology.ttl tests.yml --fail-fast\n\n# Include additional test data\nrdf-construct cq-test ontology.ttl tests.yml -d test-data.ttl\n```\n\n**Exit Codes**:\n- `0`: All tests passed\n- `1`: One or more tests failed\n- `2`: Error occurred (invalid file, parse error, etc.)\n\n---\n\n### stats - Compute Ontology Statistics\n\nCompute and display comprehensive metrics about RDF ontologies.\n\n```bash\nrdf-construct stats FILE [FILE...] [OPTIONS]\n```\n\n**Arguments**:\n- `FILE`: One or more RDF ontology files\n\n**Options**:\n- `-o, --output PATH`: Write output to file instead of stdout\n- `-f, --format FORMAT`: Output format: `text`, `json`, `markdown`, `md` (default: text)\n- `--compare`: Compare two ontology files (requires exactly 2 files)\n- `--include CATEGORIES`: Include only these metric categories (comma-separated)\n- `--exclude CATEGORIES`: Exclude these metric categories (comma-separated)\n\n**Metric Categories**:\n- `basic`: Counts (triples, classes, properties, individuals)\n- `hierarchy`: Structure (depth, branching, orphans)\n- `properties`: Coverage (domain, range, functional, symmetric)\n- `documentation`: Labels and comments coverage\n- `complexity`: Multiple inheritance, OWL axioms\n- `connectivity`: Most connected class, isolated classes\n\n**Examples**:\n\n```bash\n# Basic statistics\nrdf-construct stats ontology.ttl\n\n# JSON output for programmatic use\nrdf-construct stats ontology.ttl --format json -o stats.json\n\n# Markdown for documentation\nrdf-construct stats ontology.ttl --format markdown >> README.md\n\n# Compare two versions\nrdf-construct stats v1.ttl v2.ttl --compare\n\n# Only show specific categories\nrdf-construct stats ontology.ttl --include basic,documentation\n\n# Exclude some categories\nrdf-construct stats ontology.ttl --exclude connectivity,complexity\n```\n\n**Exit Codes**:\n- `0`: Success\n- `1`: Error occurred\n\n---\n\n## Configuration Files\n\n### UML Context Configuration\n\n**File**: `uml_contexts.yml`\n\n```yaml\ncontexts:\n  context_name:\n    description: "Human-readable description"\n\n    # Class selection (choose one)\n    root_classes:            # Start from roots, include descendants\n      - prefix:Class1\n      - prefix:Class2\n    # OR\n    focus_classes:           # Specific classes only\n      - prefix:Class1\n\n    include_descendants: true  # Include subclasses of selected classes\n    max_depth: 3              # Limit descendant depth (null = unlimited)\n\n    # Property handling\n    properties:\n      mode: domain_based     # domain_based | connected | explicit | all | none\n      include:               # Whitelist (optional)\n        - prefix:hasX\n      exclude:               # Blacklist (optional)\n        - prefix:internalProp\n\n    # Instance handling\n    instances:\n      include:\n        - prefix:Instance1\n      show_class_membership: true\n```\n\n### Style Configuration\n\n**File**: `uml_styles.yml`\n\n```yaml\nschemes:\n  scheme_name:\n    description: "Visual styling scheme"\n\n    # Namespace-based colours\n    namespace_colours:\n      "http://example.org/": "#E8F4FD"\n      "http://other.org/": "#FFF3E0"\n\n    # Type-based colours\n    type_colours:\n      owl:Class: "#E3F2FD"\n      rdfs:Class: "#E8F5E9"\n\n    # Arrows\n    arrows:\n      inheritance: "--|>"\n      object_property: "-->"\n      datatype_property: "..>"\n\n    # Stereotypes\n    show_stereotypes: true\n    stereotype_map:\n      owl:Class: "«class»"\n      prefix:MetaClass: "«meta»"\n```\n\n### Layout Configuration\n\n**File**: `uml_layouts.yml`\n\n```yaml\nlayouts:\n  layout_name:\n    description: "Layout arrangement description"\n    direction: top_to_bottom  # or left_to_right, etc.\n    arrow_direction: up       # or down, left, right\n    hide_empty_members: false\n    group_by_namespace: false\n    spacing:\n      classMarginTop: 10\n      classMarginBottom: 10\n```\n\n### Ordering Profile Configuration\n\n**File**: `order.yml`\n\n```yaml\n# Optional: control prefix ordering\nprefix_order:\n  - rdf\n  - rdfs\n  - owl\n\n# Define subject selectors\nselectors:\n  classes: "rdf:type owl:Class"\n  obj_props: "rdf:type owl:ObjectProperty"\n  data_props: "rdf:type owl:DatatypeProperty"\n\n# Define ordering profiles\nprofiles:\n  profile_name:\n    description: "Human-readable description"\n    sections:\n      - header: {}\n      - classes:\n          select: classes\n          sort: alpha  # or topological\n          roots: [prefix:RootClass, ...]\n      - object_properties:\n          select: obj_props\n          sort: topological\n```\n\n---\n\n## Exit Codes\n\n| Code | Meaning |\n|------|---------|\n| `0` | Success (or no differences/issues) |\n| `1` | General error (or differences/warnings/failures found) |\n| `2` | Command line usage error (or errors found for lint) |\n\n---\n\n## Files and Directories\n\n**Input Files**:\n- `.ttl` - RDF/Turtle ontology files\n- `.rdf`, `.owl` - RDF/XML ontology files\n- `.yml` - YAML configuration files\n- `.puml` - PlantUML diagram files\n\n**Output Files**:\n- `.puml` - PlantUML diagram files (from `uml` command)\n- `.ttl` - Ordered RDF/Turtle files (from `order` command), SHACL shapes (from `shacl-gen`)\n- `.rdf`, `.jsonld`, `.nt`, `.n3`, `.nq` - Converted RDF files (from `cast` command)\n- `.json` - Statistics output, lint results, diff results\n- `.md` - Markdown output (docs, stats)\n- `.html` - HTML documentation (from `docs` command)\n- `.xml` - JUnit XML (from `cq-test` command)\n\n**Default Output Directories**:\n- `diagrams/` - UML diagram output\n- `src/ontology/` - Ordered RDF output\n- `docs/` - Documentation output\n- _(source directory)_ - `cast` output files (default)\n\n---\n\n## Common Workflows\n\n### Exploring a New Ontology\n\n```bash\n# Quick orientation\nrdf-construct describe ontology.ttl\n\n# Brief overview for large files\nrdf-construct describe ontology.ttl --brief\n\n# Check profile compatibility\nrdf-construct describe ontology.ttl --format json | jq \'.profile.profile\'\n```\n\n### Diagram-First Ontology Design\n\n```bash\n# Design in PlantUML, generate RDF\nrdf-construct puml2rdf design.puml -o ontology.ttl -n http://example.org/ont#\n\n# Add manual annotations, then update from PlantUML\nrdf-construct puml2rdf design.puml --merge ontology.ttl -o ontology.ttl\n\n# Validate ontology quality\nrdf-construct lint ontology.ttl --level strict\n```\n\n### Complete Quality Pipeline\n\n```bash\n# Describe, lint, generate shapes, validate, test competency questions\nrdf-construct describe ontology.ttl --format json -o description.json\nrdf-construct lint ontology.ttl --format json -o lint.json\nrdf-construct shacl-gen ontology.ttl -o shapes.ttl --level strict\npyshacl -s shapes.ttl -d test-data.ttl\nrdf-construct cq-test ontology.ttl cq-tests.yml --format junit -o cq-results.xml\n```\n\n### Generate Complete Documentation\n\n```bash\n# HTML docs, UML diagrams, and SHACL shapes\nrdf-construct docs ontology.ttl -o docs/api/\nrdf-construct uml ontology.ttl -C contexts.yml -o docs/diagrams/\nrdf-construct shacl-gen ontology.ttl -o docs/shapes.ttl\n```\n\n### Build Distribution in Multiple Formats\n\n```bash\n# Export to all standard formats for maximum compatibility\nrdf-construct cast ontology.ttl --output-dir dist/\n\n# Pipe to another tool for inspection\nrdf-construct cast ontology.ttl --format nt | wc -l\n```\n\n### Compare Ontology Versions\n\n```bash\n# Generate ordered versions\nrdf-construct order v1.ttl order.yml -p canonical -o output/v1/\nrdf-construct order v2.ttl order.yml -p canonical -o output/v2/\n\n# Semantic diff\nrdf-construct diff output/v1/v1-canonical.ttl output/v2/v2-canonical.ttl\n\n# Or diff the originals directly\nrdf-construct diff v1.ttl v2.ttl --format markdown -o RELEASE_NOTES.md\n```\n\n### Track Ontology Metrics\n\n```bash\n# Generate stats for CI pipeline\nrdf-construct stats ontology.ttl --format json -o metrics.json\n\n# Compare versions before release\nrdf-construct stats v1.ttl v2.ttl --compare --format markdown >> CHANGELOG.md\n```\n\n### Test-Driven Ontology Development\n\n```bash\n# Write competency questions first\nrdf-construct cq-test ontology.ttl cq-tests.yml --tag required\n\n# Iterate until all pass\nrdf-construct cq-test ontology.ttl cq-tests.yml --verbose\n\n# Run full test suite in CI\nrdf-construct cq-test ontology.ttl cq-tests.yml --format junit -o results.xml\n```\n\n---\n\n## Tips\n\n### Check Configuration\n\nBefore generating, list available contexts/profiles:\n\n```bash\nrdf-construct contexts config.yml\nrdf-construct profiles order.yml\n```\n\n### Start Simple\n\nGenerate without styling first:\n\n```bash\nrdf-construct uml ontology.ttl -C config.yml -c simple_context\n```\n\nThen add styling once you\'re happy with the structure.\n\n### Use Descriptive Names\n\nIn YAML configs:\n- **Good**: `animal_taxonomy`, `management_structure`, `key_relationships`\n- **Bad**: `context1`, `test`, `temp`\n\n### Organise Output\n\nUse subdirectories for different versions or audiences:\n\n```bash\nrdf-construct uml ontology.ttl -C config.yml -o docs/diagrams/public/\nrdf-construct uml ontology.ttl -C config.yml -o docs/diagrams/internal/\n```\n\n---\n\n## Troubleshooting\n\n### "Command not found"\n\n**Problem**: `rdf-construct: command not found`\n\n**Solution**:\n\n```bash\n# If installed with Poetry\npoetry run rdf-construct --version\n\n# Or activate poetry shell\npoetry shell\nrdf-construct --version\n\n# If installed with pip, check PATH\npip show rdf-construct\n```\n\n### "Context/Profile not found"\n\n**Problem**: `Error: Context \'xyz\' not found`\n\n**Solution**: List available contexts/profiles:\n\n```bash\nrdf-construct contexts config.yml\nrdf-construct profiles order.yml\n```\n\n### "File not found"\n\n**Problem**: `Error: Path \'file.ttl\' does not exist`\n\n**Solution**: Check file path is correct:\n\n```bash\nls -la file.ttl\n# Use absolute path if needed\nrdf-construct uml /full/path/to/file.ttl -C config.yml\n```\n\n### Empty Output\n\n**Problem**: Generated file has no classes/properties.\n\n**Solutions**:\n1. Check CURIE format in config matches ontology prefixes\n2. Verify namespace prefixes match ontology\n3. Check class/property selection criteria\n\n**Debug**:\n\n```python\nfrom rdflib import Graph, RDF, OWL\ng = Graph().parse("ontology.ttl", format="turtle")\nprint(f"Classes: {len(list(g.subjects(RDF.type, OWL.Class)))}")\nfor pfx, ns in g.namespace_manager.namespaces():\n    if pfx: print(f"{pfx}: {ns}")\n```\n\n---\n\n## Getting Help\n\n```bash\nrdf-construct --help\nrdf-construct describe --help\nrdf-construct cast --help\nrdf-construct order --help\nrdf-construct uml --help\nrdf-construct docs --help\nrdf-construct puml2rdf --help\nrdf-construct shacl-gen --help\nrdf-construct diff --help\nrdf-construct lint --help\nrdf-construct cq-test --help\nrdf-construct stats --help\n```\n\n**Online Resources**:\n- Issues: https://github.com/aigora-de/rdf-construct/issues\n- Discussions: https://github.com/aigora-de/rdf-construct/discussions\n\n---\n\n## See Also\n\n- **[Getting Started](GETTING_STARTED.md)**: Quick start guide\n- **[Describe Guide](DESCRIBE_GUIDE.md)**: Ontology orientation\n- **[Docs Guide](DOCS_GUIDE.md)**: Documentation generation\n- **[UML Guide](UML_GUIDE.md)**: Complete UML features\n- **[PlantUML Import Guide](PUML2RDF_GUIDE.md)**: PlantUML to RDF conversion\n- **[Cast Guide](CAST_GUIDE.md)**: RDF format conversion and piping\n- **[SHACL Guide](SHACL_GUIDE.md)**: SHACL shape generation\n- **[Diff Guide](DIFF_GUIDE.md)**: Ontology comparison\n- **[Lint Guide](LINT_GUIDE.md)**: Ontology quality checking\n- **[Merge and Split Guide](MERGE_SPLIT_GUIDE.md)**: Combining and modularising ontologies\n- **[CQ Testing Guide](CQ_TEST_GUIDE.md)**: Competency question testing\n- **[Stats Guide](STATS_GUIDE.md)**: Ontology metrics and statistics\n
+# CLI Reference
+
+Complete command reference for rdf-construct.
+
+## Installation
+
+```bash
+# With pip (recommended)
+pip install rdf-construct
+
+# With Poetry (for development)
+git clone https://github.com/aigora-de/rdf-construct.git
+cd rdf-construct
+poetry install
+
+# From source
+git clone https://github.com/aigora-de/rdf-construct.git
+cd rdf-construct
+pip install -e .
+```
+
+> **Note**: If installed via Poetry, prefix commands with `poetry run` (e.g., `poetry run rdf-construct --help`). Once installed via pip, use `rdf-construct` directly.
+
+## Global Options
+
+```bash
+rdf-construct --version    # Show version
+rdf-construct --help       # Show help
+```
+
+## Commands
+
+### describe - Ontology Orientation
+
+Provide a quick orientation to an unfamiliar ontology file, showing metadata, metrics, profile, imports, and documentation coverage.
+
+```bash
+rdf-construct describe SOURCE [OPTIONS]
+```
+
+**Arguments**:
+- `SOURCE`: RDF ontology file to describe (.ttl, .rdf, .owl, etc.)
+
+**Options**:
+- `-o, --output PATH`: Write output to file instead of stdout
+- `-f, --format FORMAT`: Output format: `text` (default), `json`, `markdown`, `md`
+- `-b, --brief`: Quick overview (metadata + metrics + profile only)
+- `--no-resolve`: Skip import resolution (no network requests)
+- `--no-colour`: Disable ANSI colour codes
+
+**Output Sections**:
+
+| Section | Description |
+|---------|-------------|
+| Verdict | One-line summary: profile, scale, import status |
+| Metadata | Title, version, description, license, creators |
+| Metrics | Triples, classes, properties, individuals |
+| Profile | OWL expressiveness level (RDF, RDFS, OWL DL, OWL Full) |
+| Imports | owl:imports declarations and resolution status |
+| Namespaces | Local, standard, and external namespace usage |
+| Hierarchy | Root/leaf classes, depth, orphans, cycles |
+| Documentation | Label and comment coverage percentages |
+
+**Profile Detection**:
+
+| Profile | Description |
+|---------|-------------|
+| RDF | No schema vocabulary |
+| RDFS | Uses rdfs:Class, rdfs:subClassOf |
+| OWL 2 DL (simple) | Basic OWL constructs |
+| OWL 2 DL (expressive) | Complex restrictions, cardinality |
+| OWL 2 Full | Metaclasses, property punning |
+
+**Examples**:
+
+```bash
+# Describe an ontology file
+rdf-construct describe ontology.ttl
+
+# Quick overview (faster for large files)
+rdf-construct describe ontology.ttl --brief
+
+# Output as JSON for scripting
+rdf-construct describe ontology.ttl --format json -o description.json
+
+# Output as Markdown for documentation
+rdf-construct describe ontology.ttl --format markdown >> README.md
+
+# Skip import resolution (no network access)
+rdf-construct describe ontology.ttl --no-resolve
+
+# Disable coloured output
+rdf-construct describe ontology.ttl --no-colour
+```
+
+**Exit Codes**:
+- `0`: Success
+- `1`: Success with warnings (e.g., unresolvable imports)
+- `2`: Error (file not found, parse error)
+
+---
+
+### order - Reorder RDF Files
+
+Reorder RDF Turtle files according to semantic profiles.
+
+```bash
+rdf-construct order SOURCE CONFIG [OPTIONS]
+```
+
+**Arguments**:
+- `SOURCE`: Input RDF Turtle file (.ttl)
+- `CONFIG`: YAML configuration file defining ordering profiles
+
+**Options**:
+- `-p, --profile NAME`: Profile(s) to generate (can specify multiple, default: all)
+- `-o, --outdir PATH`: Output directory (default: `src/ontology`)
+
+**Examples**:
+
+```bash
+# Generate all profiles defined in config
+rdf-construct order ontology.ttl order.yml
+
+# Generate specific profiles only
+rdf-construct order ontology.ttl order.yml -p alpha -p logical_topo
+
+# Custom output directory
+rdf-construct order ontology.ttl order.yml -o output/
+```
+
+---
+
+### profiles - List Ordering Profiles
+
+List available profiles in a configuration file.
+
+```bash
+rdf-construct profiles CONFIG
+```
+
+**Arguments**:
+- `CONFIG`: YAML configuration file to inspect
+
+**Example**:
+
+```bash
+rdf-construct profiles order.yml
+```
+
+---
+
+### uml - Generate UML Diagrams
+
+Generate PlantUML class diagrams from RDF ontologies.
+
+```bash
+rdf-construct uml SOURCE [SOURCE...] -C CONFIG [OPTIONS]
+```
+
+**Arguments**:
+- `SOURCE`: One or more RDF files (.ttl, .rdf, .owl). First file is primary; additional files provide supporting definitions.
+- `-C, --config`: YAML configuration file defining contexts (required)
+
+**Options**:
+- `-c, --context NAME`: Generate specific context(s) (can specify multiple)
+- `-o, --outdir PATH`: Output directory (default: `diagrams`)
+- `--style-config PATH`: Path to style configuration YAML
+- `-s, --style NAME`: Style scheme name to use
+- `--layout-config PATH`: Path to layout configuration YAML
+- `-l, --layout NAME`: Layout name to use
+- `-r, --rendering-mode`: Rendering mode: `default` or `odm` (OMG ODM RDF Profile)
+
+**Examples**:
+
+```bash
+# Generate all contexts
+rdf-construct uml ontology.ttl -C config.yml
+
+# Specific context
+rdf-construct uml ontology.ttl -C config.yml -c animal_taxonomy
+
+# Multiple sources (primary + imports)
+rdf-construct uml domain.ttl imports/core.ttl -C config.yml
+
+# With styling and layout
+rdf-construct uml ontology.ttl -C config.yml \
+  --style-config styles.yml --style default \
+  --layout-config layouts.yml --layout hierarchy
+
+# ODM-compliant rendering
+rdf-construct uml ontology.ttl -C config.yml --rendering-mode odm
+```
+
+**Output**:
+- Creates `.puml` files in output directory
+- One file per context: `SOURCE-CONTEXT.puml`
+- Shows summary: number of classes, properties, instances
+
+---
+
+### contexts - List UML Contexts
+
+List available UML contexts in a configuration file.
+
+```bash
+rdf-construct contexts CONFIG
+```
+
+**Arguments**:
+- `CONFIG`: YAML configuration file to inspect
+
+**Example**:
+
+```bash
+rdf-construct contexts uml_contexts.yml
+```
+
+---
+
+### docs - Generate Documentation
+
+Generate HTML, Markdown, or JSON documentation from RDF ontologies.
+
+```bash
+rdf-construct docs SOURCE [OPTIONS]
+```
+
+**Arguments**:
+- `SOURCE`: Input RDF ontology file (.ttl, .rdf, .owl, etc.)
+
+**Options**:
+- `-o, --output PATH`: Output directory (default: `docs`)
+- `-f, --format FORMAT`: Output format: `html`, `markdown`, `md`, `json` (default: html)
+- `-C, --config PATH`: YAML configuration file
+- `-t, --template PATH`: Path to custom Jinja2 templates directory
+- `--title TEXT`: Documentation title (default: from ontology or filename)
+- `--single-page`: Generate single-page documentation
+- `--no-search`: Disable search index generation (HTML only)
+- `--no-instances`: Exclude instances from documentation
+- `--no-shapes`: Exclude SHACL shapes from documentation
+- `--no-skos`: Exclude SKOS concepts and concept schemes from documentation
+- `--include TYPES`: Include only these entity types (comma-separated: `classes`, `properties`, `object_properties`, `datatype_properties`, `annotation_properties`, `other_properties`, `instances`, `shapes`, `concepts`)
+- `--exclude TYPES`: Exclude these entity types (same names as `--include`)
+
+**Examples**:
+
+```bash
+# Generate HTML documentation
+rdf-construct docs ontology.ttl -o api-docs/
+
+# Generate Markdown for GitHub wiki
+rdf-construct docs ontology.ttl --format markdown -o wiki/
+
+# Generate JSON for custom rendering
+rdf-construct docs ontology.ttl --format json -o data/
+
+# Single-page HTML with custom title
+rdf-construct docs ontology.ttl --single-page --title "My Ontology"
+
+# Use custom templates
+rdf-construct docs ontology.ttl --template my-templates/ -o docs/
+```
+
+**Output**:
+- HTML: Complete website with navigation, search, and styling
+- Markdown: Individual `.md` files per class/property
+- JSON: Structured data for programmatic use
+
+---
+
+### cast - Convert Between RDF Formats
+
+Convert an RDF source file to one or more serialisation formats. Designed to be Unix pipe-friendly: a single `--format` writes RDF to stdout, keeping stderr for diagnostics.
+
+```bash
+rdf-construct cast SOURCE [OPTIONS]
+```
+
+**Arguments**:
+- `SOURCE`: Input RDF file (any format rdflib can parse)
+
+**Options**:
+- `-f, --format FORMAT`: Output format, repeatable. Omit for all standard formats except source. Single format writes to stdout (pipe mode).
+- `-o, --output-dir PATH`: Output directory for files (default: same directory as source)
+- `--allow-flatten`: Merge all named graphs into the default graph when converting from a quad format (TriG, N-Quads) to a single-graph format
+
+**Supported format aliases** (case-insensitive):
+
+| Canonical | Aliases | Extension | Quad? |
+|-----------|---------|-----------|-------|
+| `turtle` | `ttl`, `turtle` | `.ttl` | No |
+| `xml` | `xml`, `rdf`, `rdfxml` | `.rdf` | No |
+| `json-ld` | `json-ld`, `jsonld` | `.jsonld` | No |
+| `nt` | `nt`, `ntriples` | `.nt` | No |
+| `n3` | `n3` | `.n3` | No |
+| `trig` | `trig` | `.trig` | Yes |
+| `nquads` | `nq`, `nquads` | `.nq` | Yes |
+
+**Pipe mode** (single `--format`, no `--output-dir`):
+
+RDF is written to stdout; all diagnostic messages go to stderr. This makes the output safe to pipe directly to other tools:
+
+```bash
+rdf-construct cast ontology.ttl --format n3 | grep rdf:type
+rdf-construct cast ontology.rdf --format ttl > converted.ttl
+rdf-construct cast ontology.ttl --format json-ld | jq '.["@context"]'
+```
+
+**Default output set** (no `--format`):
+
+Converts to `turtle`, `xml`, and `json-ld`, excluding the source format. Writes one file per format to the output directory.
+
+**Quad format handling**:
+
+Converting a quad-format source (TriG, N-Quads) to a single-graph format is rejected by default with a clear error. Use `--allow-flatten` to merge all named graphs into the default graph:
+
+```bash
+rdf-construct cast dataset.trig --format ttl --allow-flatten
+```
+
+**Examples**:
+
+```bash
+# Pipe to grep (stdout is clean RDF)
+rdf-construct cast ontology.ttl --format n3 | grep rdf:type
+
+# Redirect to file
+rdf-construct cast ontology.rdf --format ttl > converted.ttl
+
+# Write multiple formats to files
+rdf-construct cast ontology.ttl --format xml --format json-ld
+
+# Default: write ttl + xml + json-ld (minus source) to source directory
+rdf-construct cast ontology.rdf
+
+# Custom output directory
+rdf-construct cast ontology.ttl --output-dir dist/
+
+# Flatten a multi-graph source
+rdf-construct cast dataset.trig --format turtle --allow-flatten
+
+# Pipe and validate
+rdf-construct cast ontology.rdf --format ttl | rdf-construct lint /dev/stdin
+```
+
+**Exit Codes**:
+- `0`: All conversions succeeded
+- `1`: Partial failure — some formats failed, at least one succeeded
+- `2`: Complete failure (parse error, or all formats failed)
+
+---
+
+### puml2rdf - Convert PlantUML to RDF
+
+Convert PlantUML class diagrams to RDF/OWL ontologies, enabling diagram-first ontology design.
+
+```bash
+rdf-construct puml2rdf SOURCE [OPTIONS]
+```
+
+**Arguments**:
+- `SOURCE`: PlantUML file (.puml or .plantuml)
+
+**Options**:
+- `-o, --output PATH`: Output file path (default: source name with .ttl extension)
+- `-f, --format FORMAT`: Output format: `turtle`, `ttl`, `xml`, `rdfxml`, `jsonld`, `json-ld`, `nt`, `ntriples` (default: turtle)
+- `-n, --namespace URI`: Default namespace URI for the ontology
+- `-C, --config PATH`: Path to YAML configuration file
+- `-m, --merge PATH`: Existing ontology file to merge with
+- `-v, --validate`: Validate only, don't generate output
+- `--strict`: Treat warnings as errors
+- `-l, --language TAG`: Language tag for labels/comments (default: en)
+- `--no-labels`: Don't auto-generate rdfs:label triples
+
+**Supported PlantUML Syntax**:
+- Classes: `class Building`, `class "Display Name" as pkg.Building`
+- Attributes: `floorArea : decimal`, `name : string`
+- Inheritance: `Building --|> Entity`, `Entity <|-- Building`
+- Associations: `Building --> Floor : hasFloor`
+- Packages: `package "http://example.org/building#" as bld { ... }`
+- Notes: `note right of Building : A physical structure`
+- Direction hints: `-u-|>`, `-d-|>`, `-l-|>`, `-r-|>` (up, down, left, right)
+
+**RDF Mapping**:
+
+| PlantUML | RDF |
+|----------|-----|
+| `class Building` | `Building rdf:type owl:Class` |
+| `floorArea : decimal` | `floorArea rdf:type owl:DatatypeProperty ; rdfs:range xsd:decimal` |
+| `Building --\|> Entity` | `Building rdfs:subClassOf Entity` |
+| `Building --> Floor : hasFloor` | `hasFloor rdf:type owl:ObjectProperty ; rdfs:domain Building ; rdfs:range Floor` |
+| Note attached to class | `rdfs:comment` |
+
+**Examples**:
+
+```bash
+# Basic conversion
+rdf-construct puml2rdf design.puml
+
+# Custom output and namespace
+rdf-construct puml2rdf design.puml -o ontology.ttl -n http://example.org/ont#
+
+# Validate without generating
+rdf-construct puml2rdf design.puml --validate
+
+# Merge with existing ontology (preserves manual annotations)
+rdf-construct puml2rdf design.puml --merge existing.ttl
+
+# Use configuration file for namespace mappings
+rdf-construct puml2rdf design.puml -C puml-config.yml
+
+# Strict mode for CI
+rdf-construct puml2rdf design.puml --validate --strict
+```
+
+**Exit Codes**:
+- `0`: Success
+- `1`: Validation warnings (with --strict)
+- `2`: Parse or validation errors
+
+---
+
+### shacl-gen - Generate SHACL Shapes
+
+Generate SHACL validation shapes from OWL ontology definitions.
+
+```bash
+rdf-construct shacl-gen SOURCE [OPTIONS]
+```
+
+**Arguments**:
+- `SOURCE`: Input RDF ontology file (.ttl, .rdf, .owl, etc.)
+
+**Options**:
+- `-o, --output PATH`: Output file path (default: `<source>-shapes.ttl`)
+- `-f, --format FORMAT`: Output format: `turtle`, `ttl`, `json-ld`, `jsonld` (default: turtle)
+- `-l, --level LEVEL`: Strictness level: `minimal`, `standard`, `strict` (default: standard)
+- `-C, --config PATH`: YAML configuration file
+- `--classes LIST`: Comma-separated list of classes to generate shapes for
+- `--closed`: Generate closed shapes (no extra properties allowed)
+- `--default-severity LEVEL`: Default severity: `violation`, `warning`, `info`
+- `--no-labels`: Don't include rdfs:label as sh:name
+- `--no-descriptions`: Don't include rdfs:comment as sh:description
+- `--no-inherit`: Don't inherit constraints from superclasses
+
+**Strictness Levels**:
+- `minimal`: Basic type constraints only (sh:class, sh:datatype)
+- `standard`: Adds cardinality and functional property constraints
+- `strict`: Maximum constraints including enumerations, closed shapes
+
+**Examples**:
+
+```bash
+# Basic generation
+rdf-construct shacl-gen ontology.ttl
+
+# Generate with strict constraints
+rdf-construct shacl-gen ontology.ttl --level strict --closed
+
+# Custom output path and format
+rdf-construct shacl-gen ontology.ttl -o shapes.ttl --format turtle
+
+# Focus on specific classes
+rdf-construct shacl-gen ontology.ttl --classes "ex:Building,ex:Floor"
+
+# Use configuration file
+rdf-construct shacl-gen ontology.ttl --config shacl-config.yml
+
+# Generate warnings instead of violations
+rdf-construct shacl-gen ontology.ttl --default-severity warning
+```
+
+**Output**:
+- Creates SHACL shapes file with NodeShapes for each class
+- Converts domain/range to sh:property constraints
+- Converts cardinality restrictions to sh:minCount/sh:maxCount
+- Converts functional properties to sh:maxCount 1
+
+---
+
+### diff - Compare RDF Files
+
+Compare two RDF files and show semantic differences.
+
+```bash
+rdf-construct diff OLD_FILE NEW_FILE [OPTIONS]
+```
+
+**Arguments**:
+- `OLD_FILE`: Original RDF file
+- `NEW_FILE`: Updated RDF file
+
+**Options**:
+- `-o, --output PATH`: Write output to file instead of stdout
+- `-f, --format FORMAT`: Output format: `text`, `markdown`, `md`, `json` (default: text)
+- `--show TYPES`: Show only these change types (comma-separated: added,removed,modified)
+- `--hide TYPES`: Hide these change types
+- `--entities TYPES`: Show only these entity types (comma-separated: classes,properties,instances)
+- `--ignore-predicates LIST`: Ignore these predicates in comparison (comma-separated CURIEs)
+
+**Examples**:
+
+```bash
+# Basic comparison
+rdf-construct diff v1.0.ttl v1.1.ttl
+
+# Generate markdown changelog
+rdf-construct diff v1.0.ttl v1.1.ttl --format markdown -o CHANGELOG.md
+
+# Show only added and removed (hide modified)
+rdf-construct diff old.ttl new.ttl --show added,removed
+
+# Focus on class changes only
+rdf-construct diff old.ttl new.ttl --entities classes
+
+# Ignore version predicates
+rdf-construct diff old.ttl new.ttl --ignore-predicates "owl:versionInfo,dct:modified"
+
+# JSON output for scripting
+rdf-construct diff old.ttl new.ttl --format json -o changes.json
+```
+
+**Exit Codes**:
+- `0`: Graphs are semantically identical
+- `1`: Differences were found
+- `2`: Error occurred
+
+---
+
+### lint - Check Ontology Quality
+
+Check RDF ontologies for structural issues, missing documentation, and best practice violations.
+
+```bash
+rdf-construct lint SOURCE [SOURCE...] [OPTIONS]
+```
+
+**Arguments**:
+- `SOURCE`: One or more RDF files to check
+
+**Options**:
+- `-l, --level LEVEL`: Strictness level: `strict`, `standard`, `relaxed` (default: standard)
+- `-f, --format FORMAT`: Output format: `text`, `json` (default: text)
+- `-c, --config PATH`: Path to `.rdf-lint.yml` configuration file
+- `-e, --enable RULE`: Enable specific rules (can use multiple times)
+- `-d, --disable RULE`: Disable specific rules (can use multiple times)
+- `--no-colour`: Disable coloured output
+- `--list-rules`: List available rules and exit
+- `--init`: Generate a default `.rdf-lint.yml` config file and exit
+
+**Available Rules**:
+
+| Rule | Category | Severity | Description |
+|------|----------|----------|-------------|
+| `orphan-class` | Structural | error | Class with no superclass or subclasses |
+| `dangling-reference` | Structural | error | Reference to undefined entity |
+| `circular-subclass` | Structural | error | Circular subclass hierarchy |
+| `property-no-type` | Structural | error | Property without type declaration |
+| `empty-ontology` | Structural | error | Ontology with no classes or properties |
+| `missing-label` | Documentation | warning | Entity without rdfs:label |
+| `missing-comment` | Documentation | warning | Entity without rdfs:comment |
+| `redundant-subclass` | Best Practice | info | Redundant subclass declaration |
+| `property-no-domain` | Best Practice | info | Property without rdfs:domain |
+| `property-no-range` | Best Practice | info | Property without rdfs:range |
+| `inconsistent-naming` | Best Practice | info | Inconsistent naming conventions |
+
+**Examples**:
+
+```bash
+# Run all lint rules
+rdf-construct lint ontology.ttl
+
+# Strict checking
+rdf-construct lint ontology.ttl --level strict
+
+# Check multiple files
+rdf-construct lint domain.ttl foundation.ttl
+
+# JSON output for CI
+rdf-construct lint ontology.ttl --format json -o lint-results.json
+
+# Enable only specific rules
+rdf-construct lint ontology.ttl -e missing-label -e missing-comment
+
+# Disable specific rules
+rdf-construct lint ontology.ttl -d orphan-class
+
+# List all available rules
+rdf-construct lint --list-rules
+
+# Generate default config file
+rdf-construct lint --init
+```
+
+**Exit Codes**:
+- `0`: No issues found
+- `1`: Warnings found (with standard/strict level)
+- `2`: Errors found
+
+---
+
+### merge - Combine RDF Ontologies
+
+Merge multiple RDF ontology files with intelligent conflict detection and resolution.
+
+```bash
+rdf-construct merge [SOURCES...] -o OUTPUT [OPTIONS]
+```
+
+**Arguments**:
+- `SOURCES`: One or more RDF files to merge (.ttl, .rdf, .owl)
+
+**Options**:
+- `-o, --output PATH`: Output file for merged ontology (required)
+- `-c, --config PATH`: YAML configuration file
+- `-p, --priority INT`: Priority for each source (can specify multiple, higher wins conflicts)
+- `--strategy STRATEGY`: Conflict resolution: `priority`, `first`, `last`, `mark_all` (default: priority)
+- `-r, --report PATH`: Write conflict report to file
+- `--report-format FORMAT`: Report format: `text`, `markdown`, `md` (default: markdown)
+- `--imports STRATEGY`: owl:imports handling: `preserve`, `remove`, `merge` (default: preserve)
+- `--migrate-data PATH`: Data file(s) to migrate (can specify multiple)
+- `--migration-rules PATH`: YAML file with migration rules
+- `--data-output PATH`: Output path for migrated data
+- `--dry-run`: Show what would happen without writing files
+- `--no-colour`: Disable coloured output
+- `--init`: Generate a default merge configuration file
+
+**Conflict Resolution Strategies**:
+
+| Strategy | Description |
+|----------|-------------|
+| `priority` | Higher priority source wins (default) |
+| `first` | First source encountered wins |
+| `last` | Last source encountered wins |
+| `mark_all` | Mark all conflicts for manual review |
+
+**Examples**:
+
+```bash
+# Basic merge of two ontologies
+rdf-construct merge core.ttl extension.ttl -o merged.ttl
+
+# With priorities (extension wins conflicts)
+rdf-construct merge core.ttl extension.ttl -o merged.ttl -p 1 -p 2
+
+# Mark all conflicts for manual review
+rdf-construct merge core.ttl extension.ttl -o merged.ttl --strategy mark_all
+
+# Generate conflict report
+rdf-construct merge core.ttl extension.ttl -o merged.ttl --report conflicts.md
+
+# Dry run (preview without writing)
+rdf-construct merge core.ttl extension.ttl -o merged.ttl --dry-run
+
+# With data migration
+rdf-construct merge core.ttl extension.ttl -o merged.ttl \
+    --migrate-data split_instances.ttl --data-output migrated.ttl
+
+# Using configuration file
+rdf-construct merge --config merge.yml -o merged.ttl
+
+# Generate default configuration
+rdf-construct merge --init
+```
+
+**Conflict Markers**:
+
+Unresolved conflicts are marked in the output file:
+
+```turtle
+# === CONFLICT: ex:Building rdfs:label ===
+# Source: core.ttl (priority 1): "Building"@en
+# Source: ext.ttl (priority 2): "Structure"@en
+# Resolution: UNRESOLVED - values differ, manual review required
+ex:Building a owl:Class ;
+    rdfs:label "Building"@en ;
+    rdfs:label "Structure"@en .
+# === END CONFLICT ===
+```
+
+Find conflicts with: `grep -n "=== CONFLICT ===" merged.ttl`
+
+**Configuration File Format**:
+
+```yaml
+sources:
+  - path: core.ttl
+    priority: 1
+  - path: extension.ttl
+    priority: 2
+    namespace_remap:
+      "http://old.org/": "http://new.org/"
+
+output:
+  path: merged.ttl
+  format: turtle
+
+conflicts:
+  strategy: priority
+  report: conflicts.md
+
+imports: preserve
+
+migrate_data:
+  sources:
+    - split_instances.ttl
+  output: migrated.ttl
+  rules:
+    - type: rename
+      from: "http://old.org/Class"
+      to: "http://new.org/Class"
+```
+
+**Exit Codes**:
+- `0`: Merge successful, no unresolved conflicts
+- `1`: Merge successful, but unresolved conflicts marked in output
+- `2`: Error (file not found, parse error, etc.)
+
+---
+
+### split - Modularise Ontologies
+
+Split a monolithic ontology into multiple modules.
+
+```bash
+rdf-construct split SOURCE [OPTIONS]
+```
+
+**Arguments**:
+- `SOURCE`: RDF ontology file to split (.ttl, .rdf, .owl)
+
+**Options**:
+- `-o, --output PATH`: Output directory for modules (default: `modules/`)
+- `-c, --config PATH`: YAML configuration file
+- `--by-namespace`: Auto-detect modules from namespaces
+- `--migrate-data PATH`: Data file(s) to split by instance type (can specify multiple)
+- `--data-output PATH`: Output directory for split data files
+- `--unmatched STRATEGY`: Strategy for unmatched entities: `common` or `error` (default: common)
+- `--common-name NAME`: Name for common module (default: `common`)
+- `--no-manifest`: Don't generate manifest.yml
+- `--dry-run`: Show what would happen without writing files
+- `--no-colour`: Disable coloured output
+- `--init`: Generate a default split configuration file
+
+**Examples**:
+
+```bash
+# Split by namespace (auto-detect modules)
+rdf-construct split large.ttl -o modules/ --by-namespace
+
+# Split using configuration file
+rdf-construct split large.ttl -o modules/ -c split.yml
+
+# With data migration
+rdf-construct split large.ttl -o modules/ -c split.yml \
+    --migrate-data instances.ttl --data-output data/
+
+# Dry run (preview without writing)
+rdf-construct split large.ttl -o modules/ --by-namespace --dry-run
+
+# Generate default configuration
+rdf-construct split --init
+```
+
+**Configuration File Format**:
+
+```yaml
+split:
+  source: ontology/monolith.ttl
+  output_dir: modules/
+
+  modules:
+    # By explicit class/property list
+    - name: core
+      description: "Core concepts"
+      output: core.ttl
+      include:
+        classes:
+          - ex:Entity
+          - ex:Event
+        properties:
+          - ex:identifier
+      include_descendants: true
+
+    # By namespace
+    - name: organisation
+      output: organisation.ttl
+      namespaces:
+        - "http://example.org/ontology/org#"
+      auto_imports: true
+
+  unmatched:
+    strategy: common
+    module: common
+    output: common.ttl
+
+  generate_manifest: true
+```
+
+**Manifest Output** (`manifest.yml`):
+
+```yaml
+source: ontology/monolith.ttl
+output_dir: modules/
+modules:
+  - name: core
+    file: core.ttl
+    classes: 5
+    properties: 3
+    triples: 42
+    imports: []
+    dependencies: []
+  - name: organisation
+    file: organisation.ttl
+    classes: 8
+    properties: 5
+    triples: 67
+    imports: [core.ttl]
+    dependencies: [core]
+summary:
+  total_modules: 2
+  total_triples: 109
+  unmatched_entities: 0
+```
+
+**Exit Codes**:
+- `0`: Split successful
+- `1`: Split successful, unmatched entities placed in common module
+- `2`: Error (file not found, config invalid, etc.)
+
+---
+
+### refactor - Rename and Deprecate Entities
+
+Refactor ontologies by renaming URIs or marking entities as deprecated.
+
+```bash
+rdf-construct refactor <subcommand> [OPTIONS]
+```
+
+**Subcommands**:
+- `rename` - Rename URIs (single entity or bulk namespace)
+- `deprecate` - Mark entities as deprecated with OWL annotations
+
+---
+
+#### refactor rename
+
+Rename URIs in ontology files.
+
+```bash
+rdf-construct refactor rename SOURCES [OPTIONS]
+```
+
+**Arguments**:
+- `SOURCES`: One or more RDF files to process (.ttl, .rdf, .owl)
+
+**Options**:
+- `--from URI`: Single URI to rename
+- `--to URI`: New URI for single rename
+- `--from-namespace NS`: Old namespace prefix for bulk rename
+- `--to-namespace NS`: New namespace prefix for bulk rename
+- `-c, --config PATH`: YAML configuration file with rename mappings
+- `-o, --output PATH`: Output file (single source) or directory (multiple sources)
+- `--migrate-data PATH`: Data file(s) to migrate (can specify multiple)
+- `--data-output PATH`: Output path for migrated data
+- `--dry-run`: Preview changes without writing files
+- `--no-colour`: Disable coloured output
+- `--init`: Generate a template rename configuration file
+
+**Examples**:
+
+```bash
+# Fix a single typo
+rdf-construct refactor rename ontology.ttl \
+    --from "http://example.org/ont#Buiding" \
+    --to "http://example.org/ont#Building" \
+    -o fixed.ttl
+
+# Bulk namespace change
+rdf-construct refactor rename ontology.ttl \
+    --from-namespace "http://old.example.org/" \
+    --to-namespace "http://new.example.org/" \
+    -o migrated.ttl
+
+# With data migration
+rdf-construct refactor rename ontology.ttl \
+    --from "ex:OldClass" --to "ex:NewClass" \
+    --migrate-data instances.ttl \
+    --data-output updated-instances.ttl
+
+# From configuration file
+rdf-construct refactor rename --config renames.yml
+
+# Preview changes (dry run)
+rdf-construct refactor rename ontology.ttl \
+    --from "ex:Old" --to "ex:New" --dry-run
+
+# Process multiple files
+rdf-construct refactor rename modules/*.ttl \
+    --from-namespace "http://old/" --to-namespace "http://new/" \
+    -o migrated/
+
+# Generate template config
+rdf-construct refactor rename --init
+```
+
+**Configuration File Format**:
+
+```yaml
+source_files:
+  - ontology.ttl
+
+output: renamed.ttl
+
+rename:
+  # Namespace mappings (applied first)
+  namespaces:
+    "http://old.example.org/v1#": "http://example.org/v2#"
+
+  # Individual entity renames (applied after namespace)
+  entities:
+    "http://example.org/v2#Buiding": "http://example.org/v2#Building"
+    "http://example.org/v2#hasAddres": "http://example.org/v2#hasAddress"
+
+# Optional data migration
+migrate_data:
+  sources:
+    - data/*.ttl
+  output_dir: data/migrated/
+```
+
+---
+
+#### refactor deprecate
+
+Mark ontology entities as deprecated with OWL annotations.
+
+```bash
+rdf-construct refactor deprecate SOURCES [OPTIONS]
+```
+
+**Arguments**:
+- `SOURCES`: One or more RDF files to process (.ttl, .rdf, .owl)
+
+**Options**:
+- `--entity URI`: URI of entity to deprecate
+- `--replaced-by URI`: URI of replacement entity (adds dcterms:isReplacedBy)
+- `-m, --message TEXT`: Deprecation message (added to rdfs:comment)
+- `--version VERSION`: Version when deprecated (included in message)
+- `-c, --config PATH`: YAML configuration file with deprecation specs
+- `-o, --output PATH`: Output file
+- `--dry-run`: Preview changes without writing files
+- `--no-colour`: Disable coloured output
+- `--init`: Generate a template deprecation configuration file
+
+**Examples**:
+
+```bash
+# Deprecate with replacement
+rdf-construct refactor deprecate ontology.ttl \
+    --entity "http://example.org/ont#LegacyTerm" \
+    --replaced-by "http://example.org/ont#NewTerm" \
+    --message "Use NewTerm instead. Will be removed in v3.0." \
+    -o updated.ttl
+
+# Deprecate without replacement
+rdf-construct refactor deprecate ontology.ttl \
+    --entity "ex:ObsoleteThing" \
+    --message "No longer needed." \
+    -o updated.ttl
+
+# Bulk deprecation from config
+rdf-construct refactor deprecate ontology.ttl \
+    -c deprecations.yml \
+    -o updated.ttl
+
+# Preview changes (dry run)
+rdf-construct refactor deprecate ontology.ttl \
+    --entity "ex:Legacy" --replaced-by "ex:Modern" --dry-run
+
+# Generate template config
+rdf-construct refactor deprecate --init
+```
+
+**Configuration File Format**:
+
+```yaml
+source_files:
+  - ontology.ttl
+
+output: deprecated.ttl
+
+deprecations:
+  - entity: "http://example.org/ont#LegacyPerson"
+    replaced_by: "http://example.org/ont#Agent"
+    message: "Deprecated in v2.0. Use Agent for both people and organisations."
+    version: "2.0.0"
+
+  - entity: "http://example.org/ont#hasAddress"
+    replaced_by: "http://example.org/ont#locatedAt"
+    message: "Renamed for consistency with location vocabulary."
+
+  - entity: "http://example.org/ont#TemporaryClass"
+    # No replacement - just deprecated
+    message: "Experimental class removed. No replacement available."
+```
+
+**Deprecation Output**:
+
+When you deprecate an entity, the following triples are added:
+
+```turtle
+ex:LegacyTerm
+    owl:deprecated true ;
+    dcterms:isReplacedBy ex:NewTerm ;
+    rdfs:comment "DEPRECATED (v2.0): Use NewTerm instead..."@en .
+```
+
+**Exit Codes**:
+- `0`: Success
+- `1`: Success with warnings (some entities not found)
+- `2`: Error (file not found, parse error, etc.)
+
+---
+
+### localise - Multi-Language Translation Management
+
+Manage translations for multi-language ontology support.
+
+```bash
+rdf-construct localise <subcommand> [OPTIONS]
+```
+
+**Subcommands**:
+- `extract` - Extract translatable strings to YAML
+- `merge` - Merge translations back into ontology
+- `report` - Generate translation coverage report
+- `init` - Create empty translation file for new language
+- `config` - Generate default configuration
+
+---
+
+#### localise extract
+
+Extract translatable strings from an ontology to a YAML file.
+
+```bash
+rdf-construct localise extract SOURCE [OPTIONS]
+```
+
+**Arguments**:
+- `SOURCE`: RDF ontology file (.ttl, .rdf, .owl)
+
+**Options**:
+- `-l, --language CODE`: Target language code (required, e.g., de, fr, es)
+- `-o, --output PATH`: Output YAML file (default: {language}.yml)
+- `--source-language CODE`: Source language code (default: en)
+- `-p, --properties PROPS`: Comma-separated properties to extract (e.g., rdfs:label,rdfs:comment)
+- `--include-deprecated`: Include deprecated entities
+- `--missing-only`: Only extract strings missing in target language
+- `-c, --config PATH`: YAML configuration file
+
+**Examples**:
+
+```bash
+# Basic extraction for German
+rdf-construct localise extract ontology.ttl --language de -o translations/de.yml
+
+# Extract only labels
+rdf-construct localise extract ontology.ttl -l de -p rdfs:label,skos:prefLabel
+
+# Extract missing strings only (for updates)
+rdf-construct localise extract ontology.ttl -l de --missing-only -o de_update.yml
+
+# Include deprecated entities
+rdf-construct localise extract ontology.ttl -l fr --include-deprecated
+```
+
+---
+
+#### localise merge
+
+Merge translation files back into an ontology.
+
+```bash
+rdf-construct localise merge SOURCE TRANSLATIONS... [OPTIONS]
+```
+
+**Arguments**:
+- `SOURCE`: RDF ontology file
+- `TRANSLATIONS`: One or more translation YAML files
+
+**Options**:
+- `-o, --output PATH`: Output file for merged ontology (required)
+- `--status STATUS`: Minimum status to include (pending|needs_review|translated|approved, default: translated)
+- `--existing STRATEGY`: How to handle existing translations (preserve|overwrite, default: preserve)
+- `--dry-run`: Preview changes without writing files
+- `--no-colour`: Disable coloured output
+
+**Examples**:
+
+```bash
+# Merge single translation file
+rdf-construct localise merge ontology.ttl de.yml -o localised.ttl
+
+# Merge multiple languages
+rdf-construct localise merge ontology.ttl translations/*.yml -o multilingual.ttl
+
+# Merge only approved translations
+rdf-construct localise merge ontology.ttl de.yml --status approved -o localised.ttl
+
+# Overwrite existing translations
+rdf-construct localise merge ontology.ttl de.yml --existing overwrite -o updated.ttl
+
+# Preview changes
+rdf-construct localise merge ontology.ttl de.yml -o output.ttl --dry-run
+```
+
+---
+
+#### localise report
+
+Generate translation coverage report.
+
+```bash
+rdf-construct localise report SOURCE [OPTIONS]
+```
+
+**Arguments**:
+- `SOURCE`: RDF ontology file
+
+**Options**:
+- `-l, --languages CODES`: Comma-separated language codes to check (required, e.g., en,de,fr)
+- `--source-language CODE`: Base language for translations (default: en)
+- `-p, --properties PROPS`: Comma-separated properties to check
+- `-o, --output PATH`: Output file for report
+- `-f, --format FORMAT`: Output format (text|markdown, default: text)
+- `-v, --verbose`: Show detailed missing translation list
+- `--no-colour`: Disable coloured output
+
+**Examples**:
+
+```bash
+# Basic coverage report
+rdf-construct localise report ontology.ttl --languages en,de,fr
+
+# Detailed report with missing entities
+rdf-construct localise report ontology.ttl -l en,de,fr --verbose
+
+# Markdown report to file
+rdf-construct localise report ontology.ttl -l en,de,fr -f markdown -o coverage.md
+
+# Check specific properties only
+rdf-construct localise report ontology.ttl -l en,de -p rdfs:label,skos:prefLabel
+```
+
+---
+
+#### localise init
+
+Create empty translation file for a new language (equivalent to extract).
+
+```bash
+rdf-construct localise init SOURCE [OPTIONS]
+```
+
+**Arguments**:
+- `SOURCE`: RDF ontology file
+
+**Options**:
+- `-l, --language CODE`: Target language code (required)
+- `-o, --output PATH`: Output YAML file (default: {language}.yml)
+- `--source-language CODE`: Source language code (default: en)
+
+**Examples**:
+
+```bash
+# Initialise Japanese translation
+rdf-construct localise init ontology.ttl --language ja -o translations/ja.yml
+```
+
+---
+
+#### localise config
+
+Generate or manage localise configuration.
+
+```bash
+rdf-construct localise config [OPTIONS]
+```
+
+**Options**:
+- `--init`: Generate a default localise configuration file
+
+**Examples**:
+
+```bash
+# Generate default config
+rdf-construct localise config --init
+```
+
+**Translation File Format**:
+
+```yaml
+metadata:
+  source_file: ontology.ttl
+  source_language: en
+  target_language: de
+  generated: 2025-01-15T10:30:00
+  properties:
+    - rdfs:label
+    - rdfs:comment
+
+entities:
+  - uri: http://example.org/ont#Building
+    type: owl:Class
+    labels:
+      - property: rdfs:label
+        source: Building
+        translation: Gebäude
+        status: translated
+      - property: rdfs:comment
+        source: A permanent structure
+        translation: ""
+        status: pending
+
+summary:
+  total_entities: 42
+  total_strings: 84
+  by_status:
+    pending: 40
+    translated: 44
+  coverage: "52.4%"
+```
+
+**Status Values**:
+- `pending`: Not yet translated (empty translation field)
+- `needs_review`: Translation uncertain, needs review
+- `translated`: Translation complete
+- `approved`: Translation reviewed and approved
+
+**Exit Codes**:
+- `0`: Success
+- `1`: Success with warnings
+- `2`: Error
+
+---
+
+### cq-test - Run Competency Question Tests
+
+Validate ontologies against SPARQL-based competency questions.
+
+```bash
+rdf-construct cq-test ONTOLOGY TEST_FILE [OPTIONS]
+```
+
+**Arguments**:
+- `ONTOLOGY`: RDF ontology file to test
+- `TEST_FILE`: YAML file containing competency question tests
+
+**Options**:
+- `-o, --output PATH`: Write output to file instead of stdout
+- `-f, --format FORMAT`: Output format: `text`, `json`, `junit` (default: text)
+- `-d, --data PATH`: Additional RDF data files (can specify multiple)
+- `-t, --tag TAG`: Run only tests with this tag (can specify multiple)
+- `-x, --exclude-tag TAG`: Skip tests with this tag (can specify multiple)
+- `--fail-fast`: Stop on first failure
+- `-v, --verbose`: Show query text and timing
+
+**Test File Format**:
+
+```yaml
+prefixes:
+  ex: http://example.org/
+
+questions:
+  - name: "Animal hierarchy exists"
+    description: "Verify Animal is the root class"
+    query: |
+      ASK { ex:Animal a owl:Class }
+    expect: true
+    tags: [schema, required]
+
+  - name: "Dogs are mammals"
+    query: |
+      SELECT ?dog WHERE {
+        ?dog rdfs:subClassOf ex:Mammal
+      }
+    expect:
+      contains:
+        - dog: ex:Dog
+```
+
+**Examples**:
+
+```bash
+# Run all tests
+rdf-construct cq-test ontology.ttl tests.yml
+
+# Run tests with specific tag
+rdf-construct cq-test ontology.ttl tests.yml --tag schema
+
+# JUnit output for CI
+rdf-construct cq-test ontology.ttl tests.yml --format junit -o results.xml
+
+# Verbose output with timing
+rdf-construct cq-test ontology.ttl tests.yml --verbose
+
+# Stop on first failure
+rdf-construct cq-test ontology.ttl tests.yml --fail-fast
+
+# Include additional test data
+rdf-construct cq-test ontology.ttl tests.yml -d test-data.ttl
+```
+
+**Exit Codes**:
+- `0`: All tests passed
+- `1`: One or more tests failed
+- `2`: Error occurred (invalid file, parse error, etc.)
+
+---
+
+### stats - Compute Ontology Statistics
+
+Compute and display comprehensive metrics about RDF ontologies.
+
+```bash
+rdf-construct stats FILE [FILE...] [OPTIONS]
+```
+
+**Arguments**:
+- `FILE`: One or more RDF ontology files
+
+**Options**:
+- `-o, --output PATH`: Write output to file instead of stdout
+- `-f, --format FORMAT`: Output format: `text`, `json`, `markdown`, `md` (default: text)
+- `--compare`: Compare two ontology files (requires exactly 2 files)
+- `--include CATEGORIES`: Include only these metric categories (comma-separated)
+- `--exclude CATEGORIES`: Exclude these metric categories (comma-separated)
+
+**Metric Categories**:
+- `basic`: Counts (triples, classes, properties, individuals)
+- `hierarchy`: Structure (depth, branching, orphans)
+- `properties`: Coverage (domain, range, functional, symmetric)
+- `documentation`: Labels and comments coverage
+- `complexity`: Multiple inheritance, OWL axioms
+- `connectivity`: Most connected class, isolated classes
+
+**Examples**:
+
+```bash
+# Basic statistics
+rdf-construct stats ontology.ttl
+
+# JSON output for programmatic use
+rdf-construct stats ontology.ttl --format json -o stats.json
+
+# Markdown for documentation
+rdf-construct stats ontology.ttl --format markdown >> README.md
+
+# Compare two versions
+rdf-construct stats v1.ttl v2.ttl --compare
+
+# Only show specific categories
+rdf-construct stats ontology.ttl --include basic,documentation
+
+# Exclude some categories
+rdf-construct stats ontology.ttl --exclude connectivity,complexity
+```
+
+**Exit Codes**:
+- `0`: Success
+- `1`: Error occurred
+
+---
+
+## Configuration Files
+
+### UML Context Configuration
+
+**File**: `uml_contexts.yml`
+
+```yaml
+contexts:
+  context_name:
+    description: "Human-readable description"
+
+    # Class selection (choose one)
+    root_classes:            # Start from roots, include descendants
+      - prefix:Class1
+      - prefix:Class2
+    # OR
+    focus_classes:           # Specific classes only
+      - prefix:Class1
+
+    include_descendants: true  # Include subclasses of selected classes
+    max_depth: 3              # Limit descendant depth (null = unlimited)
+
+    # Property handling
+    properties:
+      mode: domain_based     # domain_based | connected | explicit | all | none
+      include:               # Whitelist (optional)
+        - prefix:hasX
+      exclude:               # Blacklist (optional)
+        - prefix:internalProp
+
+    # Instance handling
+    instances:
+      include:
+        - prefix:Instance1
+      show_class_membership: true
+```
+
+### Style Configuration
+
+**File**: `uml_styles.yml`
+
+```yaml
+schemes:
+  scheme_name:
+    description: "Visual styling scheme"
+
+    # Namespace-based colours
+    namespace_colours:
+      "http://example.org/": "#E8F4FD"
+      "http://other.org/": "#FFF3E0"
+
+    # Type-based colours
+    type_colours:
+      owl:Class: "#E3F2FD"
+      rdfs:Class: "#E8F5E9"
+
+    # Arrows
+    arrows:
+      inheritance: "--|>"
+      object_property: "-->"
+      datatype_property: "..>"
+
+    # Stereotypes
+    show_stereotypes: true
+    stereotype_map:
+      owl:Class: "«class»"
+      prefix:MetaClass: "«meta»"
+```
+
+### Layout Configuration
+
+**File**: `uml_layouts.yml`
+
+```yaml
+layouts:
+  layout_name:
+    description: "Layout arrangement description"
+    direction: top_to_bottom  # or left_to_right, etc.
+    arrow_direction: up       # or down, left, right
+    hide_empty_members: false
+    group_by_namespace: false
+    spacing:
+      classMarginTop: 10
+      classMarginBottom: 10
+```
+
+### Ordering Profile Configuration
+
+**File**: `order.yml`
+
+```yaml
+# Optional: control prefix ordering
+prefix_order:
+  - rdf
+  - rdfs
+  - owl
+
+# Define subject selectors
+selectors:
+  classes: "rdf:type owl:Class"
+  obj_props: "rdf:type owl:ObjectProperty"
+  data_props: "rdf:type owl:DatatypeProperty"
+
+# Define ordering profiles
+profiles:
+  profile_name:
+    description: "Human-readable description"
+    sections:
+      - header: {}
+      - classes:
+          select: classes
+          sort: alpha  # or topological
+          roots: [prefix:RootClass, ...]
+      - object_properties:
+          select: obj_props
+          sort: topological
+```
+
+---
+
+## Exit Codes
+
+| Code | Meaning |
+|------|---------|
+| `0` | Success (or no differences/issues) |
+| `1` | General error (or differences/warnings/failures found) |
+| `2` | Command line usage error (or errors found for lint) |
+
+---
+
+## Files and Directories
+
+**Input Files**:
+- `.ttl` - RDF/Turtle ontology files
+- `.rdf`, `.owl` - RDF/XML ontology files
+- `.yml` - YAML configuration files
+- `.puml` - PlantUML diagram files
+
+**Output Files**:
+- `.puml` - PlantUML diagram files (from `uml` command)
+- `.ttl` - Ordered RDF/Turtle files (from `order` command), SHACL shapes (from `shacl-gen`)
+- `.rdf`, `.jsonld`, `.nt`, `.n3`, `.nq` - Converted RDF files (from `cast` command)
+- `.json` - Statistics output, lint results, diff results
+- `.md` - Markdown output (docs, stats)
+- `.html` - HTML documentation (from `docs` command)
+- `.xml` - JUnit XML (from `cq-test` command)
+
+**Default Output Directories**:
+- `diagrams/` - UML diagram output
+- `src/ontology/` - Ordered RDF output
+- `docs/` - Documentation output
+- _(source directory)_ - `cast` output files (default)
+
+---
+
+## Common Workflows
+
+### Exploring a New Ontology
+
+```bash
+# Quick orientation
+rdf-construct describe ontology.ttl
+
+# Brief overview for large files
+rdf-construct describe ontology.ttl --brief
+
+# Check profile compatibility
+rdf-construct describe ontology.ttl --format json | jq '.profile.profile'
+```
+
+### Diagram-First Ontology Design
+
+```bash
+# Design in PlantUML, generate RDF
+rdf-construct puml2rdf design.puml -o ontology.ttl -n http://example.org/ont#
+
+# Add manual annotations, then update from PlantUML
+rdf-construct puml2rdf design.puml --merge ontology.ttl -o ontology.ttl
+
+# Validate ontology quality
+rdf-construct lint ontology.ttl --level strict
+```
+
+### Complete Quality Pipeline
+
+```bash
+# Describe, lint, generate shapes, validate, test competency questions
+rdf-construct describe ontology.ttl --format json -o description.json
+rdf-construct lint ontology.ttl --format json -o lint.json
+rdf-construct shacl-gen ontology.ttl -o shapes.ttl --level strict
+pyshacl -s shapes.ttl -d test-data.ttl
+rdf-construct cq-test ontology.ttl cq-tests.yml --format junit -o cq-results.xml
+```
+
+### Generate Complete Documentation
+
+```bash
+# HTML docs, UML diagrams, and SHACL shapes
+rdf-construct docs ontology.ttl -o docs/api/
+rdf-construct uml ontology.ttl -C contexts.yml -o docs/diagrams/
+rdf-construct shacl-gen ontology.ttl -o docs/shapes.ttl
+```
+
+### Build Distribution in Multiple Formats
+
+```bash
+# Export to all standard formats for maximum compatibility
+rdf-construct cast ontology.ttl --output-dir dist/
+
+# Pipe to another tool for inspection
+rdf-construct cast ontology.ttl --format nt | wc -l
+```
+
+### Compare Ontology Versions
+
+```bash
+# Generate ordered versions
+rdf-construct order v1.ttl order.yml -p canonical -o output/v1/
+rdf-construct order v2.ttl order.yml -p canonical -o output/v2/
+
+# Semantic diff
+rdf-construct diff output/v1/v1-canonical.ttl output/v2/v2-canonical.ttl
+
+# Or diff the originals directly
+rdf-construct diff v1.ttl v2.ttl --format markdown -o RELEASE_NOTES.md
+```
+
+### Track Ontology Metrics
+
+```bash
+# Generate stats for CI pipeline
+rdf-construct stats ontology.ttl --format json -o metrics.json
+
+# Compare versions before release
+rdf-construct stats v1.ttl v2.ttl --compare --format markdown >> CHANGELOG.md
+```
+
+### Test-Driven Ontology Development
+
+```bash
+# Write competency questions first
+rdf-construct cq-test ontology.ttl cq-tests.yml --tag required
+
+# Iterate until all pass
+rdf-construct cq-test ontology.ttl cq-tests.yml --verbose
+
+# Run full test suite in CI
+rdf-construct cq-test ontology.ttl cq-tests.yml --format junit -o results.xml
+```
+
+---
+
+## Tips
+
+### Check Configuration
+
+Before generating, list available contexts/profiles:
+
+```bash
+rdf-construct contexts config.yml
+rdf-construct profiles order.yml
+```
+
+### Start Simple
+
+Generate without styling first:
+
+```bash
+rdf-construct uml ontology.ttl -C config.yml -c simple_context
+```
+
+Then add styling once you're happy with the structure.
+
+### Use Descriptive Names
+
+In YAML configs:
+- **Good**: `animal_taxonomy`, `management_structure`, `key_relationships`
+- **Bad**: `context1`, `test`, `temp`
+
+### Organise Output
+
+Use subdirectories for different versions or audiences:
+
+```bash
+rdf-construct uml ontology.ttl -C config.yml -o docs/diagrams/public/
+rdf-construct uml ontology.ttl -C config.yml -o docs/diagrams/internal/
+```
+
+---
+
+## Troubleshooting
+
+### "Command not found"
+
+**Problem**: `rdf-construct: command not found`
+
+**Solution**:
+
+```bash
+# If installed with Poetry
+poetry run rdf-construct --version
+
+# Or activate poetry shell
+poetry shell
+rdf-construct --version
+
+# If installed with pip, check PATH
+pip show rdf-construct
+```
+
+### "Context/Profile not found"
+
+**Problem**: `Error: Context 'xyz' not found`
+
+**Solution**: List available contexts/profiles:
+
+```bash
+rdf-construct contexts config.yml
+rdf-construct profiles order.yml
+```
+
+### "File not found"
+
+**Problem**: `Error: Path 'file.ttl' does not exist`
+
+**Solution**: Check file path is correct:
+
+```bash
+ls -la file.ttl
+# Use absolute path if needed
+rdf-construct uml /full/path/to/file.ttl -C config.yml
+```
+
+### Empty Output
+
+**Problem**: Generated file has no classes/properties.
+
+**Solutions**:
+1. Check CURIE format in config matches ontology prefixes
+2. Verify namespace prefixes match ontology
+3. Check class/property selection criteria
+
+**Debug**:
+
+```python
+from rdflib import Graph, RDF, OWL
+g = Graph().parse("ontology.ttl", format="turtle")
+print(f"Classes: {len(list(g.subjects(RDF.type, OWL.Class)))}")
+for pfx, ns in g.namespace_manager.namespaces():
+    if pfx: print(f"{pfx}: {ns}")
+```
+
+---
+
+## Getting Help
+
+```bash
+rdf-construct --help
+rdf-construct describe --help
+rdf-construct cast --help
+rdf-construct order --help
+rdf-construct uml --help
+rdf-construct docs --help
+rdf-construct puml2rdf --help
+rdf-construct shacl-gen --help
+rdf-construct diff --help
+rdf-construct lint --help
+rdf-construct cq-test --help
+rdf-construct stats --help
+```
+
+**Online Resources**:
+- Issues: https://github.com/aigora-de/rdf-construct/issues
+- Discussions: https://github.com/aigora-de/rdf-construct/discussions
+
+---
+
+## See Also
+
+- **[Getting Started](GETTING_STARTED.md)**: Quick start guide
+- **[Describe Guide](DESCRIBE_GUIDE.md)**: Ontology orientation
+- **[Docs Guide](DOCS_GUIDE.md)**: Documentation generation
+- **[UML Guide](UML_GUIDE.md)**: Complete UML features
+- **[PlantUML Import Guide](PUML2RDF_GUIDE.md)**: PlantUML to RDF conversion
+- **[Cast Guide](CAST_GUIDE.md)**: RDF format conversion and piping
+- **[SHACL Guide](SHACL_GUIDE.md)**: SHACL shape generation
+- **[Diff Guide](DIFF_GUIDE.md)**: Ontology comparison
+- **[Lint Guide](LINT_GUIDE.md)**: Ontology quality checking
+- **[Merge and Split Guide](MERGE_SPLIT_GUIDE.md)**: Combining and modularising ontologies
+- **[CQ Testing Guide](CQ_TEST_GUIDE.md)**: Competency question testing
+- **[Stats Guide](STATS_GUIDE.md)**: Ontology metrics and statistics
+


### PR DESCRIPTION
## What

`docs/user_guides/CLI_REFERENCE.md` was a **single 50KB line**. It contained 1,767 literal `\n` sequences instead of newlines, so GitHub rendered the entire reference — 194 headings, 79 code blocks — as one unbroken paragraph.

```
$ wc -l docs/user_guides/CLI_REFERENCE.md
       1 docs/user_guides/CLI_REFERENCE.md
$ head -c 120 docs/user_guides/CLI_REFERENCE.md
# CLI Reference\n\nComplete command reference for rdf-construct.\n\n## Installation\n\n```bash\n# With pip
```

Found while looking for somewhere to document #89.

## The damage, and the care taken undoing it

One round of escaping had been applied to the whole file. A full inventory before touching anything:

| Sequence | Count | Was |
|---|---|---|
| `\n` | 1767 | line breaks |
| `\\` | 27 | shell line-continuations in examples |
| `\'` | 15 | apostrophes in Python examples |
| `\"` | 2 | quotes |

Undone with a **left-to-right pass over backslash-pairs**, so a doubled backslash consumes both characters and its second one cannot be re-read as the start of another escape — the failure that would have turned `... split.yml \\\n    --migrate-data` into a broken continuation.

**Not `codecs.decode(..., 'unicode_escape')`**, which is the obvious tool and the wrong one here: it decodes via latin-1 and would have mangled the four non-ASCII characters in the file (`«`, `»`, `ä`, `—`).

Verified after:

```
after : 48517 chars, 1768 newlines
remaining literal backslash-n: 0
non-ASCII preserved: ['«', '»', 'ä', '—']
code fences: 158 (even = balanced)
headings: 194
```

Spot-checked the two cases most likely to break: shell continuations in the `merge --migrate-data` example, and the Python snippet with escaped quotes. Both correct.

**No other file in the repository has this damage** — I checked every `.md` under `docs/`, plus README and CONTRIBUTING.

## Two lines of drift, closed while I was here

Being unreadable, the file had gone unnoticed as it aged. Comparing it against `--help` output:

- All **16 commands** are still documented — better than I expected.
- The `docs` command was missing **`--no-shapes`** (shipped in v0.5.0) and **`--no-skos`**.
- Its `--include` / `--exclude` type names predated `other_properties` (#76) and `concepts` (#63).

Added, since the file was open and the gap was two lines. `docs` flags absent from the reference is now zero.

I have **not** attempted a wider content review. The file is 194 headings across 16 commands and has plainly not been read in a while; now that it renders, it is worth someone's eye, but that is a separate job from making it legible.

## Verification

- `scripts/ci-local.sh` green: 753 passed, black clean. No code changed — this is one documentation file.
