### PR TITLE
fix(docs): re-derive the badge palette to clear WCAG AA (#106)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -123,6 +123,29 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   normal vision, 15.3 under simulated deuteranopia
 
 ### Fixed
+- **Every entity-kind badge now clears WCAG AA contrast** (#106). Four failed
+  outright — `annotation` 2.15:1, `datatype` 2.43:1, `instance` 2.54:1 and
+  `object` 4.23:1, against badge text that is 12px bold and so needs 4.5:1,
+  not 3.0:1. The closest pair in the palette was also 2.1 CIEDE2000 units
+  apart, below the ~2.3 just-noticeable difference:
+  - The palette was **re-derived as a set**, not patched colour by colour,
+    because darkening one badge to pass moves it toward its neighbours.
+    Chosen by constrained search: maximise the smallest pairwise distance
+    across normal vision and simulated deuteranopia, protanopia and
+    tritanopia, subject to the contrast floor, to each family keeping its hue,
+    and to the derived kind staying the darker of its pair. Worst pair is now
+    **5.3**, lowest contrast **4.71:1**
+  - **Hue identity is preserved wherever a badge has shipped** — classes stay
+    blue, object properties violet, datatypes cyan, annotations amber,
+    instances emerald, shapes red-rose. Only the shade moves
+  - **SKOS moves from blue to fuchsia.** It collided with the Class badge,
+    which has always been blue via `--primary-colour`; SKOS arrived in this
+    unreleased version, so no user has ever seen it and the move costs nothing
+  - The **Class badge was missing from the original inventory** — it carries
+    no kind class and falls through to `--primary-colour`, so it was invisible
+    to a survey of `.entity-type.*` rules. It passes at 5.17:1 and is unchanged
+  - A test now reads the stylesheet the renderer emits and fails if any badge
+    drops below AA, so a kind added later cannot ship unchecked
 - **`order` now fails on a section whose `select:` names a selector nothing can
   resolve** (#89), instead of selecting nothing and saying nothing. The section
   simply vanished from the output — the same failure shape as #84 one level

--- a/src/rdf_construct/docs/renderers/html.py
+++ b/src/rdf_construct/docs/renderers/html.py
@@ -838,69 +838,67 @@ h4 { font-size: 1.1rem; }
     margin-left: 0.5rem;
 }
 
-.entity-type.object { background: #8b5cf6; }
-.entity-type.datatype { background: #06b6d4; }
-.entity-type.annotation { background: #f59e0b; }
-.entity-type.instance { background: #10b981; }
+/* Kind badge palette, re-derived as a set (#106).
 
-/* Properties whose kind is not implied by their declaration (#76) —
-   rdf:Property, owl:FunctionalProperty, owl:DeprecatedProperty. Neutral
-   slate rather than a hue: the badge's job is to say "the source does not
-   state which kind this is", and a saturated colour would imply it sits
-   alongside object/datatype/annotation as a fourth kind. 10.35:1 against
-   white, clearing WCAG AA, and outside every hue family in the palette
-   (nearest neighbour 5.8 CIEDE2000, under simulated tritanopia). */
-.entity-type.rdf { background: #334155; }
+   Every badge here clears WCAG AA (4.5:1) against its white text, and the
+   closest pair in the whole palette is 5.3 CIEDE2000 units apart — measured
+   across normal vision and simulated deuteranopia, protanopia and
+   tritanopia. Before this, four badges failed AA outright (annotation
+   2.15:1, datatype 2.43:1, instance 2.54:1, object 4.23:1) and the closest
+   pair was 2.1 units, below the ~2.3 just-noticeable difference.
 
-/* Shape badges (#60). Red-to-rose hue family signals kinship between
-   NodeShape and PropertyShape; brightness gradient (NodeShape darker
-   than PropertyShape) reads as parent-child. All three pass WCAG AA
-   contrast against the badge's white text:
-     .shape          #dc2626  4.83:1
-     .node_shape     #b91c1c  6.47:1
-     .property_shape #e11d48  4.70:1
-   The hue family is distinct from the other four badges under common
-   colour-vision deficiencies (amber goes pale-yellow under
-   deuteranopia; reds stay warm-saturated). Badge text labels
-   ("node shape" / "property shape") carry the category regardless of
-   perceived colour. */
+   Chosen by constrained search rather than by eye: maximise the smallest
+   pairwise distance, subject to the contrast floor, to each family keeping
+   its hue, and to the derived kind staying the darker of its pair. Raising
+   the floor to 5.0:1 was tried and rejected — it forces amber darker until
+   it collides with the reds, taking the closest pair down to 3.9.
+
+   Hue identity is preserved wherever a badge has shipped, so only the shade
+   moves: classes stay blue, object properties violet, datatypes cyan,
+   annotations amber, instances emerald, shapes red-rose. SKOS is the one
+   exception and it was free — it arrived in the unreleased v0.6.0, so no
+   user has ever seen it, and it vacates blue (which the class badge has
+   always owned via --primary-colour) for fuchsia.
+
+     class (default)      #2563eb   5.17:1   unchanged
+     object               #7c3aed   5.70:1
+     datatype             #0e7490   5.36:1
+     annotation           #b45309   5.02:1
+     rdf                  #1f2937  14.68:1
+     instance             #047857   5.48:1
+     named_individual     #14532d   9.11:1
+     shape                #dc2626   4.83:1   unchanged
+     node_shape           #7f1d1d  10.02:1
+     property_shape       #9f1239   8.02:1
+     skos_concept         #c026d3   4.71:1
+     skos_concept_scheme  #86198f   8.24:1
+
+   Badge text labels carry the category regardless of perceived colour, which
+   remains the real accessibility guarantee; the palette is the affordance,
+   not the mechanism. */
+
+/* Property kinds. */
+.entity-type.object { background: #7c3aed; }
+.entity-type.datatype { background: #0e7490; }
+.entity-type.annotation { background: #b45309; }
+
+/* Properties whose kind is not implied by their declaration (#76) — neutral
+   rather than a hue, because the badge says the source did not state one. */
+.entity-type.rdf { background: #1f2937; }
+
+/* Instances. The named-individual badge is the darker of the pair (#64). */
+.entity-type.instance { background: #047857; }
+.entity-type.named_individual { background: #14532d; }
+
+/* SHACL shapes (#60): one hue family, NodeShape darkest. */
 .entity-type.shape { background: #dc2626; }
-.entity-type.node_shape { background: #b91c1c; }
-.entity-type.property_shape { background: #e11d48; }
+.entity-type.node_shape { background: #7f1d1d; }
+.entity-type.property_shape { background: #9f1239; }
 
-/* SKOS badges (#63). Blue family, with the scheme darker than the concept
-   so the container reads as the parent — the same gradient the shape
-   family uses. Contrast against the badge's white text:
-     .skos_concept        #1d4ed8   6.70:1
-     .skos_concept_scheme #1e3a8a  10.36:1
-   Both clear WCAG AA for normal text. Blue was measured against the
-   existing badges rather than assumed: the indigo family suggested in
-   #63 sits only 11.3 CIEDE2000 units from the object-property violet
-   (10.7 under simulated deuteranopia), which is too close to call apart,
-   whereas #1d4ed8 keeps 15.3 (17.7 deuteranopia, 21.3 protanopia). Its
-   one weak axis is tritanopia, where it falls to 6.0 against the instance
-   emerald — still distinguishable, and the badge's text label carries the
-   category regardless. */
-.entity-type.skos_concept { background: #1d4ed8; }
-.entity-type.skos_concept_scheme { background: #1e3a8a; }
+/* SKOS (#63): scheme darker than concept, so the container reads as parent. */
+.entity-type.skos_concept { background: #c026d3; }
+.entity-type.skos_concept_scheme { background: #86198f; }
 
-/* Named-individual badge (#64). A darker, deeper emerald than the plain
-   instance badge it sits beside, so the two read as one family the way
-   NodeShape and PropertyShape share red-rose:
-     .instance         #10b981  (existing)
-     .named_individual #047857  5.48:1 — clears WCAG AA against white
-   It stays 21.7 CIEDE2000 units from the instance emerald in normal
-   vision and 15.3 under simulated deuteranopia — related, not confusable
-   — and is further still from every other badge in the palette. */
-.entity-type.named_individual { background: #047857; }
-
-/* Deprecation marker (#108). Deliberately NOT another solid hue: deprecation
-   is orthogonal to entity kind — a deprecated class, property, concept and
-   shape all want the same marker — so it has to sit *beside* a kind badge
-   without competing with it or claiming to be one. An outline rather than a
-   fill does that structurally, so it needs no slot in the kind palette and
-   does not pre-empt #106. Text and border are #b91c1c, 6.47:1 against the
-   page background, already in the palette as the NodeShape red. */
 .entity-type.deprecated {
     background: transparent;
     color: #b91c1c;

--- a/tests/test_docs.py
+++ b/tests/test_docs.py
@@ -1609,8 +1609,13 @@ class TestSKOSRendering:
         DocsGenerator(config).generate(skos_vocabulary)
 
         css = (output_dir / "assets" / "style.css").read_text()
-        assert ".entity-type.skos_concept { background: #1d4ed8; }" in css
-        assert ".entity-type.skos_concept_scheme { background: #1e3a8a; }" in css
+        # The colours themselves are the palette's business, and
+        # TestBadgePaletteContrast owns that policy — asserting a hex here
+        # would mean every palette change touches three unrelated tests
+        # (#106). What matters to SKOS is that both kinds have a rule of
+        # their own rather than inheriting the default.
+        assert ".entity-type.skos_concept { background: #" in css
+        assert ".entity-type.skos_concept_scheme { background: #" in css
 
     def test_html_multilingual_label_table(self, skos_vocabulary: Graph, output_dir: Path):
         """Labels render one row per language, not as duplicate triples."""
@@ -2019,7 +2024,7 @@ class TestNamedIndividualRendering:
         DocsGenerator(config).generate(named_individual_ontology)
 
         css = (output_dir / "assets" / "style.css").read_text()
-        assert ".entity-type.named_individual { background: #047857; }" in css
+        assert ".entity-type.named_individual { background: #" in css
 
     def test_html_index_shows_the_badge(self, named_individual_ontology: Graph, output_dir: Path):
         config = DocsConfig(output_dir=output_dir, format="html")
@@ -2271,7 +2276,7 @@ class TestOtherPropertiesRendering:
         assert 'class="entity-type rdf"' in page
 
         css = (output_dir / "assets" / "style.css").read_text()
-        assert ".entity-type.rdf { background: #334155; }" in css
+        assert ".entity-type.rdf { background: #" in css
 
     def test_html_index_lists_them(self, characteristic_ontology: Graph, output_dir: Path):
         config = DocsConfig(output_dir=output_dir, format="html")
@@ -3069,3 +3074,113 @@ class TestDeprecationRendering:
             and not (page.parent / ref).resolve().exists()
         ]
         assert not broken
+
+
+# ---------------------------------------------------------------------------
+# Badge palette contrast — issue #106
+# ---------------------------------------------------------------------------
+
+
+def _relative_luminance(hex_colour: str) -> float:
+    """WCAG relative luminance of an #rrggbb colour."""
+    channels = [int(hex_colour[i : i + 2], 16) / 255 for i in (1, 3, 5)]
+    linear = [c / 12.92 if c <= 0.04045 else ((c + 0.055) / 1.055) ** 2.4 for c in channels]
+    return 0.2126 * linear[0] + 0.7152 * linear[1] + 0.0722 * linear[2]
+
+
+def contrast_against_white(hex_colour: str) -> float:
+    """WCAG contrast ratio of white text on the given background."""
+    return 1.05 / (_relative_luminance(hex_colour) + 0.05)
+
+
+class TestBadgePaletteContrast:
+    """Every badge must clear WCAG AA against its white text.
+
+    Badge text is 0.75rem bold uppercase — 12px, below the 18.66px-bold
+    large-text threshold — so **AA requires 4.5:1**, not 3.0:1.
+
+    Four badges failed before #106: annotation 2.15:1, datatype 2.43:1,
+    instance 2.54:1 and object 4.23:1. The palette was re-derived as a set
+    rather than patched colour by colour, because darkening one badge to
+    pass moves it toward its neighbours.
+
+    This reads the stylesheet the renderer actually emits, so a badge added
+    later without checking fails here rather than shipping.
+    """
+
+    AA_NORMAL_TEXT = 4.5
+
+    @staticmethod
+    def _badges(output_dir: Path) -> dict[str, str]:
+        """Every badge colour in the emitted CSS, including the default."""
+        import re
+
+        css = (output_dir / "assets" / "style.css").read_text()
+        found = dict(
+            re.findall(r"\.entity-type\.([a-z_]+) \{ background: (#[0-9a-fA-F]{6}); \}", css)
+        )
+        # The Class badge carries no kind class, so it falls through to
+        # --primary-colour. It is a badge like any other and was missing from
+        # the original inventory in #106 precisely because it has no class.
+        primary = re.search(r"--primary-colour: (#[0-9a-fA-F]{6});", css)
+        assert primary is not None, "no --primary-colour in the stylesheet"
+        found["class (default)"] = primary.group(1)
+        return found
+
+    def test_every_badge_clears_aa(self, simple_ontology: Graph, output_dir: Path):
+        config = DocsConfig(output_dir=output_dir, format="html")
+        DocsGenerator(config).generate(simple_ontology)
+
+        badges = self._badges(output_dir)
+        failing = {
+            name: (colour, round(contrast_against_white(colour), 2))
+            for name, colour in badges.items()
+            if contrast_against_white(colour) < self.AA_NORMAL_TEXT
+        }
+        assert not failing, f"badges below {self.AA_NORMAL_TEXT}:1 — {failing}"
+
+    def test_the_inventory_is_complete(self, simple_ontology: Graph, output_dir: Path):
+        """Guard the guard: every kind that renders a badge must be covered.
+
+        If a new `EntityKind` gains a badge and no CSS rule, it silently
+        inherits --primary-colour and looks like a Class. The contrast test
+        above would pass while the palette quietly lost a distinction.
+        """
+        config = DocsConfig(output_dir=output_dir, format="html")
+        DocsGenerator(config).generate(simple_ontology)
+
+        styled = set(self._badges(output_dir)) - {"class (default)"}
+        expected = {
+            "object",
+            "datatype",
+            "annotation",
+            "rdf",
+            "instance",
+            "named_individual",
+            "shape",
+            "node_shape",
+            "property_shape",
+            "skos_concept",
+            "skos_concept_scheme",
+        }
+        assert expected <= styled, f"badges with no colour of their own: {expected - styled}"
+
+    def test_deprecated_marker_clears_aa_as_text(self, simple_ontology: Graph, output_dir: Path):
+        """The deprecation marker is an outline, so its *text* carries the contrast."""
+        import re
+
+        config = DocsConfig(output_dir=output_dir, format="html")
+        DocsGenerator(config).generate(simple_ontology)
+
+        css = (output_dir / "assets" / "style.css").read_text()
+        block = re.search(r"\.entity-type\.deprecated \{(.*?)\}", css, re.S)
+        assert block is not None
+        colour = re.search(r"color: (#[0-9a-fA-F]{6});", block.group(1))
+        assert colour is not None
+        assert contrast_against_white(colour.group(1)) >= self.AA_NORMAL_TEXT
+
+    def test_contrast_helper_is_right(self):
+        """Anchor the maths against values WebAIM agrees with."""
+        assert round(contrast_against_white("#ffffff"), 2) == 1.0
+        assert round(contrast_against_white("#000000"), 2) == 21.0
+        assert round(contrast_against_white("#dc2626"), 2) == 4.83


### PR DESCRIPTION
## What

Four badges failed WCAG AA against their white text, and the palette's closest pair was below the just-noticeable difference. Closes #106.

Badge text is `0.75rem` bold — 12px, below the 18.66px-bold large-text threshold — so **AA requires 4.5:1**, not 3.0:1.

## The inventory was incomplete, and one collision was mine

The issue listed seven badges. There are **twelve**, and the missing one matters:

**The Class badge carries no kind class.** It renders as `<span class="entity-type">Class</span>` and falls through to `--primary-colour` `#2563eb`. A survey of `.entity-type.*` rules cannot see it — which is exactly how, in #63, I picked `#1d4ed8` for SKOS concepts while checking against the seven named badges and never noticed it sits **4.6 units** from the Class badge. My own CVD check had a blind spot in it.

Measured across normal vision and simulated deuteranopia, protanopia and tritanopia, the closest pairs before:

```
  2.1  shape ↔ property_shape          ← below the ~2.3 JND
  2.5  class ↔ datatype
  3.2  object ↔ datatype
  3.7  named_individual ↔ skos_concept_scheme
  4.6  class ↔ skos_concept            ← mine, from #63
```

So this was never four colours to darken. It was a palette to re-derive.

## Derived, not chosen

Patching colour by colour does not work: the shallowest emerald that gets `instance` to AA lands **2.7 units** from the `named_individual` badge under deuteranopia. Fixing one badge breaks its neighbour.

So the twelve were chosen by constrained search — maximise the smallest pairwise distance across all four vision types, subject to:

- every badge ≥ 4.5:1;
- each family keeping its hue;
- the derived kind staying the darker of its pair (NodeShape darker than Shape, scheme darker than concept, named individual darker than instance);
- families staying between 5 and 22 units apart internally — far enough to distinguish, close enough to read as kin.

| | before | after |
|---|---|---|
| Badges failing AA | 4 of 12 | **0** |
| Lowest contrast | 2.15:1 | **4.71:1** |
| Closest pair (all vision types) | 2.1 | **5.3** |

```
  class (default)      #2563eb   5.17:1   unchanged
  object               #7c3aed   5.70:1
  datatype             #0e7490   5.36:1
  annotation           #b45309   5.02:1
  rdf                  #1f2937  14.68:1
  instance             #047857   5.48:1
  named_individual     #14532d   9.11:1
  shape                #dc2626   4.83:1   unchanged
  node_shape           #7f1d1d  10.02:1
  property_shape       #9f1239   8.02:1
  skos_concept         #c026d3   4.71:1
  skos_concept_scheme  #86198f   8.24:1
```

**A 5.0:1 floor was tried and rejected.** It forces amber darker until it collides with the reds, taking the worst pair from 5.3 down to **3.9**. AA is the requirement; buying contrast headroom by making kinds harder to tell apart is the wrong trade for a palette whose entire job is telling them apart.

## What churns, and what does not

**Hue identity is preserved wherever a badge has shipped.** Classes stay blue, object properties violet, datatypes cyan, annotations amber, instances emerald, shapes red-rose. Only the shade moves, so the mnemonic survives.

**SKOS moves from blue to fuchsia, and it is the one free move.** It collided with the Class badge, and one of the two had to leave blue. The Class badge has been blue since v0.1 via `--primary-colour`; SKOS arrived in **this unreleased version**, so no user has ever seen it. Same for `named_individual` taking a new shade — also unreleased. Everything a released version has shown keeps its hue.

## The guard

Two tests, both reading the stylesheet the renderer actually emits rather than a copy of the values:

- **every badge clears AA**, including the default one — so a kind added later cannot ship unchecked;
- **every kind that renders a badge has a colour of its own** — because a new kind with no CSS rule silently inherits `--primary-colour` and looks like a Class, which would leave the contrast test passing while the palette quietly lost a distinction.

I also loosened three existing tests that pinned specific hex values. Colour policy now has one owner; asserting `#1d4ed8` in the SKOS tests would mean every future palette change touches three unrelated tests.

## Verification

- `scripts/ci-local.sh` green: **827 passed** (823 before), black clean.
- The derivation script is reproducible; the figures above come from it rather than from judgement.
