### PR TITLE
docs(changelog): frame the v0.6.0 entry for release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,31 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+Completes the `docs` entity-type taxonomy carried over from v0.5.0, and fixes
+much of the output around it: links that resolved from the wrong place, entity
+filtering that was honoured by page generation but not by links, non-reproducible
+search output, and a badge palette in which four of twelve colours failed WCAG AA
+contrast.
+
+**If you consume the JSON output, two arrays have moved.** `skos:Concept` and
+`skos:ConceptScheme` subjects leave `instances` for top-level `concepts` and
+`concept_schemes`; properties whose kind the source does not state leave it for
+`other_properties`. Both are described below, and both mirror what v0.5.0 did for
+shapes.
+
+**If you publish generated HTML, ten of the twelve badge colours have changed.**
+The palette was re-derived as a set so that all of them clear WCAG AA — four did
+not — and so that no two are closer than 5.3 CIEDE2000 units under simulated
+colour-vision deficiency. Only the class and shape badges keep their previous
+values. Regenerated documentation will look different.
+
+**If you run `order` with a hand-written profile, check your selector names.** A
+section whose `select:` names something that cannot be resolved now fails the run
+instead of silently emitting a file with that section missing. A profile that has
+been quietly producing short output will start reporting it.
+
+Everything else is additive.
+
 ### Added
 - **First-class SKOS support in the `docs` command** (#63). `skos:Concept` and
   `skos:ConceptScheme` are now rendered as a distinct entity type alongside
@@ -121,6 +146,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   WCAG AA), a deeper emerald than the `#10b981` instance badge it sits
   beside so the two read as one family — 21.7 CIEDE2000 units apart in
   normal vision, 15.3 under simulated deuteranopia
+
+### Changed
+- **Breaking (JSON output):** `skos:Concept` and `skos:ConceptScheme` subjects
+  have left the `instances` array for new top-level `concepts` and
+  `concept_schemes` arrays, mirroring what v0.5.0 did for shapes. The
+  `statistics` block gains `concepts` and `concept_schemes` counts. Consumers
+  reading `instances` for SKOS entities must read the new arrays
+- A subject typed both `skos:Concept` and `owl:Class` (or a property, or a
+  SHACL shape) keeps its existing page and does not gain a second one: classes,
+  properties and shapes outrank SKOS in routing. It remains listed as a member
+  of its scheme, cross-linked to the page it does have
 
 ### Fixed
 - **Every entity-kind badge now clears WCAG AA contrast** (#106). Four failed
@@ -239,17 +275,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   cannot drift between commands again. The `order` command moved to them in v0.5.0
 - New `include_other_properties` config key; `other_properties` accepted in
   `--include` / `--exclude`, and `properties` covers it
-
-### Changed
-- **Breaking (JSON output):** `skos:Concept` and `skos:ConceptScheme` subjects
-  have left the `instances` array for new top-level `concepts` and
-  `concept_schemes` arrays, mirroring what v0.5.0 did for shapes. The
-  `statistics` block gains `concepts` and `concept_schemes` counts. Consumers
-  reading `instances` for SKOS entities must read the new arrays
-- A subject typed both `skos:Concept` and `owl:Class` (or a property, or a
-  SHACL shape) keeps its existing page and does not gain a second one: classes,
-  properties and shapes outrank SKOS in routing. It remains listed as a member
-  of its scheme, cross-linked to the page it does have
 
 ## [0.5.0] - 2026-08-22
 


### PR DESCRIPTION
## What

Frames the v0.6.0 CHANGELOG entry so it works as a release body. Documentation only — no code, no behaviour.

`scripts/release.sh --post` builds the GitHub release from this section **verbatim**:

```bash
awk -v v="$VERSION" '$0 ~ "^## \\["v"\\]"{f=1;next} /^## \[/{f=0} f' CHANGELOG.md
```

At 54 entries it opened with a wall of bullets, and the breaking changes sat 230 lines down.

## Three things

**1. A lead that says what a reader has to *do*.** Not a summary of the release — the bullets already are that — but the migration notes, up front:

- two JSON arrays have moved (`concepts` / `concept_schemes`, and `other_properties`);
- ten of the twelve badge colours have changed;
- an `order` profile naming an unresolvable selector now **fails** rather than quietly emitting a file with a section missing.

That third one is the note most likely to catch someone — a profile that has been silently producing short output will start failing a build — and it was filed under **Fixed**, where nobody looks for a migration note.

**2. `### Changed` moved above `### Fixed`.** That is the canonical Keep a Changelog order, and it puts the breaking changes near the top of the release body instead of at the bottom.

**3. Nothing else touched.** No entry added, removed or reworded — 22 top-level bullets and 32 sub-bullets either side, and every non-blank line present before is present after. Verified rather than asserted.

## Two corrections I made to my own first draft

Worth recording, because both were the kind of overstatement that reads fine and is wrong:

- I first wrote *"every badge colour has changed"*. It is **ten of twelve** — `class` (`#2563eb`) and `shape` (`#dc2626`) keep their values.
- I first wrote *"everything else is additive"*. It is not: #89 makes `order` fail where it previously succeeded. Hence the third bullet.

## On house style

The two released sections above this one carry no lead paragraph. This is a deliberate departure for a release with 54 entries and three separate migration notes, not an oversight — happy to drop it if you would rather the CHANGELOG stay strictly bullets and the framing live in the milestone description instead.

## Related

The milestone has been retitled to match: **"v0.6.0 - Docs entity types, links and accessibility"**, with a description covering the three strands and noting that #89 is the one fix outside `docs`.

Gate green: 827 passed, black clean.
